### PR TITLE
✨ owidbot: report a killed SVG tester run as killed

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 from pathlib import Path
 
@@ -12,6 +13,9 @@ SVG_TESTER_SUITES = ("graphers", "grapher-views", "mdims", "thumbnails")
 
 # Written by devTools/svgTester/verify-graphs.ts, one per suite
 VERIFY_RESULTS_FILENAME = "verify-results.json"
+
+# Mirrors SVG_TESTER_HEARTBEAT_STALE_MS in owid-grapher
+HEARTBEAT_STALE_SECONDS = 90
 
 
 def run(branch: str, head_sha: str | None = None) -> str:
@@ -89,10 +93,15 @@ def make_freshness_note(results_by_suite: dict[str, dict | None], head_sha: str 
     if not head_sha:
         return ""
 
-    commits = {results.get("grapherCommit") for results in results_by_suite.values() if results}
+    # An unreadable file carries no commit
+    readable = [results for results in results_by_suite.values() if results and results.get("status") != "unreadable"]
+
+    commits = {results.get("grapherCommit") for results in readable}
+    if not commits:
+        return ""
 
     if commits == {head_sha}:
-        if any(results.get("status") == "running" for results in results_by_suite.values() if results):
+        if any(results.get("status") == "running" and not is_stalled(results) for results in readable):
             return f"_⏳ Still running on the current commit `{head_sha[:7]}`._"
         return f"_Results are for the current commit `{head_sha[:7]}`._"
 
@@ -110,15 +119,20 @@ def make_suite_line(results: dict | None, container_name: str, suite: str) -> st
     if status == "unreadable":
         return "⚠️ no result (results file unreadable)"
 
-    if status == "running":
-        # verify-graphs.ts writes this before its first render and overwrites it at the end
-        return "_running_ (or killed mid-run)"
-
     counts = results.get("counts", {})
+    report = f" ([report]({make_report_url(container_name, suite=suite)}))"
+
+    if status == "running":
+        # verify-graphs.ts writes this before its first render and rewrites it every few
+        # seconds after. owidbot only reads the file once the SVG tester step is over, so
+        # a heartbeat that stopped means the run was killed
+        label = "⚠️ stopped mid-run" if is_stalled(results) else "⏳ running"
+        return f"{label}, {describe_progress(counts)}{report}"
+
     num_differences = counts.get("differences", 0)
     num_errors = counts.get("errors", 0)
 
-    if not num_differences and not num_errors:
+    if status == "ok":
         return "✅ no differences"
 
     notes = []
@@ -127,7 +141,32 @@ def make_suite_line(results: dict | None, container_name: str, suite: str) -> st
     if num_errors:
         notes.append(f"⚠️ {num_errors} error{'s' if num_errors != 1 else ''}")
 
-    return f"{', '.join(notes)} ([report]({make_report_url(container_name, suite=suite)}))"
+    return f"{', '.join(notes)}{report}"
+
+
+def is_stalled(results: dict) -> bool:
+    """Whether a running suite's heartbeat has stopped, meaning the run itself has."""
+    updated_at = results.get("updatedAt")
+    try:
+        heartbeat = dt.datetime.fromisoformat(updated_at)
+    except (TypeError, ValueError):
+        return True
+
+    return (dt.datetime.now(dt.timezone.utc) - heartbeat).total_seconds() > HEARTBEAT_STALE_SECONDS
+
+
+def describe_progress(counts: dict) -> str:
+    """How far a run that hasn't reported yet has got."""
+    total = counts.get("total", 0)
+    num_differences = counts.get("differences", 0)
+
+    # Until the run has enumerated its jobs, `total` is a zeroed placeholder.
+    if not total:
+        return "no charts checked yet"
+
+    done = counts.get("ok", 0) + num_differences + counts.get("errors", 0)
+    progress = f"{done:,} of {total:,} charts checked"
+    return f"{progress}, {num_differences:,} differences so far" if num_differences else progress
 
 
 def make_report_url(container_name: str, suite: str | None = None) -> str:

--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import time
 from pathlib import Path
 
 from structlog import get_logger
@@ -17,13 +18,16 @@ VERIFY_RESULTS_FILENAME = "verify-results.json"
 # Mirrors SVG_TESTER_HEARTBEAT_STALE_MS in owid-grapher
 HEARTBEAT_STALE_SECONDS = 90
 
+# Mirrors SVG_TESTER_PROGRESS_INTERVAL_MS in owid-grapher
+HEARTBEAT_POLL_SECONDS = 5
+
 
 def run(branch: str, head_sha: str | None = None) -> str:
     container_name = get_container_name(branch)
 
     svgs_repo = BASE_DIR.parent / "owid-grapher-svgs"
 
-    results_by_suite = {suite: read_verify_results(svgs_repo / suite) for suite in SVG_TESTER_SUITES}
+    results_by_suite = {suite: resolve_running(svgs_repo / suite) for suite in SVG_TESTER_SUITES}
 
     # The first owidbot run of a build happens before the SVG tester step, so no suite
     # has results yet and the per-suite block is left out.
@@ -89,7 +93,11 @@ def read_verify_results(suite_dir: Path) -> dict | None:
 
 
 def make_freshness_note(results_by_suite: dict[str, dict | None], head_sha: str | None) -> str:
-    """Whether the results above came from the PR's current commit."""
+    """Whether the results above came from the PR's current commit.
+
+    Expects statuses that resolve_running has already settled, so that `running` here
+    means a run that is actually alive rather than one that died mid-run.
+    """
     if not head_sha:
         return ""
 
@@ -101,7 +109,7 @@ def make_freshness_note(results_by_suite: dict[str, dict | None], head_sha: str 
         return ""
 
     if commits == {head_sha}:
-        if any(results.get("status") == "running" and not is_stalled(results) for results in readable):
+        if any(results.get("status") == "running" for results in readable):
             return f"_⏳ Still running on the current commit `{head_sha[:7]}`._"
         return f"_Results are for the current commit `{head_sha[:7]}`._"
 
@@ -122,11 +130,9 @@ def make_suite_line(results: dict | None, container_name: str, suite: str) -> st
     counts = results.get("counts", {})
     report = f" ([report]({make_report_url(container_name, suite=suite)}))"
 
-    if status == "running":
-        # verify-graphs.ts writes this before its first render and rewrites it every few
-        # seconds after. owidbot only reads the file once the SVG tester step is over, so
-        # a heartbeat that stopped means the run was killed
-        label = "⚠️ stopped mid-run" if is_stalled(results) else "⏳ running"
+    # `stalled` is resolve_running's verdict on a `running` file whose heartbeat stopped
+    if status in ("running", "stalled"):
+        label = "⏳ running" if status == "running" else "⚠️ stopped mid-run"
         return f"{label}, {describe_progress(counts)}{report}"
 
     num_differences = counts.get("differences", 0)
@@ -144,15 +150,74 @@ def make_suite_line(results: dict | None, container_name: str, suite: str) -> st
     return f"{', '.join(notes)}{report}"
 
 
-def is_stalled(results: dict) -> bool:
-    """Whether a running suite's heartbeat has stopped, meaning the run itself has."""
+def resolve_running(suite_dir: Path) -> dict | None:
+    """A suite's results, with a `running` status resolved to `running` or `stalled`.
+
+    A single read can't tell a live run from one killed a moment ago: both leave a recent
+    heartbeat behind. owidbot reads the file once per build step and never comes back, so
+    a wrong guess sits in the PR comment for good. A live run rewrites the file every few
+    seconds; a dead one never does, so wait for the next tick instead of guessing.
+    """
+    results = read_verify_results(suite_dir)
+    if not results or results.get("status") != "running":
+        return results
+
+    age = heartbeat_age(results)
+
+    # Nothing to wait for: a heartbeat we can't read belongs to a file written before
+    # heartbeats existed, and one already past the threshold is unambiguous. Both runs
+    # are long over.
+    if age is None or age > HEARTBEAT_STALE_SECONDS:
+        log.info("owidbot.svg_tester.stalled", suite=suite_dir.name, heartbeat_age=age)
+        return {**results, "status": "stalled"}
+
+    # Wait out the remainder of the threshold, so a heartbeat that was already 80s old
+    # costs 10s here rather than a fresh 90. A timestamp in the future - clock skew, or a
+    # garbage-but-parseable date - has a negative age that would otherwise *extend* the
+    # wait without bound, and neither owidbot buildkite step sets a timeout, so treat
+    # anything ahead of now as if it had just been written.
+    wait_for = HEARTBEAT_STALE_SECONDS - max(0.0, age)
+    log.info("owidbot.svg_tester.awaiting_heartbeat", suite=suite_dir.name, seconds=round(wait_for))
+    deadline = time.monotonic() + wait_for
+
+    while time.monotonic() < deadline:
+        time.sleep(HEARTBEAT_POLL_SECONDS)
+        latest = read_verify_results(suite_dir)
+
+        # Swept from under us by the next run's `git clean -fdx`. The run we were watching
+        # still died, and reporting that beats reporting the suite as never run: a None
+        # here would take the whole SVG tester block out of the comment.
+        if latest is None:
+            break
+
+        # A torn read tells us nothing either way - the writer renames into place, so this
+        # is near-impossible, but keep waiting rather than give up on the verdict.
+        if latest.get("status") == "unreadable":
+            continue
+
+        # It ticked, or it reported while we waited.
+        if latest.get("updatedAt") != results.get("updatedAt") or latest.get("status") != "running":
+            return latest
+
+    log.info("owidbot.svg_tester.stalled", suite=suite_dir.name, heartbeat_age=age)
+    return {**results, "status": "stalled"}
+
+
+def heartbeat_age(results: dict) -> float | None:
+    """Seconds since the run last rewrote its results, None when there's no reading it."""
     updated_at = results.get("updatedAt")
+    if not isinstance(updated_at, str):
+        return None
+
     try:
         heartbeat = dt.datetime.fromisoformat(updated_at)
-    except (TypeError, ValueError):
-        return True
+    except ValueError:
+        return None
 
-    return (dt.datetime.now(dt.timezone.utc) - heartbeat).total_seconds() > HEARTBEAT_STALE_SECONDS
+    if heartbeat.tzinfo is None:
+        heartbeat = heartbeat.replace(tzinfo=dt.timezone.utc)
+
+    return (dt.datetime.now(dt.timezone.utc) - heartbeat).total_seconds()
 
 
 def describe_progress(counts: dict) -> str:


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Follow-up to [owid/owid-grapher#6986](https://github.com/owid/owid-grapher/pull/6986), which made a running SVG tester suite rewrite `verify-results.json` every few seconds. owidbot reads that file but still only looks at `status`, `counts.differences`, `counts.errors` and `grapherCommit`, so none of the new information reaches the PR comment.

### A killed run is now reported as killed

A `running` status can mean two different things, and a single read can't tell them apart — a live run and one killed a moment ago both leave a recent heartbeat behind. Both actually occur, via the same step: the first owidbot invocation of a build (`ops/.buildkite/grapher/automated_staging_environment.yml:28`) has no `depends_on`, so it reads whatever the *previous* build left in the file — an alive run when two pushes land close together, a corpse when the previous build was cancelled or timed out.

So rather than guess from one snapshot, `resolve_running` watches for the next tick: a live run rewrites the file every 5 s, a dead one never does. It waits out the remainder of the 90 s staleness window, so a reported suite never waits at all, a live one resolves in about one interval, and only a killed run pays the full window. A dead suite is marked `stalled`, mirroring `SvgTesterDisplayStatus` on the grapher side.

| before | after |
|---|---|
| `_running_ (or killed mid-run)` | `⚠️ stopped mid-run, 1,204 of 3,910 charts checked, 12 differences so far ([report](…))` |
| `_running_ (or killed mid-run)` | `⏳ running, 1,204 of 3,910 charts checked, 12 differences so far ([report](…))` |
| `_running_ (or killed mid-run)` | `⚠️ stopped mid-run, no charts checked yet ([report](…))` |

The last is a run killed before it enumerated its jobs, when `counts` is still the zeroed placeholder `writeVerifyRunStarted` writes.

Two cases fall out for free: a suite that *reports* while we wait yields its real result rather than the placeholder, and a file swept by the next run's `git clean -fdx` still reports the run we were watching as stopped.

### An unreadable results file no longer marks everything stale

`read_verify_results` returns a `{"status": "unreadable"}` sentinel with no `grapherCommit`. `make_freshness_note` read `None` off it, which counted as "an unknown commit", so a single truncated file turned the note into *"⏳ Stale: from an unknown commit"* even when every real suite had run on HEAD. Unreadable suites are now excluded, and an all-unreadable set produces no note rather than `Stale: from ` with an empty list.

### `status` is authoritative

`✅ no differences` came from `not num_differences and not num_errors` rather than from the runner's `status` field, so the two surfaces could disagree about the same run. `summariseVerifyResults` already decides ok/differences/error (with error taking precedence, since a run that didn't complete can't claim to know what changed); owidbot reads that now.

### Worth knowing before review

- **The wait could be avoided entirely for the dominant kill path.** `run_test_suite` in `ops` survives the `timeout` kill and already inspects `$?` — it could stamp a terminal status into `verify-results.json` the way `writeVerifyRunFailure` does for pre-run failures, and then nothing here would need to poll. That's an ops + grapher change; this PR fixes the reader, which also covers the case where the agent itself dies.
- **`HEARTBEAT_STALE_SECONDS` and `HEARTBEAT_POLL_SECONDS` are hand-mirrored constants.** `SVG_TESTER_HEARTBEAT_STALE_MS`, `SVG_TESTER_PROGRESS_INTERVAL_MS`, `SVG_TESTER_SUITES` and the filename all live in `@ourworldindata/types`, and the Python side re-declares all of them. `/api/svgtester/suites.json` returns the computed status but sits behind admin auth, where reading files does not — worth a look separately.
- **No test file.** The polling loop is covered by a scratch script run locally (10 scenarios, below) rather than anything in `tests/apps/`.
- A run-level failure (`writeVerifyRunFailure`) still shows as a bare `⚠️ 1 error`, when the entry holds the actual cause and an empty `viewId`.
- `differences[]` carries `viewId`, `queryStr` and `chartType`, none of which is surfaced — the comment could list which charts moved, or break the count down by chart type with `?chartType=` links.
- The three permanent `_skipped_` lines are untouched.

### Checks

`make check` clean. The suite lines were rendered by calling `run()` with `read_verify_results` stubbed, across nine states (clean, differences, errors+differences, killed with and without a job count, live, full suite set, stale commit, unreadable-alongside-fresh).

`resolve_running` was exercised against a real directory with the constants shrunk to 3 s / 0.2 s, covering: a live run that keeps ticking, one killed with a fresh heartbeat, one killed with a stale heartbeat, a file with no heartbeat field, a run that reports mid-wait, a file swept mid-wait, an already-reported suite, a suite that never ran, a heartbeat dated in the future, and a timezone-naive timestamp. Not verified against a real staging server.