### PR TITLE
🔨🤖 Drop reads of the variables admin grapher-config layer

### DIFF
--- a/.claude/skills/edit-faust-metadata/scripts/resolve_target.py
+++ b/.claude/skills/edit-faust-metadata/scripts/resolve_target.py
@@ -131,8 +131,7 @@ def load_chart(env: OWIDEnv, *, chart_id: int | None = None, slug: str | None = 
     variables = env.read_sql(
         """
         SELECT cd.property, cd.`order`, v.id AS variable_id, v.catalogPath,
-               v.grapherConfigIdETL IS NOT NULL AS has_etl_config,
-               v.grapherConfigIdAdmin IS NOT NULL AS has_admin_config
+               v.grapherConfigIdETL IS NOT NULL AS has_etl_config
         FROM chart_dimensions cd JOIN variables v ON cd.variableId = v.id
         WHERE cd.chartId = %(chart_id)s
         ORDER BY cd.property, cd.`order`
@@ -424,7 +423,7 @@ def print_human(result: dict[str, Any]) -> None:
         for v in chart["variables"]:
             print(
                 f"  [{v['property']}] id={v['variable_id']} etl_config={bool(v['has_etl_config'])} "
-                f"admin_config={bool(v['has_admin_config'])} {v['catalogPath']}"
+                f"{v['catalogPath']}"
             )
     mdim = result.get("mdim")
     if mdim:

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -1100,7 +1100,6 @@ class Variable(Base):
     license: Mapped[dict | None] = mapped_column(JSON, default=None)
     type: Mapped[VARIABLE_TYPE | None] = mapped_column(ENUM(*get_args(VARIABLE_TYPE)), default=None)
     sort: Mapped[list[str] | None] = mapped_column(JSON, default=None)
-    grapherConfigIdAdmin: Mapped[str | None] = mapped_column(VARCHAR(32), default=None)
     grapherConfigIdETL: Mapped[bytes | None] = mapped_column(CHAR(32), default=None)
     dataChecksum: Mapped[str | None] = mapped_column(VARCHAR(64), default=None)
     metadataChecksum: Mapped[str | None] = mapped_column(VARCHAR(64), default=None)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

`variables.grapherConfigIdAdmin` is the admin-authored indicator-level config pointer. An upcoming grapher refactor renames it, and a stacked follow-up drops it outright. Nothing in the ETL consumes the value, so the two reads can go now rather than being renamed in one PR and deleted in the next.

Stacked on #6656 only because both PRs (and the larger refactor PR to come) touch `etl/grapher/model.py` and `resolve_target.py`; there is no logical dependency between them.

## What

Two reads, neither of which uses the value:

| site | what it was |
| --- | --- |
| `etl/grapher/model.py` | ORM field on `Variable` — declared, never read anywhere in the repo |
| `.claude/skills/edit-faust-metadata/scripts/resolve_target.py` | `IS NOT NULL AS has_admin_config`, printed as a diagnostic and otherwise unused |

## Why land this ahead of the refactor rather than inside it

Deleting is correct against **every** schema state — before the rename, after it, and after the drop — because a column that is present but unmapped is invisible to SQLAlchemy: it only selects declared columns, and this repo has no ORM/DB drift check. The reverse does not hold, which is the whole point:

> A mapping left in place for a column that no longer exists breaks **every ORM read and write of `variables`** — `select(Variable)`, `session.get(Variable, …)`, and `session.add(db_variable)` in `etl/grapher/to_db.py`, i.e. the upsert path every dataset upload runs. Not just config queries.

So if the grapher rename reaches production while the ETL side is still in flight, having already deleted this narrows the failure from "all variable reads and writes" to "the config-reading paths". It is insurance, and it is free.

## Safety

- **Construction**: `gm.Variable` is a `MappedAsDataclass`, but it is only ever built by keyword — `Variable.from_variable_metadata` → `cls(shortName=…, name=…, …)` — so removing a field shifts no positional argument. The other `Variable(...)` call sites in the repo are the catalog's pandas `Variable`, an unrelated class.
- **Checksums**: variable checksums are computed from `VariableMeta`, not from this ORM class, so no checksum churn and no spurious re-uploads.
- **Writes**: the ETL never assigned this column; all indicator-level config writes go over HTTP via `apps/chart_sync/admin_api.py`.

## What the column points at on production

2 configs, both on live ETL-managed indicators (`who/latest/monkeypox`, `unesco/2025-05-01/education_sdgs`). Checked whether either is rendered anywhere, because one of them carries real chart design (title, subtitle, a hand-built map colour scale, a slope-chart default, curated entities):

| consumer | count |
| --- | --- |
| charts | 0 |
| multi-dim views | 0 |
| explorer views | 0 |
| narrative charts | 0 |
| data page (`datapages` view, which derives from `charts`) | 0 |

Nothing renders them, so grapher's eventual drop is invisible to readers and needs no content migration. Recorded here in case that ever needs revisiting.

## Still open

- The larger refactor PR (`full` → `config`, `fullMd5` → `configMd5`, `grapherConfigIdETL` → `chartConfigIdETL`, and the authored layer moving to its own row) is not in this stack yet — it can only be written and verified against a grapher branch that has the new schema.
- Unrelated to this PR but worth an answer before that one: the ETL's only indicator-config write path is `PUT {admin_api}/variables/{id}/grapherConfigETL`. If the refactor renames that **route** alongside the column, the ETL breaks with a 404 and no SQL change would have predicted it.
