### PR TITLE
🐛 Fix master deploy: end_with_punctuation crashes on missing producer text

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -207,8 +207,12 @@ def end_with_punctuation(text: str | None) -> str | None:
 
     A closing quote or bracket after the punctuation counts as ending with it, so
     `… agree with?"` and `… (per 100,000 people).` are both left alone.
+
+    Text taken straight out of a table column can be a pandas missing value rather
+    than `None` (`pd.NA` raises on `bool()`), so anything that isn't a string is
+    handed back untouched.
     """
-    if not text:
+    if not isinstance(text, str) or not text:
         return text
     stripped = text.rstrip()
     if not stripped:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,15 @@
 from unittest.mock import patch
 
+import numpy as np
+import pandas as pd
+import pytest
 from owid import catalog
 
 from etl import paths
 from etl.helpers import (
     PathFinder,
     create_dataset,
+    end_with_punctuation,
 )
 
 
@@ -87,3 +91,27 @@ def test_PathFinder_with_private_steps():
     }
     assert pf.step == "data-private://garden/namespace/2023/name"
     assert pf.get_dependency_step_name("name") == "snapshot-private://namespace/2023/name"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Share of adults with an account", "Share of adults with an account."),
+        ("Share of adults with an account.", "Share of adults with an account."),
+        ("Which of these do you agree with?", "Which of these do you agree with?"),
+        ('... do you agree with?"', '... do you agree with?"'),
+        ("Deaths (per 100,000 people).", "Deaths (per 100,000 people)."),
+        ("Trailing space is kept as is ", "Trailing space is kept as is."),
+        ("", ""),
+        ("   ", "   "),
+        (None, None),
+    ],
+)
+def test_end_with_punctuation(text, expected):
+    assert end_with_punctuation(text) == expected
+
+
+@pytest.mark.parametrize("missing", [pd.NA, np.nan, pd.NaT])
+def test_end_with_punctuation_missing_values(missing):
+    # producer text read out of a table column is a pandas missing value, not None
+    assert end_with_punctuation(missing) is missing


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The master deploy has been failing since #6688 ([build 11157](https://buildkite.com/our-world-in-data/etl-deploy-master/builds/11157)):

```
File "etl/steps/data/garden/wb/2025-05-21/findex.py", line 77, in add_metadata
  meta.description_short = end_with_punctuation(short_definition.iloc[0])
File "etl/helpers.py", line 211, in end_with_punctuation
  if not text:
TypeError: boolean value of NA is ambiguous
```

`findex` reads `description_short` straight out of a table column, and 8 of its indicators have no short definition at all — the column is categorical, so those come back as `pd.NA`, whose `__bool__` raises. Wrapping the value in `end_with_punctuation` turned a value that used to pass through into a crash, which also blocked chart sync, the data-catalog publish and the LFS update behind it.

`end_with_punctuation` now hands back anything that isn't a string untouched, which is exactly what the step did before the helper was introduced. The same applies to the two `un_sdg` call sites the helper picked up in #6688.

Verified against the published meadow table: the 8 indicators have `short_definition` missing on *every* row, not just the first one `.iloc[0]` happens to pick, so passing `NA` through is the right behaviour rather than a picking bug to work around. Unit tests added for the helper — it had none.

## Still open

- Only the crash is fixed. The 8 indicators keep publishing an empty `description_short`, as they did before #6688; whether they deserve one is a data question for whoever owns findex.
- I did not re-run the garden step end to end locally (no local data for it) — the fix is covered by unit tests plus the real meadow column, and the master deploy re-run is the real check.
