### PR TITLE
📜 Keep find-chart-references' locating aids in the scatter handoff

### DIFF
--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -311,10 +311,14 @@ Pass the sweep's `--json` through `scripts/build_reference_handoff.py`, which ad
 
 ```bash
 .venv/bin/python .claude/skills/find-chart-references/scripts/find_references.py \
-  --chart-slugs '<slugs+aliases>' --json ai/<name>_references.json
+  --chart-slugs '<slugs+aliases>' --json ai/<name>_references.json \
+  --gaps-json ai/<name>_references_gaps.json
 .venv/bin/python .claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py \
-  --references ai/<name>_references.json --pairs ai/<name>_part2_pairs.json
+  --references ai/<name>_references.json --pairs ai/<name>_part2_pairs.json \
+  --gaps ai/<name>_references_gaps.json
 ```
+
+`--gaps` is not optional in practice: it carries the sweep's run-specific coverage gaps into the handoff, next to the permanent ones the builder restates from the sweep's own `NOT_SEARCHED`. Without it the handoff says so in a ⚠️ line, because a reader who never opens the sweep would otherwise read a short table as a complete blast radius. `--pairs` takes either pair schema — Part 1's table rows (admin URLs) or the Part 2 payload (public grapher URLs, resolved against the DB) — so pass whichever list matches the rows actually being retired, and pass it **before** Part 2 unpublishes them.
 
 Those aids are the difference between a row someone can fix and a row that names an article and leaves them to hunt through it:
 
@@ -324,6 +328,8 @@ Those aids are the difference between a row someone can fix and a row that names
 - **Find in the doc** — a copy-paste search string: the **link text** for a prose hyperlink, or the **chart slug** for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). `—` means there is nothing to search for.
 
 **Import those formatters from `find-chart-references/scripts/find_references.py`; never reimplement them** — `doc_url`, `gdoc_preview_url`, `deep_link`, `search_hint`, `cell`. A second copy drifts, and the drift shows up as a handoff whose links quietly stop resolving. Strip the tailscale suffix from the admin root you pass them, so the links read like the sweep's own (which are already short).
+
+They only apply to Google Doc surfaces, though — `doc_url` and `gdoc_preview_url` read `surface_id` **as** a Doc id, and on an explorer or narrative-chart row that field holds a slug or a chart id, which renders as a Doc link resolving to nothing. So the two article tables are filtered to `GDOC_SURFACES`, every other surface gets the section that explains its own consequence (key charts, the blocking explorer/data-insight/static-viz set, narrative charts), and whatever no section claims lands in a catch-all table — a row the sweep found must never go missing here.
 
 ### Key-chart slots — the Part 2 audit cannot see them
 

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -121,7 +121,7 @@ The canonical items, in order:
 8. Apply the reviewer's flagged notes; regenerate the HTML and re-import their JSON.
 9. Chart-diff sign-off on staging, then merge.
 10. **Confirm the scatter views actually reached production.** A merged PR is not evidence that they did: chart-sync only carries chart edits whose diffs were **approved** in Chart Diff, so a PR can merge green with every row ✅ on staging and leave production untouched. An abandoned first attempt (PR #6173, merged 2026-06-24) left production untouched on all seven of its pairs — deliberately: the `target_query_param` needed for Part 2 did not exist yet, so it was dropped and the migration restarted from scratch rather than left half-done. Whatever the reason, check production directly rather than inferring it from the merge.
-11. **Reference sweep on the old charts** — `find-chart-references` over each source slug *and its aliases*. Re-point embeds and links at the target's scatter view **before** retiring anything: an embed is never fixed by a redirect, and a link that works only via a 301 outlives everyone's memory of why. **Do not skip this because the Part 2 audit reports few references** — it counts a narrower set; see the key-chart trap below.
+11. **Reference sweep on the old charts** — `find-chart-references` over each source slug *and its aliases*, then `scripts/build_reference_handoff.py` to turn it into the handoff (it keeps the sweep's 📄 doc / 👁 preview / 🔗 page links and its "Find in the doc" search string — see below). Re-point embeds and links at the target's scatter view **before** retiring anything: an embed is never fixed by a redirect, and a link that works only via a 301 outlives everyone's memory of why. **Do not skip this because the Part 2 audit reports few references** — it counts a narrower set; see the key-chart trap below.
 12. Narrative charts on the sources: replace where the parent is being retired (create → re-point articles → delete; never delete first).
 13. **Part 2 audit** — `redirect_to_scatter.py` with no `--apply`. Read every verdict.
 14. Part 2 `--apply` on staging, then the browser checks in "Verifying Part 2".
@@ -304,6 +304,26 @@ The script's own table covers only gdoc links and embeds — enough to spot the 
 ```
 
 Include the sources' **aliases** in `--chart-slugs`: an article may well link an even older slug. The sweep catches what `get_chart_references` counts but doesn't locate — explorers, data insights, static viz, narrative charts, key-chart slots, WordPress posts — and it reports its own **gaps**, so a surface it couldn't check is visible rather than silently absent. Triage it the way that skill does: an **embed** is 🔴 and blocks the row (it breaks the moment the source is unpublished), a **link** is 🟡 (the 301 covers it; update the href anyway), and an unpublished or draft page is ℹ️.
+
+### The handoff must keep find-chart-references' presentation
+
+Pass the sweep's `--json` through `scripts/build_reference_handoff.py`, which adds the one workflow-specific column — the replacement URL — while **keeping every locating aid the sweep's own markdown provides**:
+
+```bash
+.venv/bin/python .claude/skills/find-chart-references/scripts/find_references.py \
+  --chart-slugs '<slugs+aliases>' --json ai/<name>_references.json
+.venv/bin/python .claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py \
+  --references ai/<name>_references.json --pairs ai/<name>_part2_pairs.json
+```
+
+Those aids are the difference between a row someone can fix and a row that names an article and leaves them to hunt through it:
+
+- **📄 doc** — the Google Doc to edit. `posts_gdocs.id` *is* the Doc id, so it is a direct link, and editing the doc is the only way to fix an embed.
+- **👁 preview** — the article in the admin previewer, which renders unpublished drafts the public page won't show.
+- **🔗 page** — the published page, deep-linked with a scroll-to-text fragment when the reference has anchor text, so it opens *at* the reference.
+- **Find in the doc** — a copy-paste search string: the **link text** for a prose hyperlink, or the **chart slug** for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). `—` means there is nothing to search for.
+
+**Import those formatters from `find-chart-references/scripts/find_references.py`; never reimplement them** — `doc_url`, `gdoc_preview_url`, `deep_link`, `search_hint`, `cell`. A second copy drifts, and the drift shows up as a handoff whose links quietly stop resolving. Strip the tailscale suffix from the admin root you pass them, so the links read like the sweep's own (which are already short).
 
 ### Key-chart slots — the Part 2 audit cannot see them
 

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -307,7 +307,7 @@ Include the sources' **aliases** in `--chart-slugs`: an article may well link an
 
 ### The handoff must keep find-chart-references' presentation
 
-Pass the sweep's `--json` through `scripts/build_reference_handoff.py`, which adds the one workflow-specific column — the replacement URL — while **keeping every locating aid the sweep's own markdown provides**:
+Pass the sweep's `--json` through `scripts/build_reference_handoff.py`, which adds the two workflow-specific columns — the replacement URL, and the reference's own params that silently override it — while **keeping every locating aid the sweep's own markdown provides**:
 
 ```bash
 .venv/bin/python .claude/skills/find-chart-references/scripts/find_references.py \
@@ -324,11 +324,11 @@ Those aids are the difference between a row someone can fix and a row that names
 
 - **📄 doc** — the Google Doc to edit. `posts_gdocs.id` *is* the Doc id, so it is a direct link, and editing the doc is the only way to fix an embed.
 - **👁 preview** — the article in the admin previewer, which renders unpublished drafts the public page won't show.
-- **🔗 page** — the published page, deep-linked with a scroll-to-text fragment when the reference has anchor text, so it opens *at* the reference.
-- **Find in the doc** — a copy-paste search string: the **link text** for a prose hyperlink, or the **chart slug** for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). `—` means there is nothing to search for.
+- **🔗 page** — the published page, deep-linked with a scroll-to-text fragment when the reference has anchor text, so it opens *at* the reference. The **page type decides the base**: a data insight is served under `/data-insights/` and an author page under `/team/`, while the sweep records `where_path` as `/<slug>` for every gdoc type — and a text fragment attached to the wrong base makes a 404 look like a working link.
+- **Find in the doc** — a copy-paste search string: the **link text** for a prose hyperlink, or the **chart slug** for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). A long one is cut short but **stays literal** — no `…`, which is not a character in the document and would make the paste find nothing.
 - **Its params** — the query string the reference already carries, because the replacement URL merges it over `tab=scatter&time=latest&country=` and **the reference's values win**. A ⚠️ marks the keys that override the retirement's own, which is the row that needs a decision rather than a paste: a reference carrying `tab=chart` lands the reader on a different tab than the retirement intends, and the merge is silent about it.
 
