### PR TITLE
🐝 Republish stale R2 indicator metadata as descriptionKey strings

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -76,6 +76,7 @@ SUBGROUPS = {
             "map-datasets": "apps.utils.map_datasets.cli",
             "scan-chart-diff": "apps.utils.scan_chart_diff.cli",
             "profile": "apps.utils.profile.cli",
+            "republish-description-key": "apps.utils.republish_description_key.cli",
         },
     },
 }

--- a/apps/utils/republish_description_key.py
+++ b/apps/utils/republish_description_key.py
@@ -94,8 +94,12 @@ def _write_metadata(variable_id: int, metadata: dict[str, Any], etag: str) -> No
 def _candidate_ids(cutoff: str | None, limit: int | None) -> list[int]:
     """Variable ids to inspect, newest dataset first so a partial run covers the visible ones.
 
-    The cutoff is only a way to skip variables whose file is already known to be fresh — the
-    file itself is always what decides whether a rewrite happens.
+    The cutoff only skips work; the file's own content always decides whether it is rewritten.
+    It is a poor filter and is off by default: `datasets.dataEditedAt` says when the dataset was
+    touched, not when a given variable's file was written, and `upsert_table` skips variables
+    whose checksums did not change. A date-only cutoff is worse still — the first production run
+    used `< '2026-07-21'` and missed 211 files whose datasets were edited that same morning,
+    hours before the migration landed at 13:06 UTC.
     """
     where = "v.descriptionKey IS NOT NULL AND v.descriptionKey != ''"
     if cutoff:
@@ -155,8 +159,10 @@ def _rewrite_one(variable_id: int, execute: bool) -> str:
 @click.option(
     "--cutoff",
     default=None,
-    help="Only inspect variables whose dataset was last edited before this date (e.g. 2026-07-21). "
-    "Skips files already known to be fresh; omit to inspect every variable.",
+    help="Only inspect variables whose dataset was last edited before this timestamp (e.g. "
+    "'2026-07-21 13:06:56'). A speed optimisation that can MISS files: the dataset's edit time "
+    "is only a proxy for the file's age, and a dataset re-run does not rewrite variables whose "
+    "checksums are unchanged. Prefer omitting it — the file's own content is the sound test.",
 )
 @click.option("--limit", type=int, default=None, help="Only inspect this many variables.")
 @click.option("--workers", type=int, default=16, show_default=True, help="Concurrent requests.")

