### PR TITLE
🔨🤖 Fix PyPI publish, and keep GitHub Action pins from going stale

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # Don't adopt a release the moment it appears: if an action's publishing
+    # account is compromised, the malicious version is usually yanked within
+    # days. Long enough to matter, short enough that pins still move.
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,16 @@
 # Other ecosystems are intentionally left out. Dependabot security updates
 # already cover pip and npm without any config, and blanket version updates
 # across this repo's dependency tree were removed in 2022 (c7d5ad0c0d) for
-# being too noisy. Grouping every action into a single monthly PR keeps this
-# to roughly one review a month.
+# being too noisy. Grouping every action into a single PR keeps the volume
+# low regardless of interval — there are only ~10 actions here, and they
+# release a couple of times a month between them.
+#
+# Weekly rather than monthly, because for actions these version updates are
+# also the de facto *security* mechanism. Dependabot's real security updates
+# ignore this schedule and fire on advisory publication, but actions almost
+# never get advisories, so nothing else will ever move these pins. Combined
+# with the cooldown below, weekly caps worst-case adoption of a fix at about
+# two weeks; monthly would have stretched it past five.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -24,7 +32,7 @@ updates:
     # would each need their own entry — there are none today.
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
     # Don't adopt a release the moment it appears: if an action's publishing
     # account is compromised, the malicious version is usually yanked within
     # days. Long enough to matter, short enough that pins still move.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot version updates.
+#
+# Deliberately scoped to GitHub Actions only.
+#
+# Actions must be pinned to immutable commit SHAs (see
+# .github/instructions/github-actions.instructions.md). Pinning is a
+# supply-chain control we want to keep, but it freezes each action until
+# somebody bumps it by hand — and actions almost never receive security
+# advisories, so Dependabot's *security* updates (which run without any config)
+# never touch them. Without the version updates below, a pin is never updated
+# at all, and eventually a stale one breaks a workflow: hatchling 1.32.0 began
+# emitting `Metadata-Version: 2.5`, which the twine bundled in a long-frozen
+# pypa/gh-action-pypi-publish pin refused to parse, breaking the PyPI release.
+#
+# Other ecosystems are intentionally left out. Dependabot security updates
+# already cover pip and npm without any config, and blanket version updates
+# across this repo's dependency tree were removed in 2022 (c7d5ad0c0d) for
+# being too noisy. Grouping every action into a single monthly PR keeps this
+# to roughly one review a month.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    # "/" covers .github/workflows. Composite actions under .github/actions
+    # would each need their own entry — there are none today.
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "⬆️"

--- a/.github/workflows/publish-owid-packages.yml
+++ b/.github/workflows/publish-owid-packages.yml
@@ -121,7 +121,12 @@ jobs:
         rm -rf dist
         uv build
 
+    # Published with uv rather than pypa/gh-action-pypi-publish so the release
+    # path carries no third-party action (and no twine frozen inside one).
+    # Authentication is still PyPI trusted publishing over OIDC, using the
+    # id-token permission and the `pypi` environment declared on this job, so
+    # the existing publisher configuration on PyPI applies unchanged.
     - name: Publish ${{ matrix.name }} to PyPI
-      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
-      with:
-        packages-dir: ${{ matrix.path }}/dist
+      run: |
+        cd ${{ matrix.path }}
+        uv publish --trusted-publishing always