-**Import those formatters from `find-chart-references/scripts/find_references.py`; never reimplement them** — `doc_url`, `gdoc_preview_url`, `deep_link`, `search_hint`, `cell`. A second copy drifts, and the drift shows up as a handoff whose links quietly stop resolving. Strip the tailscale suffix from the admin root you pass them, so the links read like the sweep's own (which are already short).
+**Import those formatters from the `find-chart-references` scripts; never reimplement them** — a second copy drifts, and the drift shows up as a handoff whose links quietly stop resolving. Take each one from whichever module gets it right: `doc_url`, `gdoc_preview_url` and `cell` from `find_references.py`, and the **page link** plus the **search string** from `reference_report.py` (`page_deep_link`, `find_in_doc`, and its `cell(..., marker="")`), which is the module that handles the page-type routes and the literal truncation. Strip the tailscale suffix from the admin root you pass them, so the links read like the sweep's own (which are already short).
 
 They only apply to Google Doc surfaces, though — `doc_url` and `gdoc_preview_url` read `surface_id` **as** a Doc id, and on an explorer or narrative-chart row that field holds a slug or a chart id, which renders as a Doc link resolving to nothing. So the two article tables are filtered to `GDOC_SURFACES`, every other surface gets the section that explains its own consequence (key charts, the blocking explorer/data-insight/static-viz set, narrative charts), and whatever no section claims lands in a catch-all table — a row the sweep found must never go missing here.
 

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -326,6 +326,7 @@ Those aids are the difference between a row someone can fix and a row that names
 - **👁 preview** — the article in the admin previewer, which renders unpublished drafts the public page won't show.
 - **🔗 page** — the published page, deep-linked with a scroll-to-text fragment when the reference has anchor text, so it opens *at* the reference.
 - **Find in the doc** — a copy-paste search string: the **link text** for a prose hyperlink, or the **chart slug** for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). `—` means there is nothing to search for.
+- **Its params** — the query string the reference already carries, because the replacement URL merges it over `tab=scatter&time=latest&country=` and **the reference's values win**. A ⚠️ marks the keys that override the retirement's own, which is the row that needs a decision rather than a paste: a reference carrying `tab=chart` lands the reader on a different tab than the retirement intends, and the merge is silent about it.
 
 **Import those formatters from `find-chart-references/scripts/find_references.py`; never reimplement them** — `doc_url`, `gdoc_preview_url`, `deep_link`, `search_hint`, `cell`. A second copy drifts, and the drift shows up as a handoff whose links quietly stop resolving. Strip the tailscale suffix from the admin root you pass them, so the links read like the sweep's own (which are already short).
 

--- a/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
+++ b/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
@@ -51,6 +51,7 @@ TARGET_KEYS = ("target_chart_admin_url", "target_chart_url")
 # Kept in step with TARGET_QUERY in redirect_to_scatter.py: every param stands in for an
 # adjustment a tab CLICK makes and a URL-supplied tab does not get.
 REDIRECT_QUERY = "tab=scatter&time=latest&country="
+REDIRECT_KEYS = {key for key, _ in parse_qsl(REDIRECT_QUERY, keep_blank_values=True)}
 SITE = "https://ourworldindata.org"
 
 MANUAL_SURFACES = {"explorer", "data insight", "static viz"}
@@ -112,6 +113,38 @@ def load_pairs(path: Path) -> dict[int, int]:
         return ref if isinstance(ref, int) else ids[ref]
 
     return {resolve(src): resolve(tgt) for src, tgt in refs}
