### PR TITLE
✨ Say in the owidbot comment whether the SVG tester results match the PR's current commit

### DIFF
--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -92,7 +92,7 @@ def cli(
             chart_diff.create_check_run(repo_name, branch, charts_df, dry_run)
 
         elif service == "grapher":
-            services_body["grapher"] = grapher.run(branch)
+            services_body["grapher"] = grapher.run(branch, head_sha=pr.head.sha)
 
         elif service == "anomalist":
             # TODO: anomalist could post a summary of anomalies to the PR

--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -14,7 +14,7 @@ SVG_TESTER_SUITES = ("graphers", "grapher-views", "mdims", "thumbnails")
 VERIFY_RESULTS_FILENAME = "verify-results.json"
 
 
-def run(branch: str) -> str:
+def run(branch: str, head_sha: str | None = None) -> str:
     container_name = get_container_name(branch)
 
     svgs_repo = BASE_DIR.parent / "owid-grapher-svgs"
@@ -30,12 +30,14 @@ def run(branch: str) -> str:
         for suite, results in results_by_suite.items()
     )
 
+    details = "\n\n".join(part for part in (rows, make_freshness_note(results_by_suite, head_sha)) if part)
+
     svg_tester_block = (
         f"""
 <details open>
 <summary><b>SVG tester:</b> </summary>
 
-{rows}
+{details}
 
 </details>
 """.strip()
@@ -80,6 +82,22 @@ def read_verify_results(suite_dir: Path) -> dict | None:
         # was never run". A truncated file is plausible - the process can be killed mid-write.
         log.warning("owidbot.svg_tester.unreadable_results", path=str(path), error=str(e))
         return {"status": "unreadable"}
+
+
+def make_freshness_note(results_by_suite: dict[str, dict | None], head_sha: str | None) -> str:
+    """Whether the results above came from the PR's current commit."""
+    if not head_sha:
+        return ""
+
+    commits = {results.get("grapherCommit") for results in results_by_suite.values() if results}
+
+    if commits == {head_sha}:
+        if any(results.get("status") == "running" for results in results_by_suite.values() if results):
+            return f"_⏳ Still running on the current commit `{head_sha[:7]}`._"
+        return f"_Results are for the current commit `{head_sha[:7]}`._"
+
+    ran_on = ", ".join(sorted(f"`{commit[:7]}`" if commit else "an unknown commit" for commit in commits - {head_sha}))
+    return f"_⏳ Stale: from {ran_on}. The run for the current commit `{head_sha[:7]}` hasn't reported yet._"
 
 
 def make_suite_line(results: dict | None, container_name: str, suite: str) -> str:


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

When you push to an open PR, the owidbot comment's SVG tester block gives no way to tell whether you're looking at the run for the commit you just pushed or at leftovers from the previous one. The first owidbot run of a build happens before the SVG tester step, so it re-posts the previous commit's results, and the second run (after the tester) overwrites them — the two are indistinguishable in the comment.

`verify-results.json` already records the commit each suite ran on (`grapherCommit`). This compares it against the PR head SHA and states the answer under the suite lines:

```
<details open>
<summary><b>SVG tester:</b> </summary>

- graphers: ❌ 3 differences ([report](http://staging-site-my-branch/admin/svgtester/graphers))
- grapher views: _skipped_
- mdims: _skipped_
- thumbnails: _skipped_

_⏳ Stale: from `abc1234`. The run for the current commit `def5678` hasn't reported yet._

</details>
```

The note takes one of four forms:

| Situation | Note |
|---|---|
| Previous build's results still on disk | `⏳ Stale: from \`abc1234\`. The run for the current commit \`def5678\` hasn't reported yet.` |
| Suite mid-render (the `running` placeholder carries the new commit) | `⏳ Still running on the current commit \`def5678\`.` |
| Tester has reported for the head commit | `Results are for the current commit \`def5678\`.` |
| Results file unreadable, so no commit to compare | `⏳ Stale: from an unknown commit. The run for the current commit \`def5678\` hasn't reported yet.` |

Suites that never ran (`_skipped_`) don't count towards staleness, and with no PR head SHA to compare against the line is omitted entirely.

Suites can't normally disagree about the commit: `svg-tester.sh` starts each run with `git clean -fdx` in `owid-grapher-svgs`, and `verify-results.json` is gitignored, so every results file present was written by the current build. If they ever do disagree (a hand-run suite on the container), the note names the commits that aren't the head and the per-suite verdicts are unchanged.

## Open

- Unverified on a real staging server — the wording above is from exercising `make_freshness_note` / `make_suite_line` locally, not from a posted comment. First owid-grapher PR that lands on this branch's staging will show it for real.
- No test committed for `make_freshness_note` (a small one existed locally and was dropped before commit).
