### PR TITLE
🐛 Fix exploded description_key in natural disasters multidims

### DIFF
--- a/etl/steps/export/multidim/natural_disasters/latest/affected.py
+++ b/etl/steps/export/multidim/natural_disasters/latest/affected.py
@@ -101,8 +101,9 @@ def run() -> None:
     # Process data.
     #
     # Sample the all-disasters aggregate description_key for grouped views (must
-    # run before prepare_table drops the column).
-    sample_description_key = list(tb_yearly["total_affected_all_disasters_yearly"].metadata.description_key or [])
+    # run before prepare_table drops the column). In the grapher channel this is a
+    # markdown string — never wrap it in list(), which splits it into one bullet per character.
+    sample_description_key = tb_yearly["total_affected_all_disasters_yearly"].metadata.description_key
     indicators = [
         ({"impact": impact, "metric": metric}, prefix)
         for (impact, metric), prefix in INDICATOR_BY_IMPACT_METRIC.items()

--- a/etl/steps/export/multidim/natural_disasters/latest/deaths.py
+++ b/etl/steps/export/multidim/natural_disasters/latest/deaths.py
@@ -67,8 +67,9 @@ def run() -> None:
     # Process data.
     #
     # Sample the all-disasters aggregate description_key for grouped views (must
-    # run before prepare_table drops the column).
-    sample_description_key = list(tb_yearly["total_dead_all_disasters_yearly"].metadata.description_key or [])
+    # run before prepare_table drops the column). In the grapher channel this is a
+    # markdown string — never wrap it in list(), which splits it into one bullet per character.
+    sample_description_key = tb_yearly["total_dead_all_disasters_yearly"].metadata.description_key
     indicators = [({"metric": metric}, prefix) for metric, prefix in INDICATOR_BY_METRIC.items()]
     tb_yearly = prepare_table(tb_yearly, "yearly", "annual", indicators)
     tb_decadal = prepare_table(tb_decadal, "decadal", "decadal", indicators)

--- a/etl/steps/export/multidim/natural_disasters/latest/economic_damages.py
+++ b/etl/steps/export/multidim/natural_disasters/latest/economic_damages.py
@@ -79,8 +79,9 @@ def run() -> None:
     # Process data.
     #
     # Sample the all-disasters aggregate description_key for grouped views (must
-    # run before prepare_table drops the column).
-    sample_description_key = list(tb_yearly["total_damages_all_disasters_yearly"].metadata.description_key or [])
+    # run before prepare_table drops the column). In the grapher channel this is a
+    # markdown string — never wrap it in list(), which splits it into one bullet per character.
+    sample_description_key = tb_yearly["total_damages_all_disasters_yearly"].metadata.description_key
     indicators = [({"metric": metric}, prefix) for metric, prefix in INDICATOR_BY_METRIC.items()]
     tb_yearly = prepare_table(tb_yearly, "yearly", "annual", indicators)
     tb_decadal = prepare_table(tb_decadal, "decadal", "decadal", indicators)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

## Problem

The "What you should know about this indicator" section of the three natural-disasters multidims renders one bullet per **character** — around 2,900 of them — instead of the 13 real bullets:

```
"descriptionKey": "- -\n- E\n- M\n- -\n- D\n- A\n- T\n- c\n- o\n- u\n- n\n- t\n- s\n…"
```

Live on all three pages ([people affected](https://ourworldindata.org/grapher/natural-disasters-people-affected), [deaths](https://ourworldindata.org/grapher/natural-disasters-deaths), [economic damages](https://ourworldindata.org/grapher/natural-disasters-economic-damages)). The `-` characters render as empty nested bullets, and the inflated config pushes the people-affected page to 872 KB of HTML (vs 272 KB for deaths).

## Cause

`description_key` became a free-form markdown string in #6438: a list authored in YAML is joined into `"- bullet\n- bullet\n…"` by `update_variable_metadata`, which runs via `VariableMeta.render()` — so every dimensioned grapher table carries the string form.

The three multidim steps still treated it as a list:

```python
sample_description_key = list(tb_yearly["total_affected_all_disasters_yearly"].metadata.description_key or [])
```

`list()` on a 2,930-character string yields 2,930 single-character items. That list becomes the `description_key` of every grouped view, and `_convert_description_key_lists` faithfully rejoins it into markdown at upsert time.

Only the aggregate/stacked views are affected — 32 in people-affected, 8 in deaths, 4 in economic damages. Individual disaster-type views read the indicator's own key and were always fine.

## Fix

Drop the `list()` wrapper and pass the value through. A string is stored as-is; a legacy list is still converted at upsert. Verified against the live published string:

| | first 60 chars | bullets |
|---|---|---|
| before | `- -\n- E\n- M\n- -\n- D\n- A\n- T\n- c\n- o\n- u\n- n\n- t\n- s…` | 2,930 |
| after | `- EM-DAT counts injured as people with physical injuries…` | 13 |

The result is byte-identical to the indicator's own `description_key`.

## Repo-wide audit

The same breakage was already fixed in the other multidims that touch `description_key` — UCDP (#6537) and PIP/LIS/WID (#6508), all of which gained a normalizer handling both forms. The natural-disasters trio was missed.

All 27 `.description_key` reads in export steps, plus every list-style operation across `etl/`, `apps/` and `lib/`, were checked. Everything else is safe:

- `wb/*/shared.py`, `noaa_ncei/natural_hazards.py` and `survey/animals_food_and_technology.py` read the garden channel, where the authored list is still correct.
- `urbanization/cities_towns_rural_areas.py` and `war/mars.py` build their own lists from literals.
- `lib/catalog/.../indicators.py` and `apps/backport/datasync/data_metadata.py` already branch on both forms.
- `energy_prices.py` sums lists, but its grapher dependency is an undimensioned passthrough, so `render()` never runs and the value is still a list. Fragile if dimensions are ever added there, but not broken.

## Open items

- Staging needs to re-export the three multidims before the grouped views can be re-checked; production stays wrong until this merges.
- The string form is an easy trap for the next grouped-view multidim. Not addressed here — a note in the `create-multidim` skill would be the place for it.