### PR TITLE
🐛 Stop automatic update jobs from committing each other's snapshots

### DIFF
--- a/scripts/update-covid-cases-deaths.sh
+++ b/scripts/update-covid-cases-deaths.sh
@@ -13,11 +13,18 @@ echo '--- Update COVID-19 cases and deaths'
 cd /home/owid/etl
 uv run etls covid/latest/cases_deaths
 
+# Files this job owns. Several update-*.sh jobs run concurrently against this same
+# checkout, so we only ever stage and commit these - `git add .` would sweep in another
+# job's half-written snapshots.
+snapshot_files=(
+    snapshots/covid/latest/cases_deaths.csv.dvc
+)
+
 # commit to master will trigger ETL which is gonna run the step
 echo '--- Commit and push changes'
 
-git add .
-git commit -m ":robot: update: covid-19 cases and deaths" || true
+git add "${snapshot_files[@]}"
+git commit -m ":robot: update: covid-19 cases and deaths" -- "${snapshot_files[@]}" || true
 git push origin master -q || true
 
 end_time=$(date +%s)

--- a/scripts/update-covid-sequence.sh
+++ b/scripts/update-covid-sequence.sh
@@ -13,11 +13,18 @@ echo '--- Update COVID-19 sequences'
 cd /home/owid/etl
 uv run etls covid/latest/sequence
 
+# Files this job owns. Several update-*.sh jobs run concurrently against this same
+# checkout, so we only ever stage and commit these - `git add .` would sweep in another
+# job's half-written snapshots.
+snapshot_files=(
+    snapshots/covid/latest/sequence.json.dvc
+)
+
 # commit to master will trigger ETL which is gonna run the step
 echo '--- Commit and push changes'
 
-git add .
-git commit -m ":robot: update: covid-19 sequences" || true
+git add "${snapshot_files[@]}"
+git commit -m ":robot: update: covid-19 sequences" -- "${snapshot_files[@]}" || true
 git push origin master -q || true
 
 end_time=$(date +%s)

--- a/scripts/update-covid-vaccinations.sh
+++ b/scripts/update-covid-vaccinations.sh
@@ -13,11 +13,19 @@ echo '--- Update COVID-19 vaccinations'
 cd /home/owid/etl
 uv run etls covid/latest/vaccinations_global
 
+# Files this job owns. Several update-*.sh jobs run concurrently against this same
+# checkout, so we only ever stage and commit these - `git add .` would sweep in another
+# job's half-written snapshots.
+snapshot_files=(
+    snapshots/covid/latest/vaccinations_global.csv.dvc
+    snapshots/covid/latest/vaccinations_global_who.csv.dvc
+)
+
 # commit to master will trigger ETL which is gonna run the step
 echo '--- Commit and push changes'
 
-git add .
-git commit -m ":robot: update: covid-19 vaccinations" || true
+git add "${snapshot_files[@]}"
+git commit -m ":robot: update: covid-19 vaccinations" -- "${snapshot_files[@]}" || true
 git push origin master -q || true
 
 end_time=$(date +%s)

--- a/scripts/update-covid-vaccinations.sh
+++ b/scripts/update-covid-vaccinations.sh
@@ -15,9 +15,9 @@ uv run etls covid/latest/vaccinations_global
 
 # Files this job owns. Several update-*.sh jobs run concurrently against this same
 # checkout, so we only ever stage and commit these - `git add .` would sweep in another
-# job's half-written snapshots.
+# job's half-written snapshots. Note this excludes vaccinations_global.csv.dvc, which the
+# same snapshot script only writes when given --path-to-file by hand.
 snapshot_files=(
-    snapshots/covid/latest/vaccinations_global.csv.dvc
     snapshots/covid/latest/vaccinations_global_who.csv.dvc
 )
 

--- a/scripts/update-excess-mortality.sh
+++ b/scripts/update-excess-mortality.sh
@@ -15,11 +15,21 @@ uv run etls excess_mortality/latest/wmd
 uv run etls excess_mortality/latest/xm_karlinsky_kobak
 uv run etls excess_mortality/latest/hmd_stmf
 
