### PR TITLE
🐛🤖 Clean up orphaned chart_configs when deleting ghost variables

### DIFF
--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -468,6 +468,21 @@ def cleanup_ghost_variables(engine: Engine, dataset_id: int, upserted_variable_i
                 )
                 return False
 
+        # collect the chart_configs rows that only these variables (and their mdim views) point at
+        rows = con.execute(
+            text(
+                """
+            SELECT grapherConfigIdETL FROM variables WHERE id IN :variable_ids AND grapherConfigIdETL IS NOT NULL
+            UNION
+            SELECT grapherConfigIdAdmin FROM variables WHERE id IN :variable_ids AND grapherConfigIdAdmin IS NOT NULL
+            UNION
+            SELECT chartConfigId FROM multi_dim_x_chart_configs WHERE variableId IN :variable_ids
+        """
+            ),
+            {"variable_ids": variable_ids_to_delete},
+        ).fetchall()
+        config_ids_to_delete = [row[0] for row in rows]
+
         # then variables themselves with related data in other tables
         # delete relationships
         con.execute(
@@ -527,6 +542,22 @@ def cleanup_ghost_variables(engine: Engine, dataset_id: int, upserted_variable_i
             ),
             {"dataset_id": dataset_id, "variable_ids": variable_ids_to_delete},
         )
+
+        # delete the now-unreferenced configs (the multi_dim_redirects guard is there because
+        # a redirect can point at an mdim view config)
+        if config_ids_to_delete:
+            con.execute(
+                text(
+                    """
+                DELETE FROM chart_configs
+                WHERE id IN :config_ids
+                  AND NOT EXISTS (
+                    SELECT 1 FROM multi_dim_redirects r WHERE r.viewConfigId = chart_configs.id
+                  )
+            """
+                ),
+                {"config_ids": config_ids_to_delete},
+            )
 
         con.commit()
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

`cleanup_ghost_variables` deletes variables with raw SQL and clears every table that
references them, but it never touches `chart_configs`. Every FK into `chart_configs`
points *outward* from the referencing row:

- `variables.grapherConfigIdETL` / `grapherConfigIdAdmin` → `chart_configs.id` (`ON DELETE RESTRICT`)
- `multi_dim_x_chart_configs.chartConfigId` → `chart_configs.id`

So `DELETE FROM variables` succeeds and the indicator's config row is simply stranded —
one leaked row per deleted variable that had an ETL grapher config. Same for each mdim
view config, since the function also deletes `multi_dim_x_chart_configs` rows directly.
Production currently holds ~1,600 of these, growing in bursts that line up with dataset
re-versions.

Grapher's own writers delete both sides — `deleteVariablesVariableIdGrapherConfigETL`
nulls the column and deletes the config row, `cleanUpOrphanedChartConfigs` does the same
for mdim views. This function now does too: it collects the config ids before the deletes
and removes them after the variables are gone (the FKs are `RESTRICT`, so the order
matters).

The `NOT EXISTS` guard on `multi_dim_redirects` is there because a redirect can point at
an mdim view config, and that FK is `RESTRICT` as well — without the guard, that rare case
would fail the whole grapher step instead of leaking a single row.

## Still open

- **The ~1,600 rows already in production are not cleaned up by this PR.** That needs a
  one-off delete of `chart_configs` rows unreferenced by `charts`, `variables`,
  `narrative_charts`, `multi_dim_x_chart_configs`, `explorer_views` and
  `multi_dim_redirects` — best placed as an `owid-grapher` migration. Not written yet.
- **No test.** `tests/` has no MySQL harness and this function's SQL is MySQL-only (the
  `IN :param` style relies on pymysql expanding lists), so covering it means new
  integration infra. The `DELETE … NOT EXISTS` semantics were verified by hand against
  sqlite; the change itself has not been run against a real database.
- **Unverified:** how many of the existing orphans are the mdim-view leg rather than the
  indicator-config leg. The public Datasette mirror carries a filtered subset of
  `chart_configs`, so that count needs a prod/staging MySQL run.