+
+
+def params_cell(own_params: str) -> str:
+    """The reference's own params, flagging the ones that override the redirect's.
+
+    The merge is silent, so the collision is what has to be visible: a reference carrying
+    `tab=chart` wins over `tab=scatter` and lands the reader on a different tab than the
+    retirement intends. That row needs a decision, not a paste.
+    """
+    query = (own_params or "").lstrip("?")
+    if not query:
+        return "—"
+    shown = f"`{fr.cell(query, 40)}`"
+    clashing = sorted({key for key, _ in parse_qsl(query, keep_blank_values=True)} & REDIRECT_KEYS)
+    return f"⚠️ {shown} overrides {', '.join(clashing)}" if clashing else shown
+
+
+def open_links(r: dict, host: str, admin: str) -> str:
+    """The sweep's own "Open" composition, for the surfaces that are not Google Docs.
+
+    `preview_url` is the actionable one here: on an explorer row it is the explorer page —
+    the thing being re-pointed — while `admin_url` is the editor of the OLD chart the row
+    points at. Dropping the preview leaves an explorer row with no way to open the explorer.
+    """
+    parts = []
+    if r.get("admin_url"):
+        parts.append(f"[✎ chart admin]({r['admin_url']})")
+    if r.get("preview_url"):
+        parts.append(f"[👁 view]({r['preview_url']})")
+    elif r.get("where_path"):
+        parts.append(f"[🔗 open]({fr.admin_url(r['where_path'], host, admin)})")
+    return " · ".join(parts) or "—"
 
 
 def replacement_url(src_id: int, own_params: str, pairs: dict[int, int], slugs: dict[int, str]) -> str:
@@ -190,8 +223,8 @@ def main() -> int:
             "",
             blurb,
             "",
-            "| Chart | Article | Open | Find in the doc | Replace with |",
-            "|---|---|---|---|---|",
+            "| Chart | Article | Open | Find in the doc | Its params | Replace with |",
+            "|---|---|---|---|---|---|",
         ]
         for r in sorted(group, key=lambda r: (r["where"], r["subject"])):
             draft = "" if r["published"] else " ⚠️draft"
@@ -206,9 +239,10 @@ def main() -> int:
                 if r.get("preview_url")
                 else f"`{fr.cell(r['subject_label'], 44)}`"
             )
+            own_params = r.get("query_string", "")
             out.append(
                 f"| {subject} | {fr.cell(r['where'], 44)}{page_type}{draft} | {links} | {fr.search_hint(r)} | "
-                f"{replacement_url(r['subject_id'], r.get('query_string', ''), pairs, slugs)} |"
+                f"{params_cell(own_params)} | {replacement_url(r['subject_id'], own_params, pairs, slugs)} |"
             )
         out.append("")
 
@@ -251,8 +285,9 @@ def main() -> int:
             "|---|---|---|---|",
         ]
         for r in sorted(manual, key=lambda r: (r["surface"], r["where"])):
-            link = f"[✎ admin]({r['admin_url']})" if r.get("admin_url") else "—"
-            out.append(f"| {r['surface']} | {fr.cell(r['where'], 44)} | `{r['subject']}` | {link} |")
+            out.append(
+                f"| {r['surface']} | {fr.cell(r['where'], 44)} | `{r['subject']}` | {open_links(r, args.host, admin)} |"
+            )
         out.append("")
 
     narrative = [r for r in rows if r["surface"] == "narrative chart"]
@@ -283,10 +318,9 @@ def main() -> int:
             "|---|---|---|---|---|",
         ]
         for r in sorted(other, key=lambda r: (r["surface"], str(r["where"]))):
-            link = fr.admin_url(r.get("where_path", ""), args.host, admin)
             out.append(
                 f"| {r['surface']} | `{fr.cell(r['subject_label'], 44)}` | {fr.cell(r['where'], 44)} | "
-                f"{fr.cell(r.get('context', ''), 44)} | {f'[🔗 open]({link})' if link else '—'} |"
+                f"{fr.cell(r.get('context', ''), 44)} | {open_links(r, args.host, admin)} |"
             )
         out.append("")
 
@@ -302,8 +336,10 @@ def main() -> int:
         "still uses an old one). A `—` means there is nothing to search for.",
         "",
         "**Replace with** merges the redirect's stored params with the reference's own, and the "
-        "reference's win — so a row whose params column is not `—` needs a decision, not a "
-        "blind paste.",
+        "reference's win. **Its params** is what the reference already carries, so you can see "
+        f"what that merge did: a ⚠️ marks the ones overriding the retirement's own "
+        f"`{REDIRECT_QUERY}` — that row lands the reader on a different tab or time range and "
+        "needs a decision, not a blind paste.",
         "",
         "## Coverage boundary",
         "",

--- a/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
+++ b/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
@@ -21,10 +21,13 @@ Usage::
     .venv/bin/python .claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py \\
         --references ai/<name>_references.json \\
         --pairs ai/<name>_part2_pairs.json \\
+        [--gaps ai/<name>_references_gaps.json] \\
         [--output ai/<name>_reference_handoff.md]
 