--- a/.github/workflows/publish-owid-packages.yml
+++ b/.github/workflows/publish-owid-packages.yml
@@ -122,6 +122,6 @@ jobs:
         uv build
 
     - name: Publish ${{ matrix.name }} to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         packages-dir: ${{ matrix.path }}/dist


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Fixes the failed `owid-datautils` 0.6.9 release ([run](https://github.com/owid/etl/actions/runs/32005753555/job/95314808261)), then removes the reason it could happen.

```
Checking lib/datautils/dist/owid_datautils-0.6.9-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## What broke

hatchling 1.32.0 (released 2026-08-11) began emitting `Metadata-Version: 2.5`. Our `lib/*/pyproject.toml` declare an unpinned `requires = ["hatchling"]`, so CI builds with the latest. The pinned `pypa/gh-action-pypi-publish` v1.14.0 bundles twine 6.1.0 + packaging 25.0, which don't know metadata 2.5 and fail at `twine check` before the upload is attempted.

Nothing about the dependency bumps in #6683 caused this — that PR was just the first `lib/*/pyproject.toml` version bump since hatchling 1.32.0 landed. The break needed a frozen publisher *and* a floating build backend; either one alone would have been fine.

## Changes

**1. Bump the action to v1.14.2** (twine 7.0.0 + packaging 26.2) — the minimal fix, kept as its own commit so it stays available if we ever want to fall back to the action.

**2. Add `.github/dependabot.yml` for the `github-actions` ecosystem.** This is the actual root cause: the repo enforces SHA pinning (`.github/zizmor.yml` sets `"*": hash-pin`) but has no version-update config, and actions almost never receive security advisories — so Dependabot's *security* updates, the only kind running here, never touch them. Every action pin was frozen indefinitely:

| Action | Pinned | Latest |
|---|---|---|
| `astral-sh/setup-uv` | v8.2.0 | v10.0.1 |
| `actions/checkout` | v6.0.3 | v7.0.1 |
| `actions/setup-python` | v6.2.0 | v7.0.0 |
| `actions/stale` | v10.3.0 | v11.0.0 |
| `zizmorcore/zizmor-action` | v0.5.6 | v0.6.2 |

Five of ten were behind, most by a major version; `gh-action-pypi-publish` was the sixth and the only one whose staleness became load-bearing. Grouped into a single PR, checked weekly. A 7-day cooldown (required by zizmor's `dependabot-cooldown` audit) keeps us from adopting a release the instant it appears, leaving time for a compromised one to be yanked. Other ecosystems are deliberately left out — security updates already cover pip and npm without config, and blanket version updates were removed in 2022 (`c7d5ad0c0d`) for being too noisy. That removal was a *pip, weekly, ungrouped* config, so this doesn't reverse it.

**3. Publish with `uv publish` instead of the action**, dropping a third-party action — and a twine frozen inside it — from the release path entirely.

## Verification

- Built `lib/datautils` locally and confirmed the wheel carries `Metadata-Version: 2.5`; `twine check` fails on 6.1.0 and passes on 7.0.0
- Diffed the action's `requirements/runtime.txt` across tags to confirm the pin change (`twine==6.1.0`/`packaging==25.0` → `twine==7.0.0`/`packaging==26.2`)
- PyPI accepts metadata 2.5 — hatchling 1.32.0's own published wheel uses it
- Authentication is unchanged by change 3: the last successful run (`30496926603`) shows OIDC trusted publishing with no token, and this PR keeps the same workflow filename, `pypi` environment and `id-token: write` permission, so the existing PyPI publisher config applies as-is
- `uv publish` uploads PEP 740 attestations by default (`--no-attestations` is the opt-out), so the provenance the action generated is preserved
- Confirmed `uv publish` defaults to `dist/*` relative to cwd, matching the `cd` the build step already does
- zizmor passes locally on both changed files, and all CI checks are green — including GitHub's own validation of `.github/dependabot.yml`

## Still open

- **`owid-datautils` 0.6.9 is not on PyPI.** The build succeeded but the upload never ran, and this PR doesn't touch a `lib/*/pyproject.toml`, so the push trigger won't fire. After merge someone needs to run *Publish OWID packages to PyPI* via `workflow_dispatch` with `package: datautils`. Nothing in the repo is broken meanwhile — `uv.lock` resolves datautils from the local path, not PyPI.
- **Change 3 is unproven end-to-end.** No `uv publish` has run against PyPI from this workflow yet; the OIDC exchange is verified only by reasoning from the previous run's config. The `workflow_dispatch` above is the first real test, and a failure there is recoverable by reverting to commit `95aca95` (the bumped action).
- `pinact` isn't installed on this machine, so the v1.14.2 SHA was resolved by hand via the GitHub API (annotated tag → commit `dc37677`) rather than by `pinact run`. Moot if change 3 stands, since the action reference is gone.
- `lib/*` still declare `requires = ["hatchling"]` unpinned. Left alone on purpose: Dependabot doesn't manage `build-system.requires`, so pinning it would create a hand-tended pin with no automation behind it — the same failure mode this PR is removing.
- `actions/setup-python` is probably now redundant (uv provisions its own Python), but removing it changes how the wheel is built, so it's out of scope here.
