### PR TITLE
🐛 Fix the create-dataset skill's unparseable frontmatter

### DIFF
--- a/.claude/skills/create-dataset/SKILL.md
+++ b/.claude/skills/create-dataset/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: create-dataset
-description: Create a brand-new OWID dataset in ETL from a data file the user provides — a local CSV/Excel, a downloaded file, or a web link to data (snapshot → meadow → garden → grapher → PR → staging server). Use when someone has data they want in ETL so they can build charts. Designed for non-technical "Cloud co-work" users: infer aggressively, build a working dataset first, then ask the person to review and correct.
+description: >-
+  Create a brand-new OWID dataset in ETL from a data file the user provides — a local
+  CSV/Excel, a downloaded file, or a web link to data (snapshot → meadow → garden →
+  grapher → PR → staging server). Use when someone has data they want in ETL so they can
+  build charts. Designed for non-technical "Cloud co-work" users: infer aggressively,
+  build a working dataset first, then ask the person to review and correct.
 metadata:
   internal: true
 ---


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

`.claude/skills/create-dataset/SKILL.md` has a frontmatter block that no standard YAML parser accepts.

The description is a plain scalar containing:

```
Designed for non-technical "Cloud co-work" users: infer aggressively, ...
```

That `: ` reads as a mapping key inside a plain scalar, so the parser fails with `mapping values are not allowed here` — and it fails on the **whole block**, not just that one line. `name`, `description` and `metadata.internal` are all lost together.

Claude Code's own loader is lenient enough that the skill still resolves from the terminal today, which is why this went unnoticed. But `metadata.internal: true` exists specifically to keep the skill out of external skill indexes, and an indexer reading the file with a standard YAML parser is exactly the consumer that gets nothing back.

The fix is a folded block scalar, which is what the neighbouring skills already use — inside one, `:` and `#` are literal and need no escaping. **The description text is unchanged byte for byte** (verified by parsing the result and comparing against the original string).

### Checks

- All 44 skills under `.claude/skills/` re-scanned: frontmatter parses everywhere, and every one yields a `name` and a `description`. This was the only failure.
- Also swept for the neighbouring hazard — a plain-scalar description containing an unescaped ` #`, which silently *truncates* the value at that point rather than failing loudly. No instances.
- `make check` clean.

### Background

Found while reviewing #6691, which hit the truncating variant of the same problem in a different skill and fixed it there. This one is older and unrelated to that branch, so it is split out rather than folded in.