-`--references` is the `--json` output of `find_references.py`; `--pairs` is the applier's own
-JSON, so the replacement URLs are the ones the migration actually created.
+`--references` is the `--json` output of `find_references.py` and `--gaps` its `--gaps-json`,
+which carries that run's own coverage gaps. `--pairs` is the pair list of the rows actually
+being retired, so the replacement URLs are the ones the migration creates; either pair schema
+works — Part 1's table rows (admin URLs) or the Part 2 payload (public grapher URLs).
 """
 
 import argparse
@@ -37,6 +40,13 @@ from urllib.parse import parse_qsl, urlencode
 from etl.config import OWID_ENV
 
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
+ADMIN_CHART_ID_RE = re.compile(r"/charts/(\d+)")
+GRAPHER_SLUG_RE = re.compile(r"/grapher/([^/?#]+)")
+
+# Part 1's pasted table names charts by admin URL; the Part 2 payload the applier consumes
+# names them by public grapher URL. Both are valid pair lists for this handoff.
+SOURCE_KEYS = ("chart_admin_url", "grapher_url")
+TARGET_KEYS = ("target_chart_admin_url", "target_chart_url")
 
 # Kept in step with TARGET_QUERY in redirect_to_scatter.py: every param stands in for an
 # adjustment a tab CLICK makes and a URL-supplied tab does not get.
@@ -61,8 +71,47 @@ def _load_find_references():
 fr = _load_find_references()
 
 
-def chart_id(url: str) -> int:
-    return int(url.rstrip("/").split("/")[-2])
+def chart_ref(url: str) -> int | str:
+    """The chart id from an admin URL, or the slug from a public grapher URL."""
+    admin_match = ADMIN_CHART_ID_RE.search(url)
+    if admin_match:
+        return int(admin_match.group(1))
+    slug_match = GRAPHER_SLUG_RE.search(url)
+    if slug_match:
+        return slug_match.group(1)
+    raise SystemExit(f"Cannot read a chart id or slug from {url!r}")
+
+
+def pick(pair: dict, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        if pair.get(key):
+            return str(pair[key])
+    raise SystemExit(f"Pair {pair} carries none of {keys}")
+
+
+def load_pairs(path: Path) -> dict[int, int]:
+    """Source chart id -> target chart id, from either pair schema.
+
+    Slugs are resolved against the DB, so this must run **before** Part 2 unpublishes the
+    sources — after that their slugs belong to `chart_slug_redirects`, not to a chart.
+    """
+    refs = [(chart_ref(pick(p, SOURCE_KEYS)), chart_ref(pick(p, TARGET_KEYS))) for p in json.loads(path.read_text())]
+    wanted = sorted({ref for pair in refs for ref in pair if isinstance(ref, str)})
+    ids: dict[str, int] = {}
+    if wanted:
+        df = OWID_ENV.read_sql(
+            "SELECT c.id, cc.slug FROM charts c JOIN chart_configs cc ON c.configId = cc.id WHERE cc.slug IN %(s)s",
+            params={"s": tuple(wanted)},
+        )
+        ids = {r["slug"]: int(r["id"]) for r in df.to_dict("records")}
+        missing = [slug for slug in wanted if slug not in ids]
+        if missing:
+            raise SystemExit(f"No chart on this server owns these slugs: {', '.join(missing)}")
+
+    def resolve(ref: int | str) -> int:
+        return ref if isinstance(ref, int) else ids[ref]
+
+    return {resolve(src): resolve(tgt) for src, tgt in refs}
 
 
 def replacement_url(src_id: int, own_params: str, pairs: dict[int, int], slugs: dict[int, str]) -> str:
@@ -83,16 +132,14 @@ def replacement_url(src_id: int, own_params: str, pairs: dict[int, int], slugs: 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Build the reference handoff for an add-gdp-scatter retirement.")
     ap.add_argument("--references", required=True, type=Path, help="--json output of find_references.py")
-    ap.add_argument("--pairs", required=True, type=Path, help="the applier's JSON pair list (Part 2 set)")
+    ap.add_argument("--pairs", required=True, type=Path, help="JSON pair list of the rows being retired")
+    ap.add_argument("--gaps", type=Path, default=None, help="--gaps-json output of find_references.py")
     ap.add_argument("--output", type=Path, default=None, help="output .md (default: alongside --references)")
     ap.add_argument("--host", default=SITE, help="public site host for page links")
     args = ap.parse_args()
 
     rows = json.loads(args.references.read_text())
-    pairs = {
-        chart_id(p["chart_admin_url"]): chart_id(p["target_chart_admin_url"])
-        for p in json.loads(args.pairs.read_text())
-    }
+    pairs = load_pairs(args.pairs)
     # The shared formatters expect an admin ROOT (".../admin"), while OWID_ENV.admin_api is
     # the API root (".../admin/api"). The tailscale suffix comes off so these links read the
     # same as the sweep's own `admin_url` values, which are already short.
@@ -114,6 +161,10 @@ def main() -> int:
         "",
     ]
 
+    # Every row a section below owns, by identity, so the catch-all at the end can list
+    # whatever no section claimed instead of dropping it.
+    placed: set[int] = set()
+
     for title, kind, blurb in [
         (
             "🔴 Embeds — a redirect does NOT fix these",
@@ -126,9 +177,14 @@ def main() -> int:
             "They keep working through the redirect; updating avoids a hop nobody will remember.",
         ),
     ]:
-        group = [r for r in rows if r["kind"] == kind]
+        # Google Doc surfaces only: the shared formatters read `surface_id` AS a Doc id, and
+        # on any other surface it is an explorer slug or a narrative-chart id, which would
+        # render as a Doc link that resolves to nothing. Those surfaces have their own
+        # sections below.
+        group = [r for r in rows if r["kind"] == kind and r["surface"] in fr.GDOC_SURFACES]
         if not group:
             continue
+        placed.update(id(r) for r in group)
         out += [
             f"## {title} ({len(group)})",
             "",
@@ -157,6 +213,7 @@ def main() -> int:
         out.append("")
 
     key_charts = [r for r in rows if r["surface"] == "key chart"]
+    placed.update(id(r) for r in key_charts)
     if key_charts:
         out += [
             f"## 🔴 Key-chart slots ({len(key_charts)}) — invisible to the Part 2 audit",
@@ -180,13 +237,15 @@ def main() -> int:
         out.append("")
 
     manual = [r for r in rows if r["surface"] in MANUAL_SURFACES]
+    placed.update(id(r) for r in manual)
     if manual:
         out += [
             f"## ⛔ Explorer / data-insight / static-viz references ({len(manual)}) — these BLOCK the row",
             "",
             "`redirect_to_scatter.py` converts these rows to `BLOCKED` before `--apply`, because they "
             "embed the old chart's config and no redirect covers them. Re-point them, then re-run with "
-            "`--allow-manual-refs`.",
+            "`--allow-manual-refs`. A data insight is itself a Google Doc, so it is listed in the table "
+            "above too — with the links that locate the reference inside it.",
             "",
             "| Surface | Where | Old chart | Open |",
             "|---|---|---|---|",
@@ -197,6 +256,7 @@ def main() -> int:
         out.append("")
 
     narrative = [r for r in rows if r["surface"] == "narrative chart"]
+    placed.update(id(r) for r in narrative)
     if narrative:
         out += [f"## ℹ️ Narrative charts ({len(narrative)}) — do not block", ""]
         for r in narrative:
@@ -204,6 +264,29 @@ def main() -> int:
                 f"- `{r['where']}` on `{r['subject']}` — params `{r.get('query_string') or '—'}`. Renders from "
                 f'its own materialized config, and its "Explore the data" href is covered by the redirect; '
                 f"its params override the stored ones."
+            )
+        out.append("")
+
+    # Anything no section above claimed — an old slug of the source, a site redirect, a
+    # surface the sweep gains later. Listed rather than dropped, so the handoff cannot go
+    # quiet about a reference the sweep did find.
+    other = [r for r in rows if id(r) not in placed]
+    if other:
+        out += [
+            f"## ❔ Other references ({len(other)}) — judge these by hand",
+            "",
+            "None of the sections above covers these. A `redirect` row is an old slug of the chart "
+            "itself, which the unpublish deletes — `redirect_to_scatter.py` re-points those unless "
+            "`--skip-alias-repoint` is passed.",
+            "",
+            "| Surface | Old chart | Where | Context | Open |",
+            "|---|---|---|---|---|",
+        ]
+        for r in sorted(other, key=lambda r: (r["surface"], str(r["where"]))):
+            link = fr.admin_url(r.get("where_path", ""), args.host, admin)
+            out.append(
+                f"| {r['surface']} | `{fr.cell(r['subject_label'], 44)}` | {fr.cell(r['where'], 44)} | "
+                f"{fr.cell(r.get('context', ''), 44)} | {f'[🔗 open]({link})' if link else '—'} |"
             )
         out.append("")
 
@@ -222,20 +305,43 @@ def main() -> int:
         "reference's win — so a row whose params column is not `—` needs a decision, not a "
         "blind paste.",
         "",
-        'This handoff covers only what the sweep found. Read its own "Not searched" section for the '
-        "coverage boundary — a short table is not by itself a clean result.",
+        "## Coverage boundary",
+        "",
+        "This handoff holds what the sweep *found*, which is not everything that exists — so a "
+        "short table is not by itself a clean result, and nothing below was checked. The "
+        "permanent limits are the sweep's own, restated here because this file is what gets "
+        "handed on:",
         "",
     ]
+    # Restated from `find_references.NOT_SEARCHED` rather than copied, for the same reason the
+    # formatters are imported: a second copy drifts, and the drift reads as coverage we have.
+    out += [f"- **Never swept:** {note}" for note in fr.NOT_SEARCHED]
+    if args.gaps is None:
+        out.append(
+            "- ⚠️ **This run's own gaps were not carried over.** Re-run the sweep with `--gaps-json` "
+            "and pass that file as `--gaps` to list them here — a surface that failed open (an "
+            "absent table, a subject that did not resolve) is the gap a reader has no other way "
+            "of knowing about."
+        )
+    else:
+        run_gaps = json.loads(args.gaps.read_text())
+        out += [f"- **Gap in this run:** {note}" for note in run_gaps]
+        if not run_gaps:
+            out.append("- The sweep reported no gaps of its own in this run.")
+    out.append("")
 
     output = args.output or args.references.with_name(
         args.references.stem.replace("_references", "") + "_reference_handoff.md"
     )
     output.write_text("\n".join(out))
-    counts = {k: len([r for r in rows if r["kind"] == k]) for k in ("embed", "link", "render")}
+    tabled = {
+        kind: len([r for r in rows if r["kind"] == kind and r["surface"] in fr.GDOC_SURFACES])
+        for kind in ("embed", "link")
+    }
     print(f"wrote {output}")
     print(
-        f"  embeds {counts['embed']}  links {counts['link']}  render {counts['render']}"
-        f"  (key charts {len(key_charts)}, manual {len(manual)}, narrative {len(narrative)})"
+        f"  {len(rows)} reference(s): article embeds {tabled['embed']}, article links {tabled['link']}, "
+        f"key charts {len(key_charts)}, manual {len(manual)}, narrative {len(narrative)}, other {len(other)}"
     )
     return 0
 

--- a/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
+++ b/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
@@ -1,0 +1,244 @@
+"""Turn a find-chart-references sweep into the actionable handoff for retiring the sources.
+
+The sweep says what points at the charts about to be retired; this adds the half that is
+specific to this workflow — **where each reference should point instead** — and keeps the
+sweep's own presentation, because that presentation is what makes a row fixable:
+
+* **📄 doc** — the Google Doc to edit. `posts_gdocs.id` IS the Doc id, so it is a direct link.
+* **👁 preview** — the article in the admin previewer, which renders unpublished drafts too.
+* **🔗 page** — the published page, deep-linked to the reference with a scroll-to-text
+  fragment when the reference has anchor text.
+* **Find in the doc** — a copy-paste search string: the link text for a prose hyperlink, or
+  the chart slug for a block embed (the doc holds a bare grapher URL there, and the slug is
+  stored as the author typed it, so it matches even when the doc still uses an old one).
+
+Without those, a handoff row names an article and leaves the editor to hunt through it. The
+formatters are **imported** from `find-chart-references/scripts/find_references.py` rather
+than reimplemented, so the two reports cannot drift apart.
+
+Usage::
+
+    .venv/bin/python .claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py \\
+        --references ai/<name>_references.json \\
+        --pairs ai/<name>_part2_pairs.json \\
+        [--output ai/<name>_reference_handoff.md]
+
+`--references` is the `--json` output of `find_references.py`; `--pairs` is the applier's own
+JSON, so the replacement URLs are the ones the migration actually created.
+"""
+
+import argparse
+import importlib.util
+import json
+import re
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode
+
+from etl.config import OWID_ENV
+
+TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
+
+# Kept in step with TARGET_QUERY in redirect_to_scatter.py: every param stands in for an
+# adjustment a tab CLICK makes and a URL-supplied tab does not get.
+REDIRECT_QUERY = "tab=scatter&time=latest&country="
+SITE = "https://ourworldindata.org"
+
+MANUAL_SURFACES = {"explorer", "data insight", "static viz"}
+
+
+def _load_find_references():
+    """Import the sweep's own formatters so the two reports share one presentation."""
+    path = Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts" / "find_references.py"
+    if not path.exists():
+        raise SystemExit(f"Cannot find the shared formatters at {path}")
+    spec = importlib.util.spec_from_file_location("find_references", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+fr = _load_find_references()
+
+
+def chart_id(url: str) -> int:
+    return int(url.rstrip("/").split("/")[-2])
+
+
+def replacement_url(src_id: int, own_params: str, pairs: dict[int, int], slugs: dict[int, str]) -> str:
+    """The target's scatter view, with the reference's own params layered on top.
+
+    Incoming params beat the redirect's stored ones key by key, so a reference carrying its
+    own `tab`/`time`/`country` keeps them — which is a decision, not a merge, and why the
+    table prints the reference's params alongside.
+    """
+    tgt = pairs.get(src_id)
+    if not tgt or tgt not in slugs:
+        return "— no target —"
+    merged = dict(parse_qsl(REDIRECT_QUERY, keep_blank_values=True))
+    merged.update(dict(parse_qsl((own_params or "").lstrip("?"), keep_blank_values=True)))
+    return f"{SITE}/grapher/{slugs[tgt]}?{urlencode(merged)}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build the reference handoff for an add-gdp-scatter retirement.")
+    ap.add_argument("--references", required=True, type=Path, help="--json output of find_references.py")
+    ap.add_argument("--pairs", required=True, type=Path, help="the applier's JSON pair list (Part 2 set)")
+    ap.add_argument("--output", type=Path, default=None, help="output .md (default: alongside --references)")
+    ap.add_argument("--host", default=SITE, help="public site host for page links")
+    args = ap.parse_args()
+
+    rows = json.loads(args.references.read_text())
+    pairs = {
+        chart_id(p["chart_admin_url"]): chart_id(p["target_chart_admin_url"])
+        for p in json.loads(args.pairs.read_text())
+    }
+    # The shared formatters expect an admin ROOT (".../admin"), while OWID_ENV.admin_api is
+    # the API root (".../admin/api"). The tailscale suffix comes off so these links read the
+    # same as the sweep's own `admin_url` values, which are already short.
+    admin = TAILSCALE_SUFFIX_RE.sub("", OWID_ENV.admin_api).removesuffix("/api")
+
+    slugs = {}
+    if pairs:
+        df = OWID_ENV.read_sql(
+            "SELECT c.id, cc.slug FROM charts c JOIN chart_configs cc ON c.configId = cc.id WHERE c.id IN %(i)s",
+            params={"i": tuple(set(pairs.values()))},
+        )
+        slugs = {int(r["id"]): r["slug"] for r in df.to_dict("records")}
+
+    out = [
+        "# Reference handoff — retiring the old GDP scatters",
+        "",
+        f"{len(rows)} reference(s) to the {len(pairs)} charts about to be retired, each with where it should "
+        "point instead. Do the 🔴 rows **before** Part 2 unpublishes anything.",
+        "",
+    ]
+
+    for title, kind, blurb in [
+        (
+            "🔴 Embeds — a redirect does NOT fix these",
+            "embed",
+            "These render the old chart's own config, so they break the moment it is unpublished.",
+        ),
+        (
+            "🟡 Links — the 301 covers them, but update the href",
+            "link",
+            "They keep working through the redirect; updating avoids a hop nobody will remember.",
+        ),
+    ]:
+        group = [r for r in rows if r["kind"] == kind]
+        if not group:
+            continue
+        out += [
+            f"## {title} ({len(group)})",
+            "",
+            blurb,
+            "",
+            "| Chart | Article | Open | Find in the doc | Replace with |",
+            "|---|---|---|---|---|",
+        ]
+        for r in sorted(group, key=lambda r: (r["where"], r["subject"])):
+            draft = "" if r["published"] else " ⚠️draft"
+            ptype = r["context"].split("(")[-1].rstrip(")") if "(" in r.get("context", "") else ""
+            page_type = f" _{ptype}_" if ptype else ""
+            preview = f" · [👁 preview]({fr.gdoc_preview_url(r, admin)})" if r.get("surface_id") else ""
+            links = f"[📄 doc]({fr.doc_url(r)}){preview} · [🔗 page]({fr.deep_link(r, args.host, admin)})"
+            if r.get("admin_url"):
+                links += f" · [✎ chart admin]({r['admin_url']})"
+            subject = (
+                f"[`{fr.cell(r['subject_label'], 44)}`]({r['preview_url']})"
+                if r.get("preview_url")
+                else f"`{fr.cell(r['subject_label'], 44)}`"
+            )
+            out.append(
+                f"| {subject} | {fr.cell(r['where'], 44)}{page_type}{draft} | {links} | {fr.search_hint(r)} | "
+                f"{replacement_url(r['subject_id'], r.get('query_string', ''), pairs, slugs)} |"
+            )
+        out.append("")
+
+    key_charts = [r for r in rows if r["surface"] == "key chart"]
+    if key_charts:
+        out += [
+            f"## 🔴 Key-chart slots ({len(key_charts)}) — invisible to the Part 2 audit",
+            "",
+            "`redirect_to_scatter.py` never sees these: its audit counts wp/gdoc/explorer/narrative/"
+            "dataInsight/staticViz, and a key chart is a chart↔tag association "
+            "(`chart_tags.keyChartLevel`), not a row in any of them. Unpublishing the source 404s "
+            "nothing — the chart simply drops out of the topic page's key-chart list, silently. Move "
+            "each association to the target, same tag and same level.",
+            "",
+            "| Topic page | Old chart | Level | Move the association to |",
+            "|---|---|---|---|",
+        ]
+        for r in sorted(key_charts, key=lambda r: (r["where"], r["subject"])):
+            tgt = pairs.get(r["subject_id"])
+            level = (r.get("context") or "").replace("keyChartLevel=", "level ")
+            out.append(
+                f"| {fr.cell(r['where'], 44)} | `{r['subject']}` (#{r['subject_id']}) | {level} | "
+                f"#{tgt} `{slugs.get(tgt, '?')}` |"
+            )
+        out.append("")
+
+    manual = [r for r in rows if r["surface"] in MANUAL_SURFACES]
+    if manual:
+        out += [
+            f"## ⛔ Explorer / data-insight / static-viz references ({len(manual)}) — these BLOCK the row",
+            "",
+            "`redirect_to_scatter.py` converts these rows to `BLOCKED` before `--apply`, because they "
+            "embed the old chart's config and no redirect covers them. Re-point them, then re-run with "
+            "`--allow-manual-refs`.",
+            "",
+            "| Surface | Where | Old chart | Open |",
+            "|---|---|---|---|",
+        ]
+        for r in sorted(manual, key=lambda r: (r["surface"], r["where"])):
+            link = f"[✎ admin]({r['admin_url']})" if r.get("admin_url") else "—"
+            out.append(f"| {r['surface']} | {fr.cell(r['where'], 44)} | `{r['subject']}` | {link} |")
+        out.append("")
+
+    narrative = [r for r in rows if r["surface"] == "narrative chart"]
+    if narrative:
+        out += [f"## ℹ️ Narrative charts ({len(narrative)}) — do not block", ""]
+        for r in narrative:
+            out.append(
+                f"- `{r['where']}` on `{r['subject']}` — params `{r.get('query_string') or '—'}`. Renders from "
+                f'its own materialized config, and its "Explore the data" href is covered by the redirect; '
+                f"its params override the stored ones."
+            )
+        out.append("")
+
+    out += [
+        "---",
+        "",
+        "The **chart name links to the view as that reference renders it** (its own params applied). "
+        "📄 opens the Google Doc to edit · 🔗 opens the published page scrolled to the reference · "
+        "👁 opens the article in the admin previewer (works for unpublished drafts too). "
+        "**Find in the doc** is a copy-paste search string for the Google Doc: the link text for a "
+        "prose hyperlink, or the chart slug for a block embed (the doc holds a bare grapher URL "
+        "there — and the slug is stored as the author typed it, so it matches even when the doc "
+        "still uses an old one). A `—` means there is nothing to search for.",
+        "",
+        "**Replace with** merges the redirect's stored params with the reference's own, and the "
+        "reference's win — so a row whose params column is not `—` needs a decision, not a "
+        "blind paste.",
+        "",
+        'This handoff covers only what the sweep found. Read its own "Not searched" section for the '
+        "coverage boundary — a short table is not by itself a clean result.",
+        "",
+    ]
+
+    output = args.output or args.references.with_name(
+        args.references.stem.replace("_references", "") + "_reference_handoff.md"
+    )
+    output.write_text("\n".join(out))
+    counts = {k: len([r for r in rows if r["kind"] == k]) for k in ("embed", "link", "render")}
+    print(f"wrote {output}")
+    print(
+        f"  embeds {counts['embed']}  links {counts['link']}  render {counts['render']}"
+        f"  (key charts {len(key_charts)}, manual {len(manual)}, narrative {len(narrative)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
+++ b/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
@@ -7,14 +7,17 @@ sweep's own presentation, because that presentation is what makes a row fixable:
 * **📄 doc** — the Google Doc to edit. `posts_gdocs.id` IS the Doc id, so it is a direct link.
 * **👁 preview** — the article in the admin previewer, which renders unpublished drafts too.
 * **🔗 page** — the published page, deep-linked to the reference with a scroll-to-text
-  fragment when the reference has anchor text.
+  fragment when the reference has anchor text, under the route its page TYPE is served on.
 * **Find in the doc** — a copy-paste search string: the link text for a prose hyperlink, or
   the chart slug for a block embed (the doc holds a bare grapher URL there, and the slug is
   stored as the author typed it, so it matches even when the doc still uses an old one).
 
 Without those, a handoff row names an article and leaves the editor to hunt through it. The
-formatters are **imported** from `find-chart-references/scripts/find_references.py` rather
-than reimplemented, so the two reports cannot drift apart.
+formatters are **imported** from the `find-chart-references` scripts rather than
+reimplemented, so the reports cannot drift apart — each one from whichever module gets it
+right: `find_references.py` for the doc/preview links, and `reference_report.py` for the page
+link and the search string, since it is the one that knows the page-type routes and truncates
+without an ellipsis.
 
 Usage::
 
@@ -57,19 +60,23 @@ SITE = "https://ourworldindata.org"
 MANUAL_SURFACES = {"explorer", "data insight", "static viz"}
 
 
-def _load_find_references():
-    """Import the sweep's own formatters so the two reports share one presentation."""
-    path = Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts" / "find_references.py"
+def _load_shared(name: str):
+    """Import a find-chart-references module, so the reports share one presentation."""
+    path = Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts" / f"{name}.py"
     if not path.exists():
         raise SystemExit(f"Cannot find the shared formatters at {path}")
-    spec = importlib.util.spec_from_file_location("find_references", path)
+    spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
 
 
-fr = _load_find_references()
+fr = _load_shared("find_references")
+# Two of the aids have a second, corrected implementation in `reference_report.py`, and this
+# report takes each formatter from whichever module gets it right — copying either one here
+# would be the drift this script exists to avoid. See `page_link` and `find_hint`.
+rr = _load_shared("reference_report")
 
 
 def chart_ref(url: str) -> int | str:
@@ -128,6 +135,28 @@ def params_cell(own_params: str) -> str:
     shown = f"`{fr.cell(query, 40)}`"
     clashing = sorted({key for key, _ in parse_qsl(query, keep_blank_values=True)} & REDIRECT_KEYS)
     return f"⚠️ {shown} overrides {', '.join(clashing)}" if clashing else shown
+
+
+def page_link(r: dict, host: str, admin: str) -> str:
+    """The published page, scrolled to the reference — page-TYPE aware.
+
+    A gdoc's slug does not sit at the root for every type: a data insight is served under
+    `/data-insights/` and an author page under `/team/`, while the sweep records `where_path`
+    as `/<slug>` for all of them. A prose link's text fragment then attaches to the wrong
+    base and makes a 404 look like a working link, so the type decides the base.
+    """
+    return rr.page_deep_link(r, host, admin)
+
+
+def find_hint(r: dict) -> str:
+    """Copy-paste search string for the doc's find box, truncated WITHOUT an ellipsis.
+
+    A long anchor has to be cut somewhere, but `…` is not a character in the document, so a
+    hint carrying one finds nothing when pasted. A literal prefix still matches, which is
+    what the shared helper's `marker=""` is for.
+    """
+    hint = rr.cell(rr.find_in_doc(r), 55, marker="")
+    return f"`{hint}`" if hint else "—"
 
 
 def open_links(r: dict, host: str, admin: str) -> str:
@@ -231,7 +260,10 @@ def main() -> int:
             ptype = r["context"].split("(")[-1].rstrip(")") if "(" in r.get("context", "") else ""
             page_type = f" _{ptype}_" if ptype else ""
             preview = f" · [👁 preview]({fr.gdoc_preview_url(r, admin)})" if r.get("surface_id") else ""
-            links = f"[📄 doc]({fr.doc_url(r)}){preview} · [🔗 page]({fr.deep_link(r, args.host, admin)})"
+            links = f"[📄 doc]({fr.doc_url(r)}){preview}"
+            page = page_link(r, args.host, admin)
+            if page:
+                links += f" · [🔗 page]({page})"
             if r.get("admin_url"):
                 links += f" · [✎ chart admin]({r['admin_url']})"
             subject = (
@@ -241,7 +273,7 @@ def main() -> int:
             )
             own_params = r.get("query_string", "")
             out.append(
-                f"| {subject} | {fr.cell(r['where'], 44)}{page_type}{draft} | {links} | {fr.search_hint(r)} | "
+                f"| {subject} | {fr.cell(r['where'], 44)}{page_type}{draft} | {links} | {find_hint(r)} | "
                 f"{params_cell(own_params)} | {replacement_url(r['subject_id'], own_params, pairs, slugs)} |"
             )
         out.append("")
@@ -293,12 +325,26 @@ def main() -> int:
     narrative = [r for r in rows if r["surface"] == "narrative chart"]
     placed.update(id(r) for r in narrative)
     if narrative:
-        out += [f"## ℹ️ Narrative charts ({len(narrative)}) — do not block", ""]
-        for r in narrative:
+        out += [
+            f"## ℹ️ Narrative charts ({len(narrative)}) — do not block, but still need replacing",
+            "",
+            "Nothing breaks at retirement: each renders from its own materialized config, and its "
+            '"Explore the data" href is covered by the redirect. It keeps showing the OLD view '
+            "though, and the parent columns are INSERT-only, so there is no re-pointing API. "
+            "Replace each one, **in this order**: **create** the replacement from the URL below "
+            'using the target chart\'s own "Create narrative chart" control, **update the '
+            "article(s)** to the new name, then **delete** the old one. Never delete first — a "
+            "published post referencing the name blocks the delete.",
+            "",
+            "| Narrative chart | On | Its params | Open | Create the replacement from |",
+            "|---|---|---|---|---|",
+        ]
+        for r in sorted(narrative, key=lambda r: str(r["where"])):
+            own_params = r.get("query_string", "")
             out.append(
-                f"- `{r['where']}` on `{r['subject']}` — params `{r.get('query_string') or '—'}`. Renders from "
-                f'its own materialized config, and its "Explore the data" href is covered by the redirect; '
-                f"its params override the stored ones."
+                f"| `{fr.cell(str(r['where']), 44)}` | `{r['subject']}` | {params_cell(own_params)} | "
+                f"{open_links(r, args.host, admin)} | "
+                f"{replacement_url(r['subject_id'], own_params, pairs, slugs)} |"
             )
         out.append("")
 
@@ -333,7 +379,8 @@ def main() -> int:
         "**Find in the doc** is a copy-paste search string for the Google Doc: the link text for a "
         "prose hyperlink, or the chart slug for a block embed (the doc holds a bare grapher URL "
         "there — and the slug is stored as the author typed it, so it matches even when the doc "
-        "still uses an old one). A `—` means there is nothing to search for.",
+        "still uses an old one). A long one is cut short but stays literal, with no `…` appended, "
+        "so it can still be pasted straight into the find box.",
         "",
         "**Replace with** merges the redirect's stored params with the reference's own, and the "
         "reference's win. **Its params** is what the reference already carries, so you can see "


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

## What this PR does

The `add-gdp-scatter` reference handoff named an article and a replacement URL and stopped there — so whoever had to fix an embed still had to find the Google Doc, then hunt through it for the reference. `find-chart-references` already solves that in its own markdown, and the handoff was discarding the solution.

Promotes the handoff builder into the skill as `scripts/build_reference_handoff.py`, keeping every locating aid the sweep provides and adding the two columns this workflow needs:

| | why it matters |
|---|---|
| **📄 doc** | `posts_gdocs.id` *is* the Google Doc id, so it's a direct link — and editing the doc is the only way to fix an embed |
| **👁 preview** | the article in the admin previewer, which renders unpublished drafts the public page won't show |
| **🔗 page** | the published page, deep-linked with a scroll-to-text fragment, so it opens *at* the reference. The page **type** decides the base: a data insight lives under `/data-insights/` and an author page under `/team/`, and a fragment attached to the wrong base makes a 404 look like a working link |
| **Find in the doc** | copy-paste search string: link text for a prose hyperlink, chart slug for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). Long ones are cut but stay **literal** — an appended `…` is not in the document and would find nothing |
| **Its params** | the query string the reference already carries, since the replacement merges it over `tab=scatter&time=latest&country=` and **the reference's values win**. A ⚠️ marks the keys that override the retirement's own — that row lands the reader on a different tab or time range, and the merge is otherwise silent about it |
| **Replace with** | the target's scatter view, which is the workflow-specific half the sweep has no way to know |