--- a/apps/utils/republish_description_key.py
+++ b/apps/utils/republish_description_key.py
@@ -1,0 +1,184 @@
+"""Rewrite `descriptionKey` in published R2 indicator metadata from a list to a markdown string.
+
+`descriptionKey` became a free-form markdown string in #6438, and the grapher DB was migrated
+with it. The per-indicator metadata JSON on R2 was not: those files are only rewritten when a
+variable is upserted, so every dataset that has not been re-run since the migration still serves
+a legacy array. owid-grapher tolerates both shapes by normalizing at each ingress point
+(`normalizeDescriptionKey`), and those shims can only be removed once no published file holds an
+array.
+
+This command closes that gap without re-running any ETL step. For each variable it reads the
+published metadata file and, if `descriptionKey` is a list, rewrites that one field with
+`description_key_to_string` — the same conversion owid-grapher applies at runtime today, so the
+rendered text is unchanged by construction. Every other field is left byte-identical, including
+`metadataChecksum` and `updatedAt`, so the file stays exactly what the last ETL run produced
+apart from the shape of this one field.
+
+Dry run by default; pass --execute to write.
+"""
+
+import concurrent.futures
+import gzip
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import click
+import structlog
+from owid.catalog import s3_utils
+from owid.catalog.core.meta import description_key_to_string
+
+from etl import config
+from etl.http import session
+
+log = structlog.get_logger()
+
+
+def _metadata_url(variable_id: int) -> str:
+    return f"{config.DATA_API_URL}/{variable_id}.metadata.json"
+
+
+def _s3_path(variable_id: int) -> str:
+    return f"{config.BAKED_VARIABLES_PATH}/{variable_id}.metadata.json"
+
+
+def _candidate_ids(cutoff: str | None, limit: int | None) -> list[int]:
+    """Variable ids to inspect, newest dataset first so a partial run covers the visible ones.
+
+    The cutoff is only a way to skip variables whose file is already known to be fresh — the
+    file itself is always what decides whether a rewrite happens.
+    """
+    where = "v.descriptionKey IS NOT NULL AND v.descriptionKey != ''"
+    if cutoff:
+        where += f" AND d.dataEditedAt < '{cutoff}'"
+    sql = f"""
+        SELECT v.id FROM variables v
+        JOIN datasets d ON d.id = v.datasetId
+        WHERE {where}
+        ORDER BY d.dataEditedAt DESC
+    """
+    if limit:
+        sql += f" LIMIT {limit}"
+    return config.OWID_ENV.read_sql(sql)["id"].tolist()
+
+
+def _rewrite_one(variable_id: int, execute: bool) -> str:
+    """Return the outcome for one variable: rewritten, already-string, missing, or failed."""
+    try:
+        response = session.get(_metadata_url(variable_id), timeout=60)
+        if response.status_code == 404:
+            return "missing"
+        response.raise_for_status()
+        metadata: dict[str, Any] = response.json()
+    except Exception as e:
+        log.error("republish.fetch_failed", variable_id=variable_id, error=str(e))
+        return "failed"
+
+    description_key = metadata.get("descriptionKey")
+    if not isinstance(description_key, list):
+        return "already-string"
+
+    converted = description_key_to_string(description_key)
+    if converted is None:
+        # An array of empty strings carries no content; drop the field rather than write null,
+        # which is what `description_key_to_string` means by None.
+        metadata.pop("descriptionKey")
+    else:
+        metadata["descriptionKey"] = converted
+
+    if not execute:
+        return "would-rewrite"
+
+    try:
+        body = gzip.compress(json.dumps(metadata, default=str).encode())
+        bucket, key = s3_utils.s3_bucket_key(_s3_path(variable_id))
+        s3_utils.connect_r2_cached().put_object(  # ty: ignore[unresolved-attribute]
+            Bucket=bucket,
+            Body=body,
+            Key=key,
+            ContentEncoding="gzip",
+            ContentType="application/json",
+        )
+    except Exception as e:
+        log.error("republish.upload_failed", variable_id=variable_id, error=str(e))
+        return "failed"
+
+    return "rewritten"
+
+
+@click.command(name="republish-description-key", help=__doc__)
+@click.option("--execute", is_flag=True, help="Write to R2. Without this the command only reports.")
+@click.option(
+    "--cutoff",
+    default=None,
+    help="Only inspect variables whose dataset was last edited before this date (e.g. 2026-07-21). "
+    "Skips files already known to be fresh; omit to inspect every variable.",
+)
+@click.option("--limit", type=int, default=None, help="Only inspect this many variables.")
+@click.option("--workers", type=int, default=16, show_default=True, help="Concurrent requests.")
+@click.option(
+    "--ids-file",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Read variable ids from a file (one per line) instead of querying the DB.",
+)
+@click.option(
+    "--state-file",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Append processed ids here and skip them on a later run, so an interrupted run resumes.",
+)
+def cli(
+    execute: bool,
+    cutoff: str | None,
+    limit: int | None,
+    workers: int,
+    ids_file: Path | None,
+    state_file: Path | None,
+) -> None:
+    target = "PRODUCTION" if config.DATA_API_ENV == "production" else config.DATA_API_ENV
+    log.info("republish.start", target=target, path=config.BAKED_VARIABLES_PATH, execute=execute)
+
+    if ids_file:
+        variable_ids = [int(line) for line in ids_file.read_text().split() if line.strip()]
+    else:
+        variable_ids = _candidate_ids(cutoff, limit)
+
+    done: set[int] = set()
+    if state_file and state_file.exists():
+        done = {int(line) for line in state_file.read_text().split() if line.strip()}
+        variable_ids = [i for i in variable_ids if i not in done]
+        log.info("republish.resuming", already_done=len(done))
+
+    log.info("republish.candidates", count=len(variable_ids))
+    if not variable_ids:
+        return
+
+    outcomes: Counter[str] = Counter()
+    handle = state_file.open("a") if (state_file and execute) else None
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(_rewrite_one, i, execute): i for i in variable_ids}
+            for n, future in enumerate(concurrent.futures.as_completed(futures), 1):
+                variable_id = futures[future]
+                outcome = future.result()
+                outcomes[outcome] += 1
+                if handle and outcome in ("rewritten", "already-string", "missing"):
+                    handle.write(f"{variable_id}\n")
+                if n % 500 == 0:
+                    handle and handle.flush()
+                    log.info("republish.progress", done=n, total=len(variable_ids), **outcomes)
+    finally:
+        if handle:
+            handle.close()
+
+    log.info("republish.done", **outcomes)
+    if not execute and outcomes["would-rewrite"]:
+        log.info("republish.dry_run", message=f"pass --execute to rewrite {outcomes['would-rewrite']} files")
+    if outcomes["failed"]:
+        raise click.ClickException(f"{outcomes['failed']} variables failed — rerun to retry them")
+
+
+if __name__ == "__main__":
+    cli()

--- a/apps/utils/republish_description_key.py
+++ b/apps/utils/republish_description_key.py
@@ -26,21 +26,69 @@ from typing import Any
 
 import click
 import structlog
+from botocore.exceptions import EndpointConnectionError, SSLError
 from owid.catalog import s3_utils
 from owid.catalog.core.meta import description_key_to_string
+from tenacity import Retrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_attempt
+from tenacity.wait import wait_exponential
 
 from etl import config
-from etl.http import session
 
 log = structlog.get_logger()
 
 
-def _metadata_url(variable_id: int) -> str:
-    return f"{config.DATA_API_URL}/{variable_id}.metadata.json"
+def _s3_bucket_key(variable_id: int) -> tuple[str, str]:
+    return s3_utils.s3_bucket_key(f"{config.BAKED_VARIABLES_PATH}/{variable_id}.metadata.json")
 
 
-def _s3_path(variable_id: int) -> str:
-    return f"{config.BAKED_VARIABLES_PATH}/{variable_id}.metadata.json"
+def _retrying() -> Retrying:
+    """Transient R2 errors are expected across tens of thousands of objects."""
+    return Retrying(
+        wait=wait_exponential(min=1, max=30),
+        stop=stop_after_attempt(5),
+        retry=retry_if_exception_type((EndpointConnectionError, SSLError)),
+    )
+
+
+def _read_metadata(variable_id: int) -> tuple[dict[str, Any], str]:
+    """Read a metadata file straight from R2, with its ETag.
+
+    Deliberately not `config.DATA_API_URL`: that goes through the CDN, which serves objects
+    long after their stated s-maxage and does not revalidate. Reading a stale copy and writing
+    it back would revert a file that ETL had already republished with fresher data.
+    """
+    bucket, key = _s3_bucket_key(variable_id)
+    for attempt in _retrying():
+        with attempt:
+            obj = s3_utils.connect_r2_cached().get_object(Bucket=bucket, Key=key)  # ty: ignore[unresolved-attribute]
+            body = obj["Body"].read()
+            if obj.get("ContentEncoding") == "gzip":
+                body = gzip.decompress(body)
+            return json.loads(body), obj["ETag"]
+    raise RuntimeError("unreachable: Retrying either returns or raises")
+
+
+def _write_metadata(variable_id: int, metadata: dict[str, Any], etag: str) -> None:
+    """Write the file back, but only if it has not changed since we read it.
+
+    An ETL upsert republishing the same variable mid-run would otherwise be clobbered by
+    whatever we read moments earlier. R2 rejects the write with PreconditionFailed instead,
+    and a later rerun picks the variable up again.
+    """
+    bucket, key = _s3_bucket_key(variable_id)
+    body = gzip.compress(json.dumps(metadata, default=str).encode())
+    for attempt in _retrying():
+        with attempt:
+            s3_utils.connect_r2_cached().put_object(  # ty: ignore[unresolved-attribute]
+                Bucket=bucket,
+                Body=body,
+                Key=key,
+                ContentEncoding="gzip",
+                ContentType="application/json",
+                IfMatch=etag,
+            )
 
 
 def _candidate_ids(cutoff: str | None, limit: int | None) -> list[int]:
@@ -66,12 +114,10 @@ def _candidate_ids(cutoff: str | None, limit: int | None) -> list[int]:
 def _rewrite_one(variable_id: int, execute: bool) -> str:
     """Return the outcome for one variable: rewritten, already-string, missing, or failed."""
     try:
-        response = session.get(_metadata_url(variable_id), timeout=60)
-        if response.status_code == 404:
-            return "missing"
-        response.raise_for_status()
-        metadata: dict[str, Any] = response.json()
+        metadata, etag = _read_metadata(variable_id)
     except Exception as e:
+        if getattr(e, "response", {}).get("Error", {}).get("Code") in ("NoSuchKey", "404"):
+            return "missing"
         log.error("republish.fetch_failed", variable_id=variable_id, error=str(e))
         return "failed"
 
@@ -91,16 +137,13 @@ def _rewrite_one(variable_id: int, execute: bool) -> str:
         return "would-rewrite"
 
     try:
-        body = gzip.compress(json.dumps(metadata, default=str).encode())
-        bucket, key = s3_utils.s3_bucket_key(_s3_path(variable_id))
-        s3_utils.connect_r2_cached().put_object(  # ty: ignore[unresolved-attribute]
-            Bucket=bucket,
-            Body=body,
-            Key=key,
-            ContentEncoding="gzip",
-            ContentType="application/json",
-        )
+        _write_metadata(variable_id, metadata, etag)
     except Exception as e:
+        code = getattr(e, "response", {}).get("Error", {}).get("Code", "")
+        if code == "PreconditionFailed":
+            # Someone republished this variable while we held it; a rerun will handle it.
+            log.warning("republish.changed_underneath", variable_id=variable_id)
+            return "changed-underneath"
         log.error("republish.upload_failed", variable_id=variable_id, error=str(e))
         return "failed"
 
