### PR TITLE
🐛 Fix next expected update for population and UN WPP datasets

### DIFF
--- a/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.meta.yml
@@ -11,7 +11,9 @@ definitions:
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
-  update_period_days: 740
+  # The UN postponed the next World Population Prospects revision from 2026 to 2027; WPP releases
+  # land on World Population Day (July 11). 2024-07-12 + 1095 days -> 2027-07-12.
+  update_period_days: 1095
   title: Historical World Population Prospects
 
 

--- a/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
@@ -252,7 +252,9 @@ tables:
 
 dataset:
   title: Population
-  update_period_days: 730
+  # The UN postponed the next World Population Prospects revision from 2026 to 2027; WPP releases
+  # land on World Population Day (July 11). 2024-07-15 + 1095 days -> 2027-07-15.
+  update_period_days: 1095
   description: |-
     Our World in Data builds and maintains a long-run dataset on population by country, region, and for the world, based on various sources.
 

--- a/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
@@ -252,9 +252,10 @@ tables:
 
 dataset:
   title: Population
-  # The UN postponed the next World Population Prospects revision from 2026 to 2027; WPP releases
-  # land on World Population Day (July 11). 2024-07-15 + 1095 days -> 2027-07-15.
-  update_period_days: 1095
+  # This is OWID's own update cadence for the OMM, not the producers'. The next revision of the
+  # underlying UN WPP is not due until July 2027, but we plan to rebuild this dataset before then.
+  # 2024-07-15 + 883 days -> 2026-12-15.
+  update_period_days: 883
   description: |-
     Our World in Data builds and maintains a long-run dataset on population by country, region, and for the world, based on various sources.
 

--- a/etl/steps/data/garden/un/2024-03-14/un_wpp_most.meta.yml
+++ b/etl/steps/data/garden/un/2024-03-14/un_wpp_most.meta.yml
@@ -8,6 +8,10 @@ definitions:
 
 dataset:
   title: Most populous age groups (UN WPP)
+  # Pinned rather than inherited from un_wpp: inheriting its period would apply it to this step's
+  # own (earlier) version date and land on March 2027, before the next WPP revision even exists.
+  # 2024-03-14 + 1215 days -> 2027-07-12.
+  update_period_days: 1215
 
   owners:
     - Fiona Spooner

--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
@@ -1,4 +1,7 @@
 dataset:
+  # The UN postponed the next World Population Prospects revision from 2026 to 2027; WPP releases
+  # land on World Population Day (July 11). 2024-07-12 + 1095 days -> 2027-07-12.
+  update_period_days: 1095
   owners:
     - Lucas Rodés-Guirao
     - Fiona Spooner

--- a/etl/steps/data/garden/un/2024-10-01/births_by_age.meta.yml
+++ b/etl/steps/data/garden/un/2024-10-01/births_by_age.meta.yml
@@ -7,6 +7,10 @@ definitions:
 
 dataset:
   title: Births by age of mother (UN WPP)
+  # Pinned rather than inherited from un_wpp: inheriting its period would apply it to this step's
+  # own (later) version date and land on October 2027, months after the next WPP revision.
+  # 2024-10-01 + 1014 days -> 2027-07-12.
+  update_period_days: 1014
 
 # this metadata file is not used in garden step, but in grapher step
   owners:


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

`update_period_days` had already elapsed on both population datasets, so grapher fell back to `today + 1 month` ([`metadataHelpers.ts:111`](https://github.com/owid/owid-grapher/blob/master/packages/%40ourworldindata/utils/src/metadataHelpers.ts#L111)) and the population chart advertised a next update of "September 2026" that drifted forward every day.

| Dataset | Charts | Before | After |
|---|---|---|---|
| `garden/demography/2024-07-15/population` | 307 | 730 → Sep 2026 (drifting) | **883 → Dec 2026** |
| `garden/un/2024-07-12/un_wpp` (+ `un_wpp_full`) | 91 | unset → nothing shown | **1095 → Jul 2027** |
| `garden/demography/2024-07-12/un_wpp_historical` | 1 | 740 → Sep 2026 (drifting) | **1095 → Jul 2027** |
| `garden/un/2024-03-14/un_wpp_most` | 1 | unset → nothing shown | **1215 → Jul 2027** |
| `garden/un/2024-10-01/births_by_age` | 1 | unset → nothing shown | **1014 → Jul 2027** |

The UN [postponed](https://www.un.org/development/desa/pd/sites/www.un.org.development.desa.pd/files/undesa_pd_2026_cpd59_e_cn.9_2026_crp.1.pdf) the next World Population Prospects revision from 2026 to 2027. The population OMM instead follows OWID's own rebuild cadence.

The last two set no period of their own and would otherwise inherit `un_wpp`'s via `combine_tables_update_period_days`, which applies it to *their* version dates — landing on Mar 2027 and Oct 2027. They're pinned instead. `garden/demography/2024-07-18/population_doubling_times` still inherits (Dec 2026, 0 charts), which is correct for it.

| | |
|---|---|
| Population chart | [prod](https://ourworldindata.org/grapher/population) · [staging](http://staging-site-fix-next-update-expected-un/grapher/population) |
| Population growth | [prod](https://ourworldindata.org/grapher/population-growth-rate) · [staging](http://staging-site-fix-next-update-expected-un/grapher/population-growth-rate) |
| Population density | [prod](https://ourworldindata.org/grapher/population-density) · [staging](http://staging-site-fix-next-update-expected-un/grapher/population-density) |
| Fertility rate (UN WPP) | [prod](https://ourworldindata.org/grapher/children-per-woman-un) · [staging](http://staging-site-fix-next-update-expected-un/grapher/children-per-woman-un) |

Metadata-only, same version folders throughout — no new variable IDs, no ghost-variable remapping.

The `faostat_qcl`, `migrant_stock` and `child_migration` entries in data-diff are unrelated drift between master and the published catalog (from #6486 and #6143), not from this branch.