**The formatters are imported from the `find-chart-references` scripts, not copied** — a second copy drifts, and the drift surfaces as a handoff whose links quietly stop resolving. Each one comes from whichever module gets it right: the doc and preview links from `find_references.py`, the page link and the search string from `reference_report.py`, which is the one that knows the page-type routes and truncates without an ellipsis. The tailscale suffix is stripped from the admin root so the links read like the sweep's own, which are already short.

Those formatters read `surface_id` **as** a Doc id, which only holds on a Google Doc surface — on an explorer or narrative-chart row that field is a slug or a chart id. So the two article tables are filtered to the shared `GDOC_SURFACES`, every other surface gets the section that explains its own consequence, and a catch-all table takes whatever no section claimed, so a row the sweep found cannot go missing here (a `redirect` row — an old slug of the source, which the unpublish deletes — has no section of its own and used to land nowhere).

Sections the ad-hoc version had no shape for:

- **Explorer / data-insight / static-viz references** — `redirect_to_scatter.py` converts those rows to `BLOCKED` before `--apply`, so the handoff states it and points at `--allow-manual-refs`. Each row opens both the retiring chart's editor and, from the sweep's `preview_url`, the explorer itself — the thing actually being re-pointed.
- **Key-chart slots**, which the Part 2 audit structurally cannot see.
- **Narrative charts**, which do not block the unpublish but still need replacing: they render on from a materialized config of the old view, and the parent column is INSERT-only, so there is no re-pointing API. Each row carries the editor link, its params, and the URL to create the replacement from, above the create → re-point articles → delete order.
- **The coverage boundary**, carried in the file rather than pointed at: the permanent limits restated from the sweep's own `NOT_SEARCHED` (imported, so they can't drift either), plus that run's gaps through `--gaps`. Left off, the handoff says the gaps weren't captured — a short table must not read as a clean result.

