### PR TITLE
🐛 Fix string boolean in labor force participation MDim config

### DIFF
--- a/etl/steps/export/multidim/worldbank_wdi/latest/labor_force_participation_rate.py
+++ b/etl/steps/export/multidim/worldbank_wdi/latest/labor_force_participation_rate.py
@@ -33,7 +33,7 @@ def run() -> None:
                 "choices": ["male", "female"],
                 "choice_new_slug": "male_vs_female",
                 "view_config": {
-                    "hideRelativeToggle": "false",
+                    "hideRelativeToggle": False,
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "chartTypes": ["LineChart", "DiscreteBar", "SlopeChart"],


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Schema validation of MDim views flagged three views of the labor force participation MDim:

```
'false' is not of type 'boolean'    hideRelativeToggle
  age_group=_15_plus__sex=male_vs_female
  age_group=_15_64__sex=male_vs_female
  age_group=_15_24__sex=male_vs_female
```

The `group_views` config for the male-vs-female views set `hideRelativeToggle` to the string `"false"` instead of the boolean `False`.

## Still open

- **The schema check never saw this config.** `validate_schema()` runs only at collection *create* time (`etl/collection/core/utils.py:96`); `Collection.save()` runs many other checks but never re-validates against the schema. So anything added or edited after creation — `group_views` configs and the `for view in c.views:` edit loops that most MDim steps have — reaches MySQL unvalidated. Adding `self.validate_schema()` to `save()` (gated off for explorers, as it already is at create time) would catch this class at build time. Not done here because it's unknown how many existing MDim steps that would newly fail — it needs a run of every MDim export step first.
- **Other MDims not swept** for the same string-boolean pattern beyond the `hideRelativeToggle`/`hasMapTab` grep. The `"false"` strings in the LIS explorer steps are fine — `etl/collection/explorer/core.py:205` stringifies booleans anyway.
