### PR TITLE
📊 Annotate FAOSTAT's own Europe and Asia aggregates for the 1992 USSR break

### DIFF
--- a/etl/steps/data/garden/faostat/2026-02-25/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2026-02-25/faostat_metadata.py
@@ -1078,4 +1078,4 @@ def run() -> None:
 # at runtime but do not match those patterns, so editing them alone does NOT trigger a rebuild here (or
 # in any downstream FAOSTAT step). After changing that harmonization, make a small edit anywhere in this
 # file (e.g. tweak this comment) to force this step's checksum to change and propagate the rebuild.
-# Last forced rebuild: 2026-08-14.
+# Last forced rebuild: 2026-08-14 (USSR-breakup annotations on FAOSTAT's own Europe and Asia aggregates).

--- a/etl/steps/data/grapher/faostat/2026-02-25/shared.py
+++ b/etl/steps/data/grapher/faostat/2026-02-25/shared.py
@@ -13,7 +13,8 @@ VERSION = CURRENT_DIR.name
 # FAOSTAT reports the USSR as a single entity until 1991, and its fifteen successor states separately from 1992.
 # In OWID region aggregates, the USSR is counted entirely inside Europe and Upper-middle-income countries, so the
 # aggregates of continents and income groups jump abruptly between 1991 and 1992, when its area is redistributed
-# among the successor states' regions.
+# among the successor states' regions. FAOSTAT's own continental aggregates break identically (e.g. land area in
+# "Europe (FAO)" falls by the same 455 million hectares as in "Europe"), so they get the same annotation.
 # NOTE: The following fields are added in this grapher step (and not in the garden step) so that they do not propagate
 # to datasets derived from the garden dataset, where they may not apply.
 # Item codes in faostat_rl with USSR data (hence affected by this issue in their OWID region aggregates).
@@ -54,7 +55,9 @@ USSR_BREAKUP_DESCRIPTION_KEY = (
 USSR_BREAKUP_ENTITY_ANNOTATIONS = "\n".join(
     [
         "Europe: Break in 1992: the USSR's successors are split between Europe and Asia",
+        "Europe (FAO): Break in 1992: the USSR's successors are split between Europe and Asia",
         "Asia: Break in 1992: the USSR's successors are split between Europe and Asia",
+        "Asia (FAO): Break in 1992: the USSR's successors are split between Europe and Asia",
         "High-income countries: Break in 1992: the USSR's successors are split across income groups",
         "Upper-middle-income countries: Break in 1992: the USSR's successors are split across income groups",
         "Lower-middle-income countries: Break in 1992: the USSR's successors are split across income groups",


### PR DESCRIPTION
> _Written by Claude Opus 5 — @pabloarosado at the wheel._

Follow-up to [📊 Annotate 1992 USSR-breakup jumps in FAOSTAT land use region aggregates](https://github.com/owid/etl/pull/6670).

That PR annotated OWID's `Europe` and `Asia` aggregates, but FAOSTAT also publishes its own continental aggregates, and `Europe (FAO)` / `Asia (FAO)` break between 1991 and 1992 in exactly the same way and by the same amount:

| Entity | Land area 1991 (Mha) | Land area 1992 (Mha) | Change |
|---|---|---|---|
| Europe | 2,666.5 | 2,211.4 | -455.1 |
| Europe (FAO) | 2,668.9 | 2,213.8 | -455.1 |
| Asia | 2,692.3 | 3,103.1 | +410.8 |
| Asia (FAO) | 2,693.2 | 3,104.0 | +410.8 |

They now get the same annotation text. Verified across the other affected items too (cropland, forest land): the FAO twin always moves by the same absolute amount as the OWID region.

The `faostat_metadata.py` trailer comment is tweaked because a change confined to the grapher `shared.py` maps to no step in `--modified` selection, so staging would not otherwise re-upsert the `faostat_rl` indicators.

## Still open

Scanning every entity for a 1991 -> 1992 jump turns up more affected aggregates that remain un-annotated, all for the same reason: `Eastern Europe (FAO)`, `Northern Europe (FAO)`, `Western Asia (FAO)`, `Central Asia (FAO)` (no data before 1992), `Land Locked Developing Countries (FAO)`, `Low Income Food Deficit Countries (FAO)` and `European Union (27)`. They would need different wording, so they are deliberately left out of this PR pending a decision on whether to cover FAO subregions at all.

The "What you should know" text still lists only the OWID aggregates by name. Left unchanged on the grounds that `Europe (FAO)`-style names read as jargon in reader-facing prose.

No chart currently pins `Europe (FAO)` or `Asia (FAO)` on a `faostat_rl` indicator, so the annotation surfaces only when a reader adds those entities via the entity picker.