`--pairs` accepts either pair schema, Part 1's table rows (admin URLs) or the Part 2 payload (public grapher URLs, resolved against the DB), since which list is the right one depends on the rows actually being retired. `SKILL.md` records the requirements, including which formatter to import from where, and step 11 of the checklist now names the builder.

## Verification

Run against the real batch-1 sweep — 22 references over 14 retiring charts: 6 article embeds, 2 article links, 13 key-chart slots, 1 narrative chart, every row accounted for by exactly one section. Feeding the same pairs as public grapher URLs instead of admin URLs produces a byte-identical handoff. The search hints resolve the way the sweep intends: anchor text where there is one (`low maternal mortality rates`, `poorest in the world`), the slug for block embeds and for the narrative chart that has none.

That sweep leaves several paths uncovered, so each was exercised with an injected row: a `redirect` row lands in the catch-all rather than disappearing; an explorer row opens both the chart editor and `/explorers/<slug>`; a data-insight row links to `/data-insights/<slug>` and an author page to `/team/<slug>`; a 100-character anchor yields a literal findable prefix instead of one ending in `…`; and a reference carrying `tab=chart&time=1990..2015` is flagged `overrides tab, time` while a harmless `yScale=linear` is not. An unresolvable slug and a pair missing both key names each exit with a message naming the problem. No tailscale suffix left in the output.
