### PR TITLE
🐛🤖 Validate definitions.common like the indicator it is

### DIFF
--- a/tests/test_metadata_schemas.py
+++ b/tests/test_metadata_schemas.py
@@ -66,6 +66,28 @@ def _strip_jinja_templated_values(obj):
             _strip_jinja_templated_values(item)
 
 
+def _strip_jinja_from_typed_blocks(ind):
+    """Strip Jinja templates from the two blocks of an indicator that hold typed fields.
+
+    `display` (numDecimalPlaces, timeInterval, …) and
+    `presentation.grapher_config` (yAxis.min/max, yEquals, …) declare enums and
+    numbers, which a Jinja template never satisfies statically. Those validate
+    at runtime once the dimensions are known — `_expand_jinja` renders them, and
+    `etl.grapher.helpers._validate_grapher_config` re-validates grapher_config
+    afterwards. Every other field (description_short, title_public, …) is typed
+    `string` in the schema, so a Jinja template passes and keeps its coverage.
+
+    Applied to each indicator *and* to `definitions.common`, which the schema
+    `$ref`s to the very same indicator definition (#6674).
+    """
+    if not isinstance(ind, dict):
+        return
+    _strip_jinja_templated_values(ind.get("display"))
+    presentation = ind.get("presentation")
+    if isinstance(presentation, dict):
+        _strip_jinja_templated_values(presentation.get("grapher_config"))
+
+
 def _get_changed_files_vs_master(pattern: str) -> set[str] | None:
     """Return set of files changed vs master matching pattern, or None to validate all.
 
@@ -169,6 +191,12 @@ def test_dataset_schemas():
 
         data = load_yaml_as_string(meta_file_path)
 
+        # `definitions.common` is merged into every indicator, and the schema validates it
+        # against the same indicator definition, so its typed blocks need the same treatment.
+        definitions = data.get("definitions")
+        if isinstance(definitions, dict):
+            _strip_jinja_from_typed_blocks(definitions.get("common"))
+
         # Ignore invalid `description` field, it's in too many latest datasets
         for tab in data.get("tables", {}).values():
             for ind in tab.get("variables", {}).values():
@@ -179,22 +207,7 @@ def test_dataset_schemas():
                 if "$schema" in ind.get("presentation", {}).get("grapher_config", {}):
                     del ind["presentation"]["grapher_config"]
 
-                # Strip Jinja templates from the two blocks that hold typed
-                # numeric fields (display: numDecimalPlaces, yAxis…; grapher_config:
-                # yAxis.min/max, yEquals…). Runtime rendering + post-render schema
-                # validation in `etl.grapher.helpers._validate_grapher_config`
-                # catches type mismatches for those fields after Jinja resolves.
-                # All other fields (description_short, title_public, etc.) keep
-                # their schema coverage even when they contain Jinja, since their
-                # schema type is `string` and Jinja-templated strings still pass.
-                display = ind.get("display", {})
-                if display:
-                    for key in list(display.keys()):
-                        if isinstance(display[key], str) and "<%" in display[key]:
-                            del display[key]
-                gc = ind.get("presentation", {}).get("grapher_config", {})
-                if gc:
-                    _strip_jinja_templated_values(gc)
+                _strip_jinja_from_typed_blocks(ind)
 
         # Validate the loaded data against the schema
         validated_count += 1
@@ -221,6 +234,34 @@ def test_dataset_schemas():
         # Raise the first error
         first_file, first_error = validation_errors[0]
         raise ValidationError(f"Validation error in file: {first_file}") from first_error
+
+
+def test_jinja_in_typed_fields_is_stripped_from_definitions_common():
+    """A Jinja-templated enum/numeric field must be skipped in `definitions.common` too.
+
+    `definitions.common` `$ref`s the indicator definition, so its `display` and
+    `presentation.grapher_config` carry the same enums and numbers a template can't
+    satisfy statically. Only `tables.*.variables.*` used to be sanitized, so the
+    first such template on master (`timeInterval` in covid/2024-11-05/github_stats,
+    #6613) broke every build until #6674.
+    """
+    data = {
+        "definitions": {
+            "common": {
+                # Renders to `week` / `day`, both in the schema's enum, once `interval` is known.
+                "display": {"timeInterval": '<% if interval == "weekly" %>week<% else %>day<% endif %>'},
+            }
+        },
+        "tables": {},
+    }
+    _strip_jinja_from_typed_blocks(data["definitions"]["common"])
+    Draft7Validator(DATASET_SCHEMA).validate(data)
+
+    # Guardrail: a non-templated bad value must still fail, i.e. the block is sanitized, not skipped.
+    bad = {"definitions": {"common": {"display": {"timeInterval": "fortnight"}}}, "tables": {}}
+    _strip_jinja_from_typed_blocks(bad["definitions"]["common"])
+    with pytest.raises(ValidationError):
+        Draft7Validator(DATASET_SCHEMA).validate(bad)
 
 
 def test_snapshot_schemas():


### PR DESCRIPTION
> _Written by Claude Opus 5 — @pabloarosado at the wheel._

`test_dataset_schemas` has been failing on master since yesterday, which fails every branch built from it ([build 47371](https://buildkite.com/our-world-in-data/etl-unit-tests/builds/47371) is one of many):

```
etl/steps/data/garden/covid/2024-11-05/github_stats.meta.yml
  On instance['definitions']['common']['display']['timeInterval']:
  '<% if interval == "weekly" %>week<% else %>day<% endif %>'
  is not one of ['day', 'week', 'month', 'quarter', 'year', 'decade']
```

## Why it broke

The test strips Jinja templates out of `display` and `presentation.grapher_config` for every `tables.*.variables.*` entry, because those blocks declare enums and numbers that a template only satisfies once the dimensions are known. It never did the same for `definitions.common` — even though `dataset-schema.json` `$ref`s that block to the very same indicator definition.

The gap was invisible until two changes landed the same day:

- [🔨🤖 Respect a declared timeInterval, and re-tag sub-yearly datasets](https://github.com/owid/etl/pull/6613) added the first Jinja-templated *typed* field under `definitions.common`, a `timeInterval` that resolves to `week` for the weekly slice of `covid/2024-11-05/github_stats` and `day` otherwise.
- [🐛 Fix test_dataset_schemas validating zero files](https://github.com/owid/etl/pull/6663) fixed the active-DAG filter that had been skipping every file, so the validator finally saw it.

The metadata is correct; only the test was wrong. `render_yaml_file` on the four `interval` values yields `week`, `day`, `day`, `day` — all inside the enum.

## The fix

The strip now runs through one `_strip_jinja_from_typed_blocks` helper, called for `definitions.common` and for each indicator.

## How this was verified

**The test does run on all files, and that is what CI runs.** `_get_changed_files_vs_master` returns `None` on Buildkite — `git rev-parse --abbrev-ref HEAD` gives `HEAD` on a detached checkout, and `git diff master` then fails for want of a local `master` ref — so every CI build full-scans. Build 47371 proves it rather than assuming it: that branch changed three `.meta.yml` files, all under `climate/2026-08-07`, yet the validator reached `covid/2024-11-05/github_stats.meta.yml`.

Forcing the same full scan locally: **652 files validated and passing** with this fix; the same 652 with master's copy of the test fails on `github_stats`.

**Coverage was measured, not argued.** The dict handed to the validator was recorded for each of the 652 files, before and after. Same file set, three keys removed, nothing added or altered anywhere else:

| File | Key | Effect |
|---|---|---|
| `covid/2024-11-05/github_stats` | `definitions.common.display.timeInterval` | the enum — the only failure |
| `covid/latest/infections_model` | `definitions.common.display.name` | string-typed, passed before |
| `ihme_gbd/2026-02-07/gbd_risk_cancer` | `…grapher_config.note` | string-typed, passed before |

**Nothing else of this shape exists.** Across all 1491 `.meta.yml` files in the repo — active, archived, excluded, fasttrack alike — those three are the only `<%` templates inside a `definitions.common` typed block, and `timeInterval` is the only non-string field among the six Jinja values found there.

The condition stays `<%` only, not the runtime's wider `<%`-or-`<<`. 285 `<<`-only values sit in these blocks today (246 `display.name`, 39 in grapher_config title/subtitle/note), all string-typed and legitimately validated; widening the strip would drop them from the schema's `additionalProperties: false` check for no gain.

A new unit test pins the policy on a synthetic `definitions.common`, and asserts that a non-templated `timeInterval: fortnight` there still fails — the block is sanitized, not skipped.

## Still open

- **A `<<`-only template in an enum or numeric field would still break statically** — `timeInterval: <<interval>>` fails the same way, in a variable block just as in `definitions.common`. Pre-existing, not introduced or fixed here. The precise fix would be to strip by the field's declared schema type rather than by template syntax; that is a bigger change than a red-CI fix warrants.
- **The changed-files fast path never engages in CI**, per the `git diff master` failure above. That full scan is what surfaced this bug, so it is arguably the safer behaviour, but the intended per-PR speedup only works locally. Not touched here.
- **Nobody ran the grapher step end-to-end.** This PR verifies the template renders to valid enum values via `render_yaml_file`; it does not run `grapher://covid/2024-11-05/github_stats` to confirm the weekly slice reaches the DB as `week`. #6613 claims to have done that.