### PR TITLE
🐛 Chart diff: only treat a slug as taken if a chart owns it

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -576,15 +576,26 @@ class ChartDiff:
         """Get all chart slugs. Use `slugs` to filter slugs as this can be slow otherwise."""
         if slugs is not None:
             where = "WHERE slug IN %(slugs)s"
+            where_configs = "AND cc.slug IN %(slugs)s"
             params = {"slugs": tuple(slugs)}
         else:
             where = ""
+            where_configs = ""
             params = {}
 
         slugs_redirects = set(
             read_sql(f"SELECT slug FROM chart_slug_redirects {where}", target_session, params=params)["slug"]
         )
-        slugs = set(read_sql(f"SELECT slug FROM chart_configs {where}", target_session, params=params)["slug"])
+        # A chart_configs row only holds a *chart's* slug if a chart points at it. Without the join
+        # we also pick up slugs from config rows nothing owns, and report them as taken.
+        slugs = set(
+            read_sql(
+                "SELECT cc.slug FROM chart_configs cc JOIN charts c ON c.configId = cc.id "
+                f"WHERE cc.slug IS NOT NULL {where_configs}",
+                target_session,
+                params=params,
+            )["slug"]
+        )
         return slugs | slugs_redirects
 
     @staticmethod


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

`ChartDiff._get_chart_slugs` read `chart_configs.slug` without joining an owner table, so it also collected slugs from config rows that no chart points at — on production, 15 leftover `mdd-*` slugs from republished multi-dim pages. Those slugs feed chart diff's "slug already exists in target environment" check, which then blocks a new chart from syncing over a slug that no chart actually holds. Joining through `charts` fixes it.

## What

The query was:

```sql
SELECT slug FROM chart_configs WHERE slug IN %(slugs)s
```

A `chart_configs` row only holds a *chart's* slug if a chart points at it. Without the join the query also returns slugs from config rows nothing owns. Those feed the conflict check in `ChartDiff.from_charts_df`:

```python
if not target_chart and source_chart.slug in slugs_in_target:
    error = f"Slug '{source_chart.slug}' already exists in target environment."
```

So a new chart claiming one of those slugs is reported as a conflict and blocked from syncing, even though no chart holds it.

## Verification

Against a production clone:

| | before | after | removed | added |
| --- | --- | --- | --- | --- |
| distinct slugs (`slugs=None`) | 5,083 | 5,068 | 15 | 0 |

The removed set is exactly the 15 `mdd-*` slugs. **Nothing was added**, so this is a strict subset and no real chart slug loses its conflict protection. None of the 15 has any row in `multi_dim_data_pages` — they are dead leftovers from republished pages, not live multi-dim pages.

## Also

Added `cc.slug IS NOT NULL`. `None` was previously in the set, so a new draft chart (which has no slug) could match itself and be told its slug was taken. Only reachable through the unfiltered branch, which the sole caller never uses — latent rather than live.

The `where` / `where_configs` split is needed because the qualified `cc.slug` can't share the redirects query's unqualified clause.

## Deliberately not here

Published multi-dim pages are served from the same `/grapher/<slug>` route as charts, so a slug a published multi-dim answers on is arguably taken too, and this function does not know that. That gap is **real but pre-existing and independent of this change**: 0 of the 35 published multi-dims have their slug in `chart_configs.slug` at all, so it was never in the conflict set either before or after this join. Closing it means *adding* ~121 slugs to the set — a stricter check in the opposite direction, with its own blast radius. It belongs in its own PR.

This supersedes #6645, which bundled that addition together with this fix and became hard to review as one diff.

## Context

Found while scanning the ETL for `chart_configs` reads that assume a single owner, ahead of a grapher schema change that moves each config's authored layer into its own `chart_configs` row. This was the only by-slug read of `chart_configs` in the repo without an owner join; every other one, SQL and ORM alike, already reaches the table through `charts.configId`.

That schema change now exists as owid-grapher#6979, so the effect is measured rather than predicted. On its staging DB:

| | rows returned | distinct slugs |
| --- | --- | --- |
| bare query | **15,809** | 5,086 |
| owner-joined (this PR) | 5,071 | 5,071 |

Two things follow. Correctness is unaffected — the caller collapses the result into a `set()`, so the duplicate rows carry the same values and the outcome is still just the 15 phantoms removed. But the bare query pulls **3.1× the rows** on the new schema, because a published chart's authored row carries both `slug` and `isPublished` (5,188 authored rows, 5,071 with a slug, 4,295 published), and `idx_chart_configs_slug` is non-unique so nothing complains. The joined form is a clean 1:1.

In other words the `set()` was doing, incidentally, the job the join should do — and it stops doing it the moment anyone counts rows, returns ids, joins onward, or drops the dedup.

## Still open

- Nobody has eyeballed this in the Wizard UI. The change is verified at the SQL level only; a reviewer with a pending chart diff could confirm the conflict warning behaves.
- The multi-dim namespace gap above is left unfixed, on purpose.