+# Files this job owns. Several update-*.sh jobs run concurrently against this same
+# checkout, so we only ever stage and commit these - `git add .` would sweep in another
+# job's half-written snapshots.
+snapshot_files=(
+    snapshots/excess_mortality/latest/wmd.csv.dvc
+    snapshots/excess_mortality/latest/xm_karlinsky_kobak.csv.dvc
+    snapshots/excess_mortality/latest/xm_karlinsky_kobak_ages.csv.dvc
+    snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
+)
+
 # commit to master will trigger ETL which is gonna run the step
 echo '--- Commit and push changes'
 
-git add .
-git commit -m ":robot: automatic excess mortality update" || true
+git add "${snapshot_files[@]}"
+git commit -m ":robot: automatic excess mortality update" -- "${snapshot_files[@]}" || true
 git push origin master -q || true
 
 end_time=$(date +%s)

--- a/scripts/update-flunet.sh
+++ b/scripts/update-flunet.sh
@@ -13,6 +13,14 @@ echo '--- Update flunet'
 
 cd /home/owid/etl
 
+# Files this job owns. Several update-*.sh jobs run concurrently against this same
+# checkout, so we only ever stage, commit and revert these - `git add .` would sweep in
+# (and `git reset --hard` would destroy) another job's half-written snapshots.
+snapshot_files=(
+    snapshots/who/latest/fluid.csv.dvc
+    snapshots/who/latest/flunet.csv.dvc
+)
+
 exit_code_1=0
 exit_code_2=0
 
@@ -24,12 +32,12 @@ then
     # commit to master will trigger ETL which is gonna run the step
     echo '--- Commit and push changes'
 
-    git add .
-    git commit -m ":robot: automatic flunet update" || true
+    git add "${snapshot_files[@]}"
+    git commit -m ":robot: automatic flunet update" -- "${snapshot_files[@]}" || true
     git push origin master -q || true
 else
-    echo "At least one of the Python scripts returned a non-zero exit code. Resetting all files..."
-    git reset --hard HEAD
+    echo "At least one of the Python scripts returned a non-zero exit code. Reverting our files..."
+    git checkout -- "${snapshot_files[@]}"
     exit 1
 fi
 

--- a/scripts/update-measles.sh
+++ b/scripts/update-measles.sh
@@ -14,11 +14,18 @@ cd /home/owid/etl
 
 uv run etls cdc/latest/measles_cases
 
+# Files this job owns. Several update-*.sh jobs run concurrently against this same
+# checkout, so we only ever stage and commit these - `git add .` would sweep in another
+# job's half-written snapshots.
+snapshot_files=(
+    snapshots/cdc/latest/measles_cases.json.dvc
+)
+
 # commit to master will trigger ETL which is gonna run the step
 echo '--- Commit and push changes'
 
-git add .
-git commit -m ":robot: automatic measles update" || true
+git add "${snapshot_files[@]}"
+git commit -m ":robot: automatic measles update" -- "${snapshot_files[@]}" || true
 git push origin master -q || true
 
 end_time=$(date +%s)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The automatic dataset update jobs all run concurrently as `owid` against the **same** `/home/owid/etl` checkout on `etl-prod-2`, and each one ended with `git add .`. So every job committed whatever the others happened to have half-written at that moment. Each script now stages and commits only the `.dvc` files its own snapshots produce, and `update-flunet.sh`'s failure path reverts just those files instead of running `git reset --hard HEAD`. No behaviour change when a job runs alone.

_Review depth: skim the mechanism, but please check the per-job file lists — the whole fix rests on each list being exactly the set of `.dvc` files that job writes._

## Why this matters

It has been happening daily, in both directions, and it is the norm rather than the exception. **`snapshots/who/latest/fluid.csv.dvc` has been committed by the excess-mortality job on 11 of its last 12 changes** — `date_accessed` and, on most days, the `md5`/`size` too. So the FluID snapshot's actual data pointer routinely lands in a commit for an unrelated dataset.

```bash
git log --format='%h %ad %s' --date=short -12 -- snapshots/who/latest/fluid.csv.dvc
```

The reverse case is what made today's failure visible: commit 1875de4f5b (`:robot: automatic excess mortality update`) carries flunet's `date_accessed` bump, applied seconds before FluID's download failed. Flunet's `git reset --hard HEAD` could no longer undo a change another job had already committed, so `master` is left claiming FluID was accessed on 2026-08-13 while its `outs` md5 is still the file from 2026-08-11 — published provenance for a day the download in fact failed.

