### PR TITLE
🐛 Bypass poisoned CDN cache that corrupts the FluID snapshot

### DIFF
--- a/snapshots/who/latest/fluid.csv.dvc
+++ b/snapshots/who/latest/fluid.csv.dvc
@@ -10,13 +10,13 @@ meta:
     attribution_short: WHO
     url_main: https://www.who.int/teams/global-influenza-programme/surveillance-and-monitoring/fluid
     url_download: https://xmart-api-public.who.int/FLUMART/VIW_FID_EPI?$format=csv
-    date_accessed: '2026-08-13'
+    date_accessed: '2026-08-14'
     date_published: '2023-02-16'
     license:
       name: CC BY-NC-SA 3.0 IGO
       url: https://www.who.int/about/policies/publishing/copyright
 wdir: ../../../data/snapshots/who/latest
 outs:
-  - md5: 4506f6e7f9b3d856b0d665f90c235904
-    size: 74630258
+  - md5: 8b79e94250b7e9d3804656b8a0afa3b5
+    size: 74725339
     path: fluid.csv

--- a/snapshots/who/latest/fluid.py
+++ b/snapshots/who/latest/fluid.py
@@ -77,6 +77,14 @@ def _assert_not_corrupted(path: Path) -> None:
     of fields, which pandas refuses to tokenize, or it lands on a row boundary and instead
     duplicates and drops whole rows, which parses cleanly and would otherwise be published as
     silently wrong data. A correct body has no duplicate rows at all.
+
+    NOTE: this is a backstop, not the fix — the cache-busting URL above is what stops corrupted
+    bodies being served in the first place, since every observed splice came from a cache hit. It
+    cannot catch a hypothetical splice that only drops rows without duplicating any. Closing that
+    gap needs a second full download to compare against (there is no ETag, no Content-MD5, and
+    `$count` times out at the origin), which would double the load on an endpoint that already
+    returns 504s — a worse trade than the residual risk. If the parse or duplicate check ever fires
+    on a body that came back with a fresh cache key, that assumption needs revisiting.
     """
     size = path.stat().st_size
     if size < MIN_SIZE_BYTES:

--- a/snapshots/who/latest/fluid.py
+++ b/snapshots/who/latest/fluid.py
@@ -1,47 +1,92 @@
 """Script to create a snapshot of dataset 'FluID, World Health Organization'."""
 
-from datetime import date
+import time
+from datetime import date, datetime, timezone
 from pathlib import Path
 
-import click
 import pandas as pd
+import structlog
+from requests.exceptions import RequestException
 
+from etl.download_helpers import DownloadCorrupted, download
 from etl.snapshot import Snapshot
+
+log = structlog.get_logger()
 
 # Version for current snapshot dataset.
 SNAPSHOT_VERSION = Path(__file__).parent.name
 
+# The WHO xmart API is served through Azure Front Door, which repeatedly hands this host a *cached*
+# body assembled from more than one origin response, spliced together at 8 MiB boundaries. The body
+# is exactly the length the Content-Length header promises, so the download itself looks healthy,
+# but rows around each splice are fragmented, duplicated and lost — one observed body was missing
+# 282 rows, carried 156 duplicates, and merged two half-rows into a 66-field line. AFD ignores
+# `Cache-Control: no-cache`, and every plain request keeps hitting the same poisoned entry (five in
+# a row returned an identical corrupt md5). A unique query parameter is a fresh cache key, so it
+# always misses the cache and reaches the origin, which serves a correct body.
+CACHE_BUST_PARAM = "owid_cache_bust"
 
-@click.command()
-@click.option(
-    "--upload/--skip-upload",
-    default=True,
-    type=bool,
-    help="Upload dataset to Snapshot",
-)
-def main(upload: bool) -> None:
+# Number of download attempts. Each one uses a new cache-busting value, so this also covers the
+# 504s the origin returns when it is slow to generate the export.
+MAX_ATTEMPTS = 3
+
+# Snapshot should have at least 50mb, otherwise something went wrong.
+MIN_SIZE_BYTES = 50 * 2**20
+
+
+def run(upload: bool = True) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"who/{SNAPSHOT_VERSION}/fluid.csv")
+    assert snap.metadata.origin, "origin is not set"
+    assert snap.metadata.origin.url_download, "url_download is not set"
 
-    # Bump date_accessed to today since this is a `latest/` snapshot that re-pulls fresh data.
-    assert snap.metadata.origin
+    snap.path.parent.mkdir(parents=True, exist_ok=True)
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        url = _cache_busting_url(snap.metadata.origin.url_download)
+        try:
+            download(url, str(snap.path))
+            _assert_not_corrupted(snap.path)
+            break
+        except (DownloadCorrupted, RequestException) as e:
+            log.warning("fluid.download_failed", attempt=attempt, max_attempts=MAX_ATTEMPTS, error=str(e))
+            if attempt == MAX_ATTEMPTS:
+                raise
+            time.sleep(10 * attempt)
+
+    # Bump date_accessed to today since this is a `latest/` snapshot that re-pulls fresh data. This
+    # happens only once the download is known good, so a failed run leaves the .dvc file untouched.
     snap.metadata.origin.date_accessed = date.today().isoformat()
     snap.metadata.save()
-
-    # Download data from source.
-    snap.download_from_source()
-
-    # Try reading the csv, we sometimes get error invalid CSV with error
-    # ParserError: Error tokenizing data. C error: Expected 49 fields in line 50053, saw 56
-    # if this fails, don't upload the file
-    pd.read_csv(snap.path)
-
-    # Snapshot should have at least 50mb, otherwise something went wrong
-    assert snap.path.stat().st_size > 50 * 2**20, "Snapshot file must have at least 50mb"
 
     # Add file to DVC and upload to S3.
     snap.dvc_add(upload=upload)
 
 
-if __name__ == "__main__":
-    main()
+def _cache_busting_url(url_download: str) -> str:
+    """Add a value that has never been requested before, to force a cache miss."""
+    nonce = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+    separator = "&" if "?" in url_download else "?"
+    return f"{url_download}{separator}{CACHE_BUST_PARAM}={nonce}"
+
+
+def _assert_not_corrupted(path: Path) -> None:
+    """Reject a body that was spliced together from several origin responses.
+
+    A splice shows up in one of two ways: it merges two half-rows into a line with the wrong number
+    of fields, which pandas refuses to tokenize, or it lands on a row boundary and instead
+    duplicates and drops whole rows, which parses cleanly and would otherwise be published as
+    silently wrong data. A correct body has no duplicate rows at all.
+    """
+    size = path.stat().st_size
+    if size < MIN_SIZE_BYTES:
+        raise DownloadCorrupted(f"FluID snapshot is {size} bytes, expected at least {MIN_SIZE_BYTES}.")
+
+    try:
+        df = pd.read_csv(path, low_memory=False)
+    except pd.errors.ParserError as e:
+        raise DownloadCorrupted(f"FluID snapshot is not valid CSV: {e}") from e
+
+    duplicates = int(df.duplicated().sum())
+    if duplicates:
+        raise DownloadCorrupted(f"FluID snapshot has {duplicates} duplicate rows, a correct body has none.")


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The daily flunet job has been failing on the FluID snapshot with `ParserError: Expected 38 fields in line …, saw 66`. The cause is not WHO's data: Azure Front Door, which fronts the xmart API, serves `etl-prod-2` a **cached body assembled from more than one origin response, spliced at 8 MiB boundaries**. The body is exactly as long as `Content-Length` promises, so the download looks healthy, but rows around each splice are fragmented, duplicated and lost. This adds a cache-busting query parameter so the request reaches the origin, and validates the body before it can be uploaded.

_Review depth: deep on the cache-busting parameter — it changes the URL we actually fetch, and the reasoning for why nothing simpler works is in the evidence below. The validation helper is straightforward._

## What the corrupted body looks like

One captured body (the file the failed run left on `etl-prod-2`) against a known-good one of **identical byte length**:

| | good | spliced |
|---|---|---|
| md5 | `8b79e942…` | `2c9a0b6a…` |
| rows lost | — | **282** |
| duplicate rows | 0 | **156** |
| rows present that shouldn't be | — | 127 |

The two agree byte-for-byte up to offset 8388609 — exactly 8 MiB — where the stream jumps mid-row:

```
good: ...,2021-07-26,2021,30,202130,65TO,2629,0,,,...,2021-07-25,2021,30,202130
                                                              ^ row ends cleanly
bad:  ...,2021-07-26,2021,30,202130,65TO,2629,0,,,...,2021-07-25 1-01,2021,44,202144,0TO4,13295,...
                                                              ^ splices into a row from week 44
```

Two half-rows joined together make the 66-field line pandas rejects. **A splice that happens to land on a row boundary parses cleanly**, which is the more dangerous case — it would publish a FluID dataset quietly missing and double-counting hundreds of rows. There is already a workaround downstream that has been absorbing exactly this (see the follow-up note at the bottom).

## Why cache-busting, and not something simpler

Everything here was measured from `etl-prod-2`, since that is the only side that reproduces — every download to a laptop is clean:

| variant | `x-cache` | md5 | bad rows |
|---|---|---|---|
| plain URL (×5 in a row) | `TCP_REMOTE_HIT` / `TCP_HIT` | identical corrupt md5 every time | 2–4 |
| `Cache-Control: no-cache` + `Pragma: no-cache` | `TCP_HIT` | same corrupt body | 4 |
| **unique query parameter** | **`TCP_MISS`** | **`8b79e942…`** | **0** |
| `$orderby=…` | `TCP_MISS` | clean, different order | 0 |

- **Retrying cannot work.** Five consecutive plain requests returned the *same* corrupt md5. The poisoned entry is cached for `max-age=10800` (3 h), which spans the whole daily job including Buildkite's automatic retries.
- **`no-cache` request headers are ignored** by Azure Front Door — still a `TCP_HIT`, still corrupt.
- **Any cache miss is clean**, and the cache-busted body is byte-identical to what a healthy edge serves, which is what confirms the origin data is fine and only the cached copy is mangled.
- **`$orderby` also works** (it is just another distinct cache key) but was rejected: it changes row order in the snapshot for no benefit, and on the sibling FluNet endpoint the same parameter **504s**, so it makes the request measurably more fragile.
- There is **no server-side integrity signal at all** to validate against instead: no `ETag`, no `Content-MD5`, and both OData `$count` forms fail at the origin with `Microsoft.Data.SqlClient.SqlException: Execution Timeout Expired`.

`url_download` in the `.dvc` stays clean — the nonce is appended at download time, not recorded as metadata.

## Verified

- The new guard rejects the real corrupted body and accepts the clean one:
  `spliced → DownloadCorrupted: not valid CSV: Expected 38 fields in line 67487, saw 66`, `clean → accepted`.
- The duplicate-row check catches the silent case, which the parse check alone cannot. Replaying 1000 rows into the clean file (what a backwards splice does) still parses to a `(589524, 38)` frame, and is rejected with `has 1000 duplicate rows, a correct body has none`.
- The check is sound on real data: a clean body has **0** duplicate rows and 0 non-numeric `ISO_YEAR` values, so neither check can fire on a healthy download. Its documented blind spot — a splice that only drops rows — is discussed [in this thread](https://github.com/owid/etl/pull/6671#discussion_r3781832924).
- **The snapshot is included in this PR**, taken through the new code path: `588,524` rows × 38 columns, 189 countries, `ISO_YEAR` 1996–2026, latest week starting `2026-08-03`, 0 duplicate rows, 0 non-numeric `ISO_YEAR`. Its md5 `8b79e942…` is the same body two independent CDN edges return, so what got uploaded is the origin's own export. `url_download` in the `.dvc` is untouched — the nonce is appended at download time, never recorded.
- That commit also repairs `date_accessed`, which claimed `2026-08-13` while the data was from `2026-08-11` — the wrong-provenance artifact left by the concurrency bug fixed in #6658.
- `data://meadow/who/latest/fluid` rebuilds on the new snapshot with **no** `Dropping malformed row with non-numeric iso_year` warnings and no coercion warnings, which is the direct evidence for the follow-up note below.
- FluNet was probed the same way and is currently clean on every variant, so it is deliberately left unchanged — forcing a cache miss there would push every request onto the origin that produces those 504s, for no present benefit.

**Not verified:** the corruption only reproduces from `etl-prod-2`, so the confirmation that matters is tomorrow's scheduled run going green. The FluID download now always bypasses the CDN cache, which means it always pays full origin generation time — if that turns out to raise the 504 rate, the retry loop absorbs it, but it is the thing to watch.

<details>
<summary>Follow-up worth a separate look: a downstream workaround that has been masking this</summary>

`etl/steps/data/meadow/who/latest/fluid.py:36-43` coerces `iso_year` to numeric and silently drops rows where it fails, commented as *"Source data has a malformed row with a date in iso_year"*. That is this corruption, not a WHO data quirk — a splice puts a date where the year belongs (`2021-07-25` + `1-01,2021,44,…`), and a clean body has **zero** non-numeric `iso_year` values. So on days when the splice landed just right, the job succeeded and quietly dropped the damaged rows instead of failing.

Left in place here because removing it changes the failure behaviour of a step that currently passes, and this PR already stops corrupted bodies from reaching it. Worth deleting so future corruption fails loudly.

</details>