@@ -176,6 +219,11 @@ def cli(
     log.info("republish.done", **outcomes)
     if not execute and outcomes["would-rewrite"]:
         log.info("republish.dry_run", message=f"pass --execute to rewrite {outcomes['would-rewrite']} files")
+    if outcomes["changed-underneath"]:
+        log.info(
+            "republish.rerun_needed",
+            message=f"{outcomes['changed-underneath']} variables were republished mid-run; rerun to pick them up",
+        )
     if outcomes["failed"]:
         raise click.ClickException(f"{outcomes['failed']} variables failed — rerun to retry them")
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

R2 indicator metadata files are only rewritten when a variable is upserted, so every dataset not re-run since #6438 still serves `descriptionKey` as a legacy array — **88,214 variables across 396 datasets**, while the grapher DB has been string-only since the migration. owid-grapher absorbs the difference by normalizing at four ingress points, and those shims can only be removed once no published file holds an array. This adds `etl d republish-description-key`, which closes that gap without re-running a single ETL step.

_Skim: one new command, no existing code paths touched. The judgement worth checking is the approach — patch one field in place rather than rebuild the file — argued below._

**How:** for each variable, fetch the published metadata file, and if `descriptionKey` is a list, rewrite **only that field** with `description_key_to_string`. Everything else — `dimensions`, `display`, `origins`, `metadataChecksum`, `updatedAt` — is left byte-identical, so the file remains exactly what the last ETL run produced apart from this field's shape.

**Why patch instead of rebuild.** The obvious alternative is to rebuild the file from the DB via `dm.variable_metadata()`, the way an upsert does. I tried that first and rejected it:

- it needs each variable's `.data.json` to recompute `dimensions` — 88k data downloads for a field that isn't changing;
- it also rewrites `updatedAt` and `metadataChecksum`, so the diff stops being "one field" and starts being something a reviewer has to reason about.

The patch is also the safer of the two on rendering: `description_key_to_string` is the same conversion owid-grapher's `normalizeDescriptionKey` already applies to these files at runtime, so the rewritten file says exactly what the browser renders today. Verified on 40 stale variables that the locally converted text is byte-identical to the string MySQL holds — **40/40 match** — so this also brings R2 into agreement with the DB rather than inventing a third version of the text.

## Verified

Ran end to end against a staging namespace (`s3://owid-api-staging/…`), 60 variables:

- **Shape**: 60/60 arrays became strings.
- **Nothing else moved**: diffing a rewritten file against its production counterpart field by field, the only difference is `descriptionKey`.
- **Text is unchanged**: the written string equals `description_key_to_string(production array)` exactly — i.e. what grapher computes at runtime.
- **Rendering**: the affected data page renders the same 5 bullets, the chart fetches the rewritten file (`200`), and the browser console is clean.
- **Idempotent**: a second run reports `already-string=60` and writes nothing.
- **Production dry run** (read-only) over 200 candidates reports `would-rewrite=200`, confirming the selection and the production target resolve correctly.

Not verified: no production file has been written — the full run is a separate, deliberate step (commands in the appendix).

## This has been run against production

All 146,645 published files now hold a string; **zero arrays remain**, verified by reading every object from R2.

| Run | Result |
|---|---|
| 50-file trial | `rewritten=50`, only `descriptionKey` changed in all 50, text byte-identical to the runtime conversion |
| Main run (`--cutoff 2026-07-21`) | `rewritten=90,259`, `already-string=51`, **0 failed, 0 changed-underneath**, ~36 min at 16 workers |
| Stragglers | `rewritten=211` — see below |
| Final sweep over all 146,645 | **146,645 strings, 0 arrays, 0 missing** |

**The cutoff missed 211 files, and this is the lesson worth keeping.** `--cutoff 2026-07-21` selects on `datasets.dataEditedAt`, which is only a proxy for when a *file* was written. Those 211 belonged to datasets edited on 21 July between 08:37 and 12:04 — hours before #6438 landed at 13:06 UTC — so their files were pre-migration while their timestamps were not. A second way it under-selects: `upsert_table` skips variables whose checksums are unchanged, so a re-run dataset can still hold stale files. The command's own content test is the sound one, so `--cutoff` is now documented as a speed optimisation that can miss files, not the recommended path.

## How to run it

Dry run by default; `--execute` is the only thing that writes.

```bash
# 1. read-only: how many files still hold an array (no cutoff — content decides)
ENV_FILE=.env.prod.write .venv/bin/etl d republish-description-key

# 2. small live batch first
ENV_FILE=.env.prod.write .venv/bin/etl d republish-description-key \
    --limit 100 --execute --state-file /tmp/republish.txt

# 3. the rest, resumable — rerunning skips ids already in the state file
ENV_FILE=.env.prod.write .venv/bin/etl d republish-description-key \
    --workers 16 --execute --state-file /tmp/republish.txt
```

Drop `ENV_FILE` to target your own namespace, or set `STAGING=<branch>` for a branch's staging server.

**Verify against R2, not the API.** The CDN serves these files long past their stated `s-maxage` without revalidating — one object was still serving the old shape 90 minutes after being rewritten — so a spot check through `api.ourworldindata.org` makes a correct run look broken. Use `?nocache` if you must go through HTTP. And give any verification script the same retries the command has: a 24-worker scan without them reported 200 phantom "missing" files that a serial re-check found present.

<details><summary>Details</summary>

### Where this sits in the migration

| Egress from ETL | State before this PR |
|---|---|
| `variables.descriptionKey` (MySQL) | string-only — 0 arrays in 108,867 rows |
| mdim configs | string-only — 18 carry the field, 0 arrays |
| explorer configs | field never appears |
| **R2 indicator metadata** | **mixed — arrays wherever a dataset predates the migration** |

After a full run, the last row joins the others and owid-grapher can drop `normalizeDescriptionKey` along with its call sites in `db/model/Variable.ts`, `grapher/src/core/loadVariable.ts` (×2), `types/src/dbTypes/Variables.ts` and `utils/src/MultiDimDataPageConfig.ts`, and tighten `parseVariableDescriptionKey` to reject an array instead of converting it. That is a separate PR in owid-grapher, and it should land only after the run is confirmed complete.

This is independent of migrating the ~3,861 `description_key` YAML lists in `etl/steps/**` to strings. Those are an authoring convenience that never reaches an egress in list form; they can stay as long as we like without blocking any of the above.

### Failure handling

Fetch and upload errors are logged per variable, counted, and the command exits non-zero with the count so a rerun retries them; only successfully processed ids are written to the state file. Progress is logged every 500 variables with a running tally.

</details>