Two further consequences of the same cause: a job could commit another job's *partially written* snapshot, and flunet's `git reset --hard HEAD` could destroy another job's in-flight downloads outright.

## How it works

`git commit -m … -- <paths>` is a path-limited commit: it takes the working-tree content of exactly those paths and ignores the rest of the index. That's what makes it safe here — another job that has already run `git add` on *its* files does not get its work swallowed into our commit, and its staged state survives intact.

The `git add "${snapshot_files[@]}"` before it is deliberate rather than redundant: it means a *newly added* `.dvc` file gets tracked. Without it, `git commit -- <untracked path>` fails with `pathspec did not match`, and the existing `|| true` would swallow that into a silent no-commit.

Scoping was chosen at the file level, not the directory level, because two of these directories are shared: `snapshots/covid/latest/` holds ~70 `.dvc` files across unrelated datasets, and `snapshots/who/latest/` holds `monkeypox.csv.dvc` and `avian_influenza_ah5n1.csv.dvc` alongside the two flu files.

`update-wildfires.sh` and `update-monkeypox.sh` are left alone. Both `exit 0` before reaching their git blocks, and wildfires' dead code refers to `snapshots/climate/latest/`, which no longer exists.

## Verified

- The path-limited commit semantics, in a scratch repo simulating the race: job B's commit contains only its own file, while another job's staged *and* unstaged edits both survive; the scoped `git checkout --` on the failure path restores only our file.
- Each job's file list against the snapshot scripts themselves, since that's where a list could silently go stale. `excess_mortality/latest/xm_karlinsky_kobak.py` writes two snapshots, so both are listed:

```bash
grep -n 'Snapshot(\|add_snapshot(' \
  snapshots/covid/latest/{cases_deaths,sequence,vaccinations_global}.py \
  snapshots/excess_mortality/latest/{wmd,xm_karlinsky_kobak,hmd_stmf}.py \
  snapshots/who/latest/{fluid,flunet}.py \
  snapshots/cdc/latest/measles_cases.py
```

  A `Snapshot(...)` in the script is necessary but not sufficient, which Codex caught on the first pass: `vaccinations_global.py` also constructs `vaccinations_global.csv`, but only behind `if path_to_file:`, i.e. only for a human running it by hand. The scheduled call writes just `vaccinations_global_who.csv`, so the manual snapshot is excluded (eababb7b80) — listing it would have left a cross-commit path open for exactly the in-flight work this PR is fixing. That file was last touched by a human PR in Feb 2025, and `vaccinations_global_who.csv.dvc` hasn't changed since June 2025, so this job now legitimately commits nothing: its `git commit` no-ops through the existing `|| true`. Every recent `:robot: update: covid-19 vaccinations` commit was in fact carrying the covid-sequence job's work.

- `bash -n` on all eight scripts; `shellcheck` reports nothing new (only pre-existing `SC2004` style nits on the untouched `$(($end_time - $start_time))` lines).

**Not verified:** the scripts themselves only run on `etl-prod-2`, so the real proof is the next scheduled build committing exactly its own files.

<details>
<summary>What prompted this, and what needs no action</summary>

Found while investigating [build 1294](https://buildkite.com/our-world-in-data/etl-automatic-dataset-updates-master/builds/1294), where the flunet job failed three times. That failure was entirely upstream and is unrelated to this fix:

- attempt 1 — WHO's xmart API returned `504 Gateway Time-out` for `VIW_FID_EPI`;
- attempts 2 and 3 — the download succeeded but the CSV was malformed at the *identical* offset (`Expected 38 fields in line 271867, saw 67`), i.e. deterministically broken content, not a flaky transfer. The `pd.read_csv(snap.path)` guard in `snapshots/who/latest/fluid.py` did its job and refused to upload it.

Re-downloading `VIW_FID_EPI` a couple of hours later gave a clean file — 587,780 rows × 38 columns, and a strict `csv.reader` pass finds zero rows with a wrong field count. Upstream has healed, so no retry logic is added here; the daily job recovers on its own.

The stale `date_accessed` in `snapshots/who/latest/fluid.csv.dvc` also needs no fix of its own: the next successful flunet run rewrites both that field and the md5.

</details>
