### PR TITLE
📜🤖 Warn when a GDP-scatter migration loses the log axis or an exclusion

### DIFF
--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -170,6 +170,18 @@ timeline. Requiring the same year graded it a benign `no data` and dropped it ou
 altogether. The value is then read back at that same tolerance, since the observation itself may
 sit a year or two off the timeline year it was found under.
 
+The candidates for that year are **every year the two variables cover**, not just the entity's own
+observation years, because the year that pairs them can be one where the entity has neither: y in
+2000 and GDP in 2002 at tolerance 1 meet at **2001**, a year on the timeline because other entities
+have data there and a year the reader reaches by dragging the handle. Searching only the entity's
+own years missed it and sent the entity back as a benign `no data`.
+
+`no data` is also checked **before** the `OWID_` code, so an excluded aggregate that has no
+pairable year is `no data` rather than `aggregate`. The `aggregate` note claims the entity "renders
+as one point among the countries"; an entity with no pair renders nowhere, since
+`matchingEntitiesOnly` hides it. Testing the code first raised a warning — and a `RECONSIDER` row —
+on the strength of a sentence that was not true of that entity.
+
 (2026-08-19, production: of 22 published GDP scatters carrying `excludedEntityNames`, 8 exclude
 `World` or another OWID aggregate — the single commonest case, which is why `aggregate` is its
 own class, detected by the `OWID_` prefix on `entityCode` rather than by a name list. Charts 1131

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -406,6 +406,13 @@ embed, and a raw pasted `/grapher/…` URL. The last is stored as `linkType='url
 also unwraps Google redirect wrappers and skips archived hosts. Since the carrier count is the
 link/embed split rather than the aggregate `postsGdocs`, a raw-URL reference left out of both
 would be counted nowhere at all.
+
+**A reference sweep that fails blocks `--apply`.** `gdoc_references` is unguarded, so it fails
+closed on its own; the raw-URL sweep is guarded only so that a read-only audit still prints what it
+did gather, and under `--apply` it `REFUSED`s with a non-zero exit instead. An incomplete references
+audit must never authorise the unpublish — that is the same principle that turns a `MANUAL` row into
+`BLOCKED`, applied to the case where the count is missing rather than alarming. There is
+deliberately no waiver flag: retry the sweep, do not wave it through.
 - **NOTHING carries it** — an **exclusion** loss. The target never re-applies exclusions, so no
   href, on any surface, brings the entity back off the scatter. An exclusion-only row therefore
   reports no "fixable by hand" count at all; the only question it poses is whether the chart

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -97,11 +97,65 @@ That second case is what **Part 2's redirect produces**, so a reader arriving by
 7. Emits warnings (no action) for:
    - Target has no `selectedEntityNames` — line/bar/slope views will fall back to Grapher defaults.
    - Target `stackMode: relative` — on scatter this is the "Display average annual change" mode; we want the toggle available but **off by default**, so a relative default is flagged for review.
-   - Source `excludedEntityNames` — would apply across all views, not just scatter.
+   - Source `excludedEntityNames` — never applied to the target (they would hide the entity from all views, not just the scatter), so each one **reappears** on the migrated scatter. Graded per entity by `classify_exclusions` into `y-OUTLIER` / `aggregate` / `unclear` / `ungradeable` (a decision is needed) vs `high-GDP` / `no data` (benign), with the numbers in the **EXCLUDED ENTITIES** table. Only the first group makes the note a `WARN`.
+   - Source y axis is **log** — the target's scatter tab opens linear, and only a URL carrying `yScale=log` restores it. See "A log y axis and an exclusion list are the two things the migration cannot carry".
    - GDP coverage mismatch — if y-indicator's earliest year predates the chosen GDP's coverage (WDI≈1990, PWT≈1950, Maddison≈year 1), suggest a deeper-history alternative.
    - Few entities on default scatter view — counts entities with both a y- and an x-value within tolerance at the default time; if fewer than ~15 AND source uses higher tolerance, recommends bumping target's y `display.tolerance`.
 
 Push uses `apps.chart_sync.admin_api.AdminAPI.update_chart(id, cfg)`.
+
+### A log y axis and an exclusion list are the two things the migration cannot carry
+
+Everything else on the source is either mirrored onto the target or left behind for a reason that
+holds. These two are different — they are *lost*, and the only channel that gives either back is
+a query string:
+
+- **A log y axis** stays behind because `yAxis` is global (step 5). Part 2's redirect and a
+  hand-updated article link carry `yScale=log`; a reader who **clicks** the scatter tab does not,
+  and neither does any surface that has no URL of its own.
+- **`excludedEntityNames`** is never applied to the target (exclusions are global too, so they
+  would hide the entity from its line/bar/map views), so every excluded entity **reappears** on
+  the migrated scatter. Nothing, anywhere, puts it back.
+
+The surfaces with no query string are what decide whether the retirement is worth doing, and
+there are three:
+
+- a **key-chart slot** has nowhere to put one — `GdocPost.loadRelatedCharts` selects only
+  `chartId, slug, title, variantName, keyChartLevel`, and `RelatedCharts` renders
+  `<GrapherWithFallback slug={activeChartSlug}>`;
+- a gdoc **embed** resolves the chart itself and renders its default tab
+  (`makeGrapherLinkedChart` builds no query string);
+- a **featured metric** is worse still: it names a chart, an MDIM view or an explorer view and
+  never a chart's *tab*, so the scatter view cannot be featured at all (see "Featured metrics").
+
+On a featured or embedded source, a log axis is therefore gone for good and no amount of
+re-pointing recovers it. That is what makes "is this migration worth doing?" a real question
+rather than a formality, and why the answer depends on how the old chart is referenced.
+
+**Leaving the standalone chart alone is a legitimate outcome.** The skill reports the loss and
+the topic owner decides: the applier `WARN`s on a log source, the reviewer HTML asks the question
+with both shapes side by side, and Part 2's audit prints a `RECONSIDER` block weighing the loss
+against the blast radius. None of them blocks — see "RECONSIDER" in Part 2 for why not.
+
+Exclusions are **graded**, not listed, because the two usual reasons for one have opposite
+consequences here. The target's x axis is log, so a very high GDP per capita — the classic
+Ireland / Luxembourg / Qatar exclusion — costs almost nothing: on chart 6305, Ireland's $131,338
+against a pack topping out at $95,173 is **+0.14 of a decade** of extra axis width, i.e.
+invisible — though "benign" there is a claim about the *axis*, and the note says so: a very high
+GDP per capita can also be excluded because the figure itself is distorted (Ireland's profit
+shifting, a Gulf state's expat denominator), which a log axis does not fix. A y outlier is the
+opposite: on chart 5029, Australia's 3,243 ha average farm size
+against a pack of 0.35–582.5 **stretches the y axis 5.6x**, and `yAxis.max` is global so the
+scatter cannot cap it alone. That is why `grade_exclusion` measures each axis in the units it is
+drawn in rather than testing for statistical outlierness — a symmetric IQR fence gets skewed
+indicators badly wrong (chart 1131: Cape Verde's 40.3 kg/ha cereal yield sits well inside a
+±3·IQR fence while being **14.3x below the lowest** of the other 88 countries).
+
+(2026-08-19, production: of 22 published GDP scatters carrying `excludedEntityNames`, 8 exclude
+`World` or another OWID aggregate — the single commonest case, which is why `aggregate` is its
+own class, detected by the `OWID_` prefix on `entityCode` rather than by a name list. Charts 1131
+and 5029, both of which exclude a genuine y outlier, are **also key charts** on their topic pages
+— the compound case where the loss lands where no query string reaches.)
 
 ## Run this as a checklist in the chat
 
@@ -123,7 +177,7 @@ The canonical items, in order:
 10. **Confirm the scatter views actually reached production.** A merged PR is not evidence that they did: chart-sync only carries chart edits whose diffs were **approved** in Chart Diff, so a PR can merge green with every row ✅ on staging and leave production untouched. An abandoned first attempt (PR #6173, merged 2026-06-24) left production untouched on all seven of its pairs — deliberately: the `target_query_param` needed for Part 2 did not exist yet, so it was dropped and the migration restarted from scratch rather than left half-done. Whatever the reason, check production directly rather than inferring it from the merge.
 11. **Reference sweep on the old charts** — `find-chart-references` over each source slug *and its aliases*, then `scripts/build_reference_handoff.py` to turn it into the handoff (it keeps the sweep's 📄 doc / 👁 preview / 🔗 page links and its "Find in the doc" search string — see below). Re-point embeds and links at the target's scatter view **before** retiring anything: an embed is never fixed by a redirect, and a link that works only via a 301 outlives everyone's memory of why. **Do not skip this because the Part 2 audit reports few references** — it counts a narrower set; see the key-chart and featured-metric traps below. Settle the ⭐ featured-metric rows in the same pass: they are the only ones that cannot be repaired after the unpublish.
 12. Narrative charts on the sources: replace where the parent is being retired (create → re-point articles → delete; never delete first).
-13. **Part 2 audit** — `redirect_to_scatter.py` with no `--apply`. Read every verdict.
+13. **Part 2 audit** — `redirect_to_scatter.py` with no `--apply`. Read every verdict, **and resolve every `RECONSIDER` row with the topic owner before item 14**. That block is the one verdict here that does not block on its own (a lossy retirement is an editorial call, not a broken page), so it is the one that gets applied past if nobody answers it.
 14. Part 2 `--apply` on staging, then the browser checks in "Verifying Part 2".
 15. Part 2 `--apply --allow-production` once the scatter views are live on production, then the same checks against the live site.
 
@@ -152,12 +206,13 @@ Keep the list alive across turns: carry the untouched items forward rather than 
    echo '<JSON>' | .venv/bin/python .claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
    ```
 
-   Output: two stdout tables.
+   Output: three stdout tables.
 
    - **PER-ROW ACTIONS** — `chart`, `src`, `gdp_source`, `status`, `notes`. Statuses: `OK`, `SKIPPED` (e.g. stacked-family chart), `FAIL`, `ERR_PUT`, `ERROR`.
+   - **EXCLUDED ENTITIES** — one row per entity the source excluded, with its class and the measurement behind it. Printed only when some source has exclusions. The `notes` column is one joined line, so this is where the evidence for "this entity's return is a defect" lives.
    - **Y-DIM DISPLAY NAMES** — `chart`, `varId`, manual `display.name` (on chart), ETL `display.name` (from `variables.display`), catalog `variable.name`. Only populated for `OK` rows.
 
-4. **Show both tables to the user** verbatim (or formatted as markdown).
+4. **Show all three tables to the user** verbatim (or formatted as markdown).
 
 5. **Follow up on display names — and do it LAST.** Where a target ended up with a manual `display.name` but the ETL variable already defines a reasonable one (or `variable.name` is clean), use `AskUserQuestion` to let the user pick which manual overrides to drop. Then run a small inline Python block to delete the `name` key from `display` on each chosen chart (preserving `unit`/`shortUnit`/etc.), via the same `AdminAPI.update_chart` flow.
 
@@ -191,7 +246,8 @@ print(read_analytics(open('.claude/skills/add-gdp-scatter/scripts/find_targets.s
 ```
 
 It uses `/* */` comments deliberately: `read_analytics` flattens the SQL onto one line, where a `--` comment would swallow the rest of the query and fail with a misleading `Unexpected end of statement`. As of 2026-08-04 it returns 167 GDP scatters — 124 with a target, 43 without.
-- **Source has `excludedEntityNames`** → warning only. Exclusions on the target would also hide those entities from line/bar/map views, which is rarely intended.
+- **Source has `excludedEntityNames`** → warning only, and graded: exclusions on the target would also hide those entities from line/bar/map views, which is rarely intended, so each excluded entity comes back on the scatter and the skill says whether that matters.
+- **Source y axis is log** → warning only; the target keeps a linear default, because `yAxis` is global.
 - **GDP coverage mismatch** → warning only; the user picks per chart whether to switch sources.
 - **Sparse scatter view** → warning only; tolerance affects all views, not just scatter.
 
@@ -224,7 +280,9 @@ The right pane toggles (or press `v`) between the two states a URL can produce:
 
 The third state — after a reader *clicks* the scatter tab — no URL can reproduce (see "`adjustStateForTab` fires on a tab CLICK only"). Open the Default view and click the scatter tab **inside the frame**: it should match the Redirect view. That comparison is the practical check that the redirect's `time=`/`country=` params really stand in for the click, which is the one thing about Part 2 that has never been verified live. On a **log row the two differ by design** — the click leaves the target's linear `yAxis` alone while the redirect forces `log` — so the pane's own hint says so rather than letting a correct row read as a defect.
 
-Per-row flags are split so the "With warnings" filter stays worth using. **Warnings** are possible defects — no `ScatterPlot` tab, scatter as the primary type, `hideTimeline` with a time range, `stackMode: relative`, source `excludedEntityNames` that the target will not carry. **Context** is expected-but-needed-to-read-the-panes, e.g. that the target selects N entities which both routes should clear — so if you *do* see highlighting, one of the two mechanisms failed. Keep new checks on the right side of that line; a warning on every row is the same as no warnings.
+Per-row flags are split so the "With warnings" filter stays worth using. **Warnings** are possible defects — no `ScatterPlot` tab, scatter as the primary type, `hideTimeline` with a time range, `stackMode: relative`, an exclusion whose return actually changes the chart, and the log-axis question. **Context** is expected-but-needed-to-read-the-panes, e.g. that the target selects N entities which both routes should clear — so if you *do* see highlighting, one of the two mechanisms failed. Keep new checks on the right side of that line; a warning on every row is the same as no warnings.
+
+The two lossy checks are the reason that split has to be computed rather than assumed. A log source produces **both**: a context line (the two panes differ by design — see below) and a warning (whether a *linear* scatter still shows the relationship the author chose log for). That is a judgment nobody else in the workflow makes, and the reviewer is the only person looking at both shapes at once. Exclusions are graded by the applier's `classify_exclusions`, and the classes decide the box: `y-OUTLIER` / `aggregate` / `unclear` are warnings carrying their measurement, while a benign `high-GDP` or `no data` is context ("back on the scatter, but harmless"). Importing the applier's `EXCLUSION_WARN_CLASSES` rather than re-deriving the split is what keeps the reviewer saying the same thing the applier's run said.
 
 Decisions are fingerprinted on both configs' `fullMd5` plus the GDP variable id, so a re-run of the applier (which rewrites the target) invalidates stale approvals instead of silently keeping them.
 
@@ -281,10 +339,43 @@ All read-only, so the audit reports the verdict `--apply` will act on:
 
 `get_chart_references` counts (`wp/gdoc/expl/narr/ins/sviz`), flagging `MANUAL` when explorers / dataInsights / staticViz is non-zero — **a redirect alone does not fix those** (they embed the old chart's config directly). Those rows are turned into `BLOCKED` **before** the apply loop runs, so `--apply` cannot unpublish them: the loop gates purely on `status`, and leaving a MANUAL row at `CREATE` meant the audit flagged the breakage and then caused it anyway. Re-point the dependents, then re-run with `--allow-manual-refs`.
 
+Two columns come from outside `get_chart_references`, because it cannot see either:
+
+- **`keych`** — key-chart slots, from `chart_tags` directly (`key_chart_slots`). See "Key-chart slots" below.
+- **`lossy`** — whether the migrated scatter will look like the chart it replaces, from `source_lossiness` plus the applier's exclusion grading. Detailed in the `RECONSIDER` block, which also counts featured-metric slots (`featured_metric_slots`, via the sweep's own reader).
+
 Plus a table of **article references that need a hand edit**, from `posts_gdocs_links`:
 
 - an **embed** (any `componentType` that isn't `span-*`) resolves to the target chart but renders the target's **default tab** — `makeGrapherLinkedChart` builds its URL without a query string, so `tab=scatter` never reaches it;
 - a **link** carrying its own `tab=` or `time=` keeps those values, because the visitor's params override the stored ones.
+
+### RECONSIDER — when the answer is to not retire the chart at all
+
+A row is `RECONSIDER` when the retirement costs the reader something the redirect cannot give
+back: the source's **log y axis**, or an **exclusion whose return changes the chart** (the two
+losses in "A log y axis and an exclusion list are the two things the migration cannot carry").
+The block prints, per row, what is lost and where the loss lands — split by whether the fix can
+travel at all:
+
+- **fixable by hand** — article links and embeds, which can be re-pointed with the params.
+- **CANNOT carry the fix** — key-chart slots (no query string) and featured metrics (a chart's
+  tab cannot be featured at all). Named, not counted, so the topic owner can see whose pages
+  they are. Featured metrics are matched by `find_references.sweep_featured_metrics`, not a local
+  `LIKE`: the only handle a `featured_metrics` row carries is a URL, and `LIKE '%/grapher/foo%'`
+  cannot tell `foo` from `foo-bar`.
+
+**It is warn-only on purpose, and that is a deliberate departure from how `MANUAL` is handled.**
+A `MANUAL` reference is turned into `BLOCKED` because the unpublish would *break* an explorer or
+a data insight, and no editorial view changes that. A lossy retirement breaks nothing — the chart
+still renders, on a linear axis, with an extra dot on it — so whether it is acceptable is a
+judgment about the chart, not a fact about the database. Roughly a fifth of a batch is
+logarithmic (2026-08-14, batch 1: 3 of 14), so blocking those would mean a waiver flag on every
+run, and a flag passed every run stops being read. Hence: the verdict gets its own printed block
+**and** a `[RECONSIDER: …]` suffix on the row's note in the PLAN table, and checklist item 13
+requires each one to be answered before the apply — but `--apply` will not stop for it.
+
+The corollary is that a quiet block is informative: a batch with no `RECONSIDER` rows means every
+retirement in it is a faithful swap, which is worth saying in the report.
 
 ### Re-point every reference at the new scatter view
 
@@ -328,7 +419,7 @@ Those aids are the difference between a row someone can fix and a row that names
 - **Find in the doc** — a copy-paste search string: the **link text** for a prose hyperlink, or the **chart slug** for a block embed (the doc holds a bare grapher URL there, and `posts_gdocs_links.target` keeps the slug as the author typed it, so it still matches when the doc uses an older one). A long one is cut short but **stays literal** — no `…`, which is not a character in the document and would make the paste find nothing.
 - **Its params** — the query string the reference already carries. Both consumers follow the same rule: the **replacement URL** merges it over the proposed params with **the reference's values winning** — an editorial choice: an article that pinned a country or a year meant to, and a paste should not silently discard that — and the **redirect** merges the same way, key by key (see "A reference's own params override the redirect's, key by key" below). So the cell grades collisions only: ⚠️ names the proposed keys the reference overrides — a reference carrying `tab=chart` lands the reader on a different tab than the retirement intends, and that row needs a decision rather than a paste — while a non-colliding query merges in with the proposed view intact.
 
-**`yScale=log` when the retiring chart had a log y axis.** The applier never forces `yAxis.scaleType: log` on a target — `yAxis` is global, so it would flip the line/bar views too — it only enables the toggle and leaves the default **linear**. A source authored on a log y axis therefore becomes a *linear* scatter on the target, and its shape changes: the author chose log because that is the shape the relationship has. So the replacement link proposes `yScale=log` for exactly those rows, restoring it for that view alone, on the same principle as `time=latest` and `country=` — each stands in for something a URL-supplied tab does not get.
+**`yScale=log` when the retiring chart had a log y axis.** The applier never forces `yAxis.scaleType: log` on a target — `yAxis` is global, so it would flip the line/bar views too — it only enables the toggle and leaves the default **linear**. A source authored on a log y axis therefore becomes a *linear* scatter on the target, and its shape changes: the author chose log because that is the shape the relationship has. So the replacement link proposes `yScale=log` for exactly those rows, restoring it for that view alone, on the same principle as `time=latest` and `country=` — each stands in for something a URL-supplied tab does not get. That is the whole recovery channel, though: it only reaches surfaces that have a URL, which is why a log row is also a `RECONSIDER` row rather than a solved problem.
 
 Read the flag from the **source**, never the target: the target's `yAxis.scaleType` is deliberately left linear, so it cannot tell you what the retiring chart looked like. Because the param is per-row, the ⚠️ collision check is against *that row's* proposal rather than a shared constant — so a reference's own `yScale=linear` is an override on a log row and merely its own setting everywhere else. (2026-08-14, batch 1: 3 of 14 sources were log — 6045, 663, 3740 — and one article link on 663 already carried `yScale=linear`, which wins and is flagged.)
 
@@ -351,7 +442,7 @@ Consequences to carry into every report:
 - This describes the PRODUCTION 404→301 function. Two other layers behave differently, and both the same way: **staging's** serving layer and a fresh row's first-week static **302** (`_redirects`) each answer with the stored query and drop the visitor's params entirely (staging: batch-1 staging apply, 2026-08-14; the 302: verified on production right after the batch-1 apply, same day, held to this section's own standard — non-colliding `?foo=bar` and `?xScale=log` were dropped, which a stored-side-wins merge would have kept, and colliding `?country=~CHL` / `?tab=chart` landed on the stored query too, on a log and a plain row both). So for its first week a fresh redirect sends every arrival to the stored view; the per-key merge only starts once the 302 expires and the 301 function takes over. Neither layer can validate this section's merge claim.
 - Re-verify with a distinguishing pair (a query that *omits* a stored key) if grapher changes how chart redirects are baked or served. `functions/_common/redirectTools.ts`'s explorer path also merges per key but with the TARGET winning — a different code path; don't generalize from it in either direction.
 
-Both consumers get the log set from **`apply_scatter_defaults.log_y_axis_sources`**, which owns the reversed-source exclusion — do not re-derive it. A reversed source (GDP on its `y`) must be **excluded**: its `scaleType` describes the *GDP* axis, while the target's `y` is the non-GDP indicator, so proposing log there would make the wrong axis logarithmic. That is the same reason `process_row` skips its y-oriented mirrors for a reversed source, and getting it right in one script while forgetting it in another is exactly how this went wrong once.
+All three consumers get the log set from **`apply_scatter_defaults.log_y_axis_sources`**, which owns the reversed-source exclusion — do not re-derive it. It is now a one-line wrapper over **`source_lossiness`**, which reads the log flag and `excludedEntityNames` off the same single config query so Part 2 can grade a retirement without fetching every source config a second time; take the log set from the wrapper and the pair of losses from `source_lossiness`, never by re-reading `yAxis.scaleType` locally. A reversed source (GDP on its `y`) must be **excluded**: its `scaleType` describes the *GDP* axis, while the target's `y` is the non-GDP indicator, so proposing log there would make the wrong axis logarithmic. That is the same reason `process_row` skips its y-oriented mirrors for a reversed source, and getting it right in one script while forgetting it in another is exactly how this went wrong once.
 
 One limit remains: a reference that forces a **non-scatter** tab still receives the proposal, since the source's log was a global setting — but it is being applied to a view the author's choice was not about, so treat those rows as a judgment call.
 
@@ -363,17 +454,19 @@ They only apply to Google Doc surfaces, though — `doc_url` and `gdoc_preview_u
 
 The narrative-chart section is the one place a **placement** table appears: `gdoc (narrative chart)` rows, which name the articles that place each narrative chart by name. They are deliberately excluded from `GDOC_SURFACES` — the surface is a gdoc, but the row references the *narrative chart*, not the chart being retired, so counting it among the article embeds would overstate both. Nest them under their narrative chart instead, with the same Doc / previewer / page links and search string the embed and link tables get, since the article edit is a step of the replacement.
 
-### Key-chart slots — the Part 2 audit cannot see them
+### Key-chart slots — no query string reaches them
 
-`get_chart_references` counts `postsWordpress`, `postsGdocs`, `explorers`, `narrativeCharts`, `dataInsights` and `staticViz`. **Key charts are none of those** — a key chart is a chart↔tag association (`chart_tags.keyChartLevel`), not a row in any reference table — so `redirect_to_scatter.py` reports nothing for them and its verdicts look clean while topic pages quietly depend on the chart you are about to unpublish.
+`get_chart_references` counts `postsWordpress`, `postsGdocs`, `explorers`, `narrativeCharts`, `dataInsights` and `staticViz`. **Key charts are none of those** — a key chart is a chart↔tag association (`chart_tags.keyChartLevel`), not a row in any reference table. `redirect_to_scatter.py` therefore queries `chart_tags` itself (`key_chart_slots`) for its `keych` column; before it did, its verdicts looked clean while topic pages quietly depended on the chart being unpublished.
 
 Unpublishing the source does not break a link here; it removes the chart from the topic page's key-chart list. So the loss is silent, on pages nobody is looking at during the migration. **Move each association to the target chart** (same tag, same `keyChartLevel`) as part of step 11.
 
-This is the concrete reason step 11 says not to trust a quiet Part 2 audit: on 2026-08-04 the audit's own tables held 6 embeds + 3 links, while the full sweep found **15 key-chart slots across 13 topic pages** — the largest single category, and entirely invisible to Part 2.
+**But a moved slot renders the target's DEFAULT view, not the scatter.** `GdocPost.loadRelatedCharts` selects only `chartId, slug, title, variantName, keyChartLevel`, and `RelatedCharts` renders `<GrapherWithFallback slug={activeChartSlug}>` — there is nowhere to put a query string, so neither `tab=scatter` nor a log row's `yScale=log` can travel here. Where the page was featuring the chart *because* it was a scatter, moving the association is not an equivalent swap; that is what makes a key-chart slot the surface that can turn a `RECONSIDER` row into "keep the standalone chart". Tell the topic owner rather than moving it quietly.
 
-### Featured metrics — invisible to Part 2 too, and the scatter view cannot hold one
+Step 11 still says not to trust a quiet Part 2 audit, because the `keych` column counts slots and the full sweep *locates* them: on 2026-08-04 the audit's own tables held 6 embeds + 3 links, while the sweep found **15 key-chart slots across 13 topic pages** — the largest single category.
 
-Same blind spot, same reason: a featured metric is a row in `featured_metrics` keyed by **URL**, so it is in none of the tables `get_chart_references` counts. It feeds a topic page's featured rail and the top of that topic's search results. And unlike a key chart it does not heal itself — the row is resolved only when Algolia indexes, matching pathname *and* exact params against **published** records, so unpublishing empties the slot silently. The one signal is an *"Algolia Featured Metric Indexing Failures"* post in Slack after the next index.
+### Featured metrics — the scatter view cannot hold one
+
+Same blind spot as key charts, same reason: a featured metric is a row in `featured_metrics` keyed by **URL**, so it is in none of the tables `get_chart_references` counts. Part 2 reads them itself for the `RECONSIDER` block (`featured_metric_slots`), but only for the rows that block reports — the ⭐ handoff section is still where every slot is listed and settled. It feeds a topic page's featured rail and the top of that topic's search results. And unlike a key chart it does not heal itself — the row is resolved only when Algolia indexes, matching pathname *and* exact params against **published** records, so unpublishing empties the slot silently. The one signal is an *"Algolia Featured Metric Indexing Failures"* post in Slack after the next index.
 
 **The scatter view cannot be featured at all.** A featured metric names a chart, an MDIM view or an explorer view — never a chart's *tab*. `tab=` is a reader param: the admin strips it on paste, and a chart's Algolia record carries no query params, so a URL keeping `tab=scatter` matches nothing and fails to index.
 

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -151,6 +151,12 @@ drawn in rather than testing for statistical outlierness — a symmetric IQR fen
 indicators badly wrong (chart 1131: Cape Verde's 40.3 kg/ha cereal yield sits well inside a
 ±3·IQR fence while being **14.3x below the lowest** of the other 88 countries).
 
+The two pack tests (`Y_PACK_FACTOR`, "N× above the highest / below the lowest") are **ratios**, so
+they only run against a positive bound. On an indicator whose values are negative, `hi_y × 2` sits
+*below* the pack, which would make an ordinary in-range value read as an outlier, and a pack
+topping out at exactly `0` would divide by zero. Those indicators are graded on the span stretch
+alone, which is sign-agnostic and still catches a genuine outlier.
+
 Both sides of that comparison are read at the **same year**. An entity with no value at the
 target's default year is graded at its latest year with both indicators instead, and the peer
 pack is rebuilt at *that* year rather than held at the default one — otherwise a trending
@@ -361,14 +367,24 @@ A row is `RECONSIDER` when the retirement costs the reader something the redirec
 back: the source's **log y axis**, or an **exclusion whose return changes the chart** (the two
 losses in "A log y axis and an exclusion list are the two things the migration cannot carry").
 The block prints, per row, what is lost and where the loss lands — split by whether the fix can
-travel at all:
+travel at all, which depends on **both the loss and the surface**:
 
-- **fixable by hand** — article links and embeds, which can be re-pointed with the params.
-- **CANNOT carry the fix** — key-chart slots (no query string) and featured metrics (a chart's
-  tab cannot be featured at all). Named, not counted, so the topic owner can see whose pages
-  they are. Featured metrics are matched by `find_references.sweep_featured_metrics`, not a local
-  `LIKE`: the only handle a `featured_metrics` row carries is a URL, and `LIKE '%/grapher/foo%'`
-  cannot tell `foo` from `foo-bar`.
+- **fixable by hand** — prose links (gdoc `span-*` rows and the legacy WordPress ones), and only
+  for a **log** loss: a link's href can be given `yScale=log`.
+- **CANNOT carry the fix** — gdoc **embeds** (an embed resolves the chart and renders its
+  *default* tab, so no query string reaches it — the same fact the hand-edit table below reports),
+  key-chart slots (no query string), and featured metrics (a chart's tab cannot be featured at
+  all). The latter two are named, not counted, so the topic owner can see whose pages they are.
+  Featured metrics are matched by `find_references.sweep_featured_metrics`, not a local `LIKE`:
+  the only handle a `featured_metrics` row carries is a URL, and `LIKE '%/grapher/foo%'` cannot
+  tell `foo` from `foo-bar`.
+- **NOTHING carries it** — an **exclusion** loss. The target never re-applies exclusions, so no
+  href, on any surface, brings the entity back off the scatter. An exclusion-only row therefore
+  reports no "fixable by hand" count at all; the only question it poses is whether the chart
+  still reads correctly with the entity present.
+
+Getting that split wrong is not cosmetic: counting embeds as fixable, or offering a hand-edit for
+an exclusion, makes an unrecoverable row look solved.
 
 **It is warn-only on purpose, and that is a deliberate departure from how `MANUAL` is handled.**
 A `MANUAL` reference is turned into `BLOCKED` because the unpublish would *break* an explorer or

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -157,6 +157,14 @@ they only run against a positive bound. On an indicator whose values are negativ
 topping out at exactly `0` would divide by zero. Those indicators are graded on the span stretch
 alone, which is sign-agnostic and still catches a genuine outlier.
 
+**One case needs its own test rather than a ratio:** an excluded value at or **below zero while
+every peer is positive**. That is the limiting case of "below the lowest" — infinitely far below —
+so no ratio expresses it, and the span stretch does not cover it either, because a broad pack
+absorbs the extra width (y=0 against a pack of 1–100 stretches the axis only 1.01×). It is graded
+`y-OUTLIER` on the sign alone. This matters because the pack tests, not the stretch, are what catch
+this whole shape of case: chart 1131's Cape Verde is caught by "below the lowest" alone, its stretch
+being just 1.04×.
+
 Both sides of that comparison are read at the **same year**. An entity with no value at the
 target's default year is graded at its latest year with both indicators instead, and the peer
 pack is rebuilt at *that* year rather than held at the default one — otherwise a trending
@@ -398,7 +406,10 @@ travel at all, which depends on **both the loss and the surface**:
   the only handle a `featured_metrics` row carries is a URL, and `LIKE '%/grapher/foo%'` cannot
   tell `foo` from `foo-bar`. That sweep runs **after** the aliases are resolved and is fed every
   one of the source's slugs, because a slot may name an inbound alias rather than the current
-  slug — and the unpublish deletes the aliases too, so such a slot empties just the same.
+  slug — and the unpublish deletes the aliases too, so such a slot empties just the same. The count
+  is per **slot**, not per topic: one pathname can hold several slots under a single tag (different
+  `incomeGroup` rows), each a separate row to re-point, so repeated tags are shown with a
+  multiplicity (`Agriculture x3`) rather than collapsed into one.
 
 Both reference counts cover **all three** ways an article can hold a chart: a prose link, a block
 embed, and a raw pasted `/grapher/…` URL. The last is stored as `linkType='url'`, which

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -97,7 +97,7 @@ That second case is what **Part 2's redirect produces**, so a reader arriving by
 7. Emits warnings (no action) for:
    - Target has no `selectedEntityNames` — line/bar/slope views will fall back to Grapher defaults.
    - Target `stackMode: relative` — on scatter this is the "Display average annual change" mode; we want the toggle available but **off by default**, so a relative default is flagged for review.
-   - Source `excludedEntityNames` — never applied to the target (they would hide the entity from all views, not just the scatter), so each one **reappears** on the migrated scatter. Graded per entity by `classify_exclusions` into `y-OUTLIER` / `aggregate` / `unclear` / `ungradeable` (a decision is needed) vs `high-GDP` / `no data` (benign), with the numbers in the **EXCLUDED ENTITIES** table. Only the first group makes the note a `WARN`.
+   - Source `excludedEntityNames` — never applied to the target (they would hide the entity from all views, not just the scatter), so each one **reappears** on the migrated scatter. Graded per entity by `classify_exclusions` into `y-OUTLIER` / `aggregate` / `high-GDP-material` / `unclear` / `ungradeable` (a decision is needed) vs `high-GDP` / `no data` (benign), with the numbers in the **EXCLUDED ENTITIES** table. Only the first group makes the note a `WARN` — the group *is* `EXCLUSION_WARN_CLASSES`, which the table's own footer prints, so the two cannot drift. Note that a high GDP per capita is benign only while it stays inside `X_MATERIAL_DECADES`; past that it grades `high-GDP-material` and warns like the rest.
    - Source y axis is **log** — the target's scatter tab opens linear, and only a URL carrying `yScale=log` restores it. See "A log y axis and an exclusion list are the two things the migration cannot carry".
    - GDP coverage mismatch — if y-indicator's earliest year predates the chosen GDP's coverage (WDI≈1990, PWT≈1950, Maddison≈year 1), suggest a deeper-history alternative.
    - Few entities on default scatter view — counts entities with both a y- and an x-value within tolerance at the default time; if fewer than ~15 AND source uses higher tolerance, recommends bumping target's y `display.tolerance`.
@@ -150,6 +150,12 @@ scatter cannot cap it alone. That is why `grade_exclusion` measures each axis in
 drawn in rather than testing for statistical outlierness — a symmetric IQR fence gets skewed
 indicators badly wrong (chart 1131: Cape Verde's 40.3 kg/ha cereal yield sits well inside a
 ±3·IQR fence while being **14.3x below the lowest** of the other 88 countries).
+
+Both sides of that comparison are read at the **same year**. An entity with no value at the
+target's default year is graded at its latest year with both indicators instead, and the peer
+pack is rebuilt at *that* year rather than held at the default one — otherwise a trending
+indicator has the point and the pack drifting apart, and the verdict measures the trend rather
+than the entity. The measured year is printed whenever it is not the default.
 
 (2026-08-19, production: of 22 published GDP scatters carrying `excludedEntityNames`, 8 exclude
 `World` or another OWID aggregate — the single commonest case, which is why `aggregate` is its
@@ -282,7 +288,7 @@ The third state — after a reader *clicks* the scatter tab — no URL can repro
 
 Per-row flags are split so the "With warnings" filter stays worth using. **Warnings** are possible defects — no `ScatterPlot` tab, scatter as the primary type, `hideTimeline` with a time range, `stackMode: relative`, an exclusion whose return actually changes the chart, and the log-axis question. **Context** is expected-but-needed-to-read-the-panes, e.g. that the target selects N entities which both routes should clear — so if you *do* see highlighting, one of the two mechanisms failed. Keep new checks on the right side of that line; a warning on every row is the same as no warnings.
 
-The two lossy checks are the reason that split has to be computed rather than assumed. A log source produces **both**: a context line (the two panes differ by design — see below) and a warning (whether a *linear* scatter still shows the relationship the author chose log for). That is a judgment nobody else in the workflow makes, and the reviewer is the only person looking at both shapes at once. Exclusions are graded by the applier's `classify_exclusions`, and the classes decide the box: `y-OUTLIER` / `aggregate` / `unclear` are warnings carrying their measurement, while a benign `high-GDP` or `no data` is context ("back on the scatter, but harmless"). Importing the applier's `EXCLUSION_WARN_CLASSES` rather than re-deriving the split is what keeps the reviewer saying the same thing the applier's run said.
+The two lossy checks are the reason that split has to be computed rather than assumed. A log source produces **both**: a context line (the two panes differ by design — see below) and a warning (whether a *linear* scatter still shows the relationship the author chose log for). That is a judgment nobody else in the workflow makes, and the reviewer is the only person looking at both shapes at once. Exclusions are graded by the applier's `classify_exclusions`, and the classes decide the box: every class in `EXCLUSION_WARN_CLASSES` (`y-OUTLIER`, `aggregate`, `high-GDP-material`, `unclear`, `ungradeable`) is a warning carrying its measurement, while a benign `high-GDP` or `no data` is context ("back on the scatter, but harmless"). Importing the applier's `EXCLUSION_WARN_CLASSES` rather than re-deriving the split is what keeps the reviewer saying the same thing the applier's run said.
 
 Decisions are fingerprinted on both configs' `fullMd5` plus the GDP variable id, so a re-run of the applier (which rewrites the target) invalidates stale approvals instead of silently keeping them.
 

--- a/.claude/skills/add-gdp-scatter/SKILL.md
+++ b/.claude/skills/add-gdp-scatter/SKILL.md
@@ -163,6 +163,13 @@ pack is rebuilt at *that* year rather than held at the default one — otherwise
 indicator has the point and the pack drifting apart, and the verdict measures the trend rather
 than the entity. The measured year is printed whenever it is not the default.
 
+That fallback year honours the target's **tolerance**, and is not a raw-year intersection: at a
+non-zero tolerance Grapher pairs a y value with a GDP value from a neighbouring year, so an entity
+whose two observations never share a year can still be a point the reader meets by dragging the
+timeline. Requiring the same year graded it a benign `no data` and dropped it out of the warning
+altogether. The value is then read back at that same tolerance, since the observation itself may
+sit a year or two off the timeline year it was found under.
+
 (2026-08-19, production: of 22 published GDP scatters carrying `excludedEntityNames`, 8 exclude
 `World` or another OWID aggregate — the single commonest case, which is why `aggregate` is its
 own class, detected by the `OWID_` prefix on `entityCode` rather than by a name list. Charts 1131
@@ -377,7 +384,16 @@ travel at all, which depends on **both the loss and the surface**:
   all). The latter two are named, not counted, so the topic owner can see whose pages they are.
   Featured metrics are matched by `find_references.sweep_featured_metrics`, not a local `LIKE`:
   the only handle a `featured_metrics` row carries is a URL, and `LIKE '%/grapher/foo%'` cannot
-  tell `foo` from `foo-bar`.
+  tell `foo` from `foo-bar`. That sweep runs **after** the aliases are resolved and is fed every
+  one of the source's slugs, because a slot may name an inbound alias rather than the current
+  slug — and the unpublish deletes the aliases too, so such a slot empties just the same.
+
+Both reference counts cover **all three** ways an article can hold a chart: a prose link, a block
+embed, and a raw pasted `/grapher/…` URL. The last is stored as `linkType='url'`, which
+`gdoc_references` does not read, so it comes from `find_references.sweep_gdoc_url_links` — which
+also unwraps Google redirect wrappers and skips archived hosts. Since the carrier count is the
+link/embed split rather than the aggregate `postsGdocs`, a raw-URL reference left out of both
+would be counted nowhere at all.
 - **NOTHING carries it** — an **exclusion** loss. The target never re-applies exclusions, so no
   href, on any surface, brings the entity back off the scatter. An exclusion-only row therefore
   reports no "fixable by hand" count at all; the only question it poses is whether the chart

--- a/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
+++ b/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
@@ -239,7 +239,14 @@ def grade_exclusion(
 
     lo_y, hi_y = min(others_y), max(others_y)
     span = hi_y - lo_y
-    stretch = (max(hi_y, y) - min(lo_y, y)) / span if span > 0 else float("inf")
+    if span > 0:
+        stretch = (max(hi_y, y) - min(lo_y, y)) / span
+    else:
+        # A pack with no spread at all — every other entity on the same value. Stretch is then a
+        # ratio over zero, so it is only meaningful as a yes/no: an entity ON that value changes
+        # nothing (1.0), any other value turns a zero-width axis into a real one (unbounded).
+        # Without the first case an entity sitting exactly on the pack graded `y-OUTLIER`.
+        stretch = 1.0 if y == hi_y else float("inf")
     above = y > hi_y * Y_PACK_FACTOR
     below = 0 < y < lo_y / Y_PACK_FACTOR
     if stretch >= Y_STRETCH_FACTOR or above or below:
@@ -247,7 +254,12 @@ def grade_exclusion(
         if above or below:
             factor = y / hi_y if above else lo_y / y
             why += f" — {factor:,.1f}x {'above the highest' if above else 'below the lowest'}"
-        if stretch >= Y_STRETCH_FACTOR:
+        if math.isinf(stretch):
+            why += (
+                "; they all sit on one value, so it turns a zero-width y axis into a real range, and yAxis.max "
+                "is global so the scatter cannot cap it alone"
+            )
+        elif stretch >= Y_STRETCH_FACTOR:
             why += f"; stretches the y axis {stretch:.1f}x, and yAxis.max is global so the scatter cannot cap it alone"
         return "y-OUTLIER", why
 
@@ -303,12 +315,27 @@ def classify_exclusions(
     `log_y_axis_sources` does: getting it right in one script and forgetting it in another is
     exactly how this went wrong once.
     """
+    codes = {**entity_codes(gdp_var_id, engine), **entity_codes(y_var_id, engine)}
+    packs: dict[int, tuple[list[float], list[float]]] = {}
+
+    def pack_at(yr: int) -> tuple[list[float], list[float]]:
+        """The peer distribution as the chart draws it at `yr`, memoized per year.
+
+        Rebuilt per year rather than computed once, because an entity graded at a fallback year
+        has to be compared against the pack AT THAT YEAR: for a trending indicator, holding the
+        pack at the default year while moving the point measures the trend instead of the
+        entity, which flips the verdict either way. Cheap — `values_at_year` reads the frame
+        `load_var_data` already holds, so no extra query.
+        """
+        if yr not in packs:
+            ys = values_at_year(y_var_id, yr, tolerance, engine)
+            xs = values_at_year(gdp_var_id, yr, tolerance, engine)
+            names = sorted((set(ys) & set(xs)) - set(excluded))
+            packs[yr] = ([ys[n] for n in names], [xs[n] for n in names])
+        return packs[yr]
+
     y_at = values_at_year(y_var_id, year, tolerance, engine)
     x_at = values_at_year(gdp_var_id, year, tolerance, engine)
-    codes = {**entity_codes(gdp_var_id, engine), **entity_codes(y_var_id, engine)}
-    pack = sorted((set(y_at) & set(x_at)) - set(excluded))
-    others_y = [y_at[n] for n in pack]
-    others_x = [x_at[n] for n in pack]
 
     # An entity absent at the default year may still be an outlier the reader meets by dragging
     # the timeline, so fall back to its latest year with both values rather than calling it moot.
@@ -326,6 +353,7 @@ def classify_exclusions(
                 x = values_at_year(gdp_var_id, shared, 0, engine).get(name)
             else:
                 y = x = None
+        others_y, others_x = pack_at(used) if y is not None and x is not None else ([], [])
         cls, why = grade_exclusion(y, x, others_y, others_x, codes.get(name))
         rows.append({"entity": name, "cls": cls, "why": why, "year": used if y is not None else None, "exact": exact})
     return rows
@@ -755,7 +783,7 @@ def print_exclusion_table(results: list[dict]) -> None:
         print(f"{r['chart']:>6}  {e['entity'][:26]:<26}  {e['cls']:<18}  {e['why']}{year}")
     print()
     print(
-        "  y-OUTLIER / aggregate / unclear / ungradeable want a decision; high-GDP and no data are benign "
+        f"  {' / '.join(sorted(EXCLUSION_WARN_CLASSES))} want a decision; high-GDP and no data are benign "
         "(the target's x axis is log, and matchingEntitiesOnly hides an entity with no pair)."
     )
 

--- a/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
+++ b/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
@@ -351,11 +351,14 @@ def classify_exclusions(
     for name in excluded:
         y, x, used, exact = y_at.get(name), x_at.get(name), year, True
         if y is None or x is None:
-            shared = _latest_shared_year(y_all, x_all, name)
+            shared = _latest_shared_year(y_all, x_all, name, tolerance)
             if shared is not None:
+                # Read with the same tolerance the year was found under: at a non-zero tolerance
+                # `shared` can be a timeline year whose actual observation sits a year or two off,
+                # and a tolerance-0 read would then come back empty.
                 used, exact = shared, False
-                y = values_at_year(y_var_id, shared, 0, engine).get(name)
-                x = values_at_year(gdp_var_id, shared, 0, engine).get(name)
+                y = values_at_year(y_var_id, shared, tolerance, engine).get(name)
+                x = values_at_year(gdp_var_id, shared, tolerance, engine).get(name)
             else:
                 y = x = None
         others_y, others_x = pack_at(used) if y is not None and x is not None else ([], [])
@@ -364,13 +367,24 @@ def classify_exclusions(
     return rows
 
 
-def _latest_shared_year(y_df, x_df, entity: str) -> int | None:
+def _latest_shared_year(y_df, x_df, entity: str, tolerance: int = 0) -> int | None:
+    """Latest timeline year where BOTH indicators resolve for this entity, tolerance included.
+
+    Not a raw-year intersection: with a non-zero tolerance Grapher pairs a y value with a GDP
+    value from a neighbouring year, so demanding the same year understated which entities the
+    reader can actually reach by dragging the timeline — and an entity wrongly found absent
+    graded as a benign `no data` and dropped out of the warning entirely.
+    """
     if y_df is None or x_df is None or y_df.empty or x_df.empty:
         return None
-    ys = set(y_df.loc[y_df["entityName"] == entity, "year"])
-    xs = set(x_df.loc[x_df["entityName"] == entity, "year"])
-    shared = ys & xs
-    return int(max(shared)) if shared else None
+    ys = {int(v) for v in y_df.loc[y_df["entityName"] == entity, "year"]}
+    xs = {int(v) for v in x_df.loc[x_df["entityName"] == entity, "year"]}
+    if not ys or not xs:
+        return None
+    for yr in sorted(ys | xs, reverse=True):
+        if any(abs(y - yr) <= tolerance for y in ys) and any(abs(x - yr) <= tolerance for x in xs):
+            return yr
+    return None
 
 
 def coverage_warning(y_min_year: int, gdp_var_id: int) -> str | None:

--- a/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
+++ b/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
@@ -230,10 +230,14 @@ def grade_exclusion(
     The question is not whether the point is a statistical outlier but whether putting it back
     changes what the reader sees — so each axis is measured in the units it is drawn in.
     """
-    if (code or "").startswith(AGGREGATE_CODE_PREFIX):
-        return "aggregate", f"{code} is an OWID aggregate — it renders as one point among the countries"
+    # Missing data comes FIRST, including for an aggregate: `aggregate`'s claim is that the entity
+    # "renders as one point among the countries", and an entity with no y/GDP pair renders nowhere
+    # — `matchingEntitiesOnly` hides it. Testing the code first turned such an aggregate into a
+    # warning, and so into a RECONSIDER row, on the strength of a sentence that was not true of it.
     if y is None or x is None:
         return "no data", "no year has both a y and a GDP value, so matchingEntitiesOnly hides it regardless"
+    if (code or "").startswith(AGGREGATE_CODE_PREFIX):
+        return "aggregate", f"{code} is an OWID aggregate — it renders as one point among the countries"
     if not others_y or not others_x:
         return "ungradeable", "no other entity has both values here, so there is no pack to compare against"
 
@@ -377,11 +381,17 @@ def _latest_shared_year(y_df, x_df, entity: str, tolerance: int = 0) -> int | No
     """
     if y_df is None or x_df is None or y_df.empty or x_df.empty:
         return None
-    ys = {int(v) for v in y_df.loc[y_df["entityName"] == entity, "year"]}
-    xs = {int(v) for v in x_df.loc[x_df["entityName"] == entity, "year"]}
+    ys = {int(v) for v in y_df.loc[y_df["entityName"] == entity, "year"].unique()}
+    xs = {int(v) for v in x_df.loc[x_df["entityName"] == entity, "year"].unique()}
     if not ys or not xs:
         return None
-    for yr in sorted(ys | xs, reverse=True):
+    # Candidates are every year the two variables cover, not just this entity's own observation
+    # years: the year that PAIRS them can be one where the entity itself has neither. y in 2000
+    # and GDP in 2002 at tolerance 1 meet at 2001 — on the timeline because other entities have
+    # data there, and a year the reader reaches by dragging the handle. Searching only {2000, 2002}
+    # found nothing and sent the entity back as a benign `no data`.
+    timeline = {int(v) for v in y_df["year"].unique()} | {int(v) for v in x_df["year"].unique()}
+    for yr in sorted(timeline, reverse=True):
         if any(abs(y - yr) <= tolerance for y in ys) and any(abs(x - yr) <= tolerance for x in xs):
             return yr
     return None

--- a/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
+++ b/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
@@ -247,8 +247,13 @@ def grade_exclusion(
         # nothing (1.0), any other value turns a zero-width axis into a real one (unbounded).
         # Without the first case an entity sitting exactly on the pack graded `y-OUTLIER`.
         stretch = 1.0 if y == hi_y else float("inf")
-    above = y > hi_y * Y_PACK_FACTOR
-    below = 0 < y < lo_y / Y_PACK_FACTOR
+    # The two pack tests are RATIOS, so they only mean anything against a positive bound: on a
+    # negative pack `hi_y * 2` sits BELOW the pack, which made an ordinary in-range value (y=-7
+    # against -10..-5) read as "above the highest", and a pack topping out at exactly 0 divided
+    # by zero in the factor below. Indicators with negative or zero values are graded on `stretch`
+    # alone, which is a span ratio and so sign-agnostic.
+    above = hi_y > 0 and y > hi_y * Y_PACK_FACTOR
+    below = lo_y > 0 and 0 < y < lo_y / Y_PACK_FACTOR
     if stretch >= Y_STRETCH_FACTOR or above or below:
         why = f"y={y:,.4g} against the other {len(others_y)} at {lo_y:,.4g}-{hi_y:,.4g}"
         if above or below:

--- a/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
+++ b/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
@@ -25,6 +25,7 @@ overrides.
 """
 
 import json
+import math
 import re
 import sys
 from collections.abc import Iterable
@@ -65,6 +66,23 @@ GDP_CATALOG_PATTERNS = {
 ANY_GDP_VARIABLE_IDS = {1294305, 1204826, 900793, 1108541}
 
 CONTINENTS_ID = 900801
+
+# An entity the source excluded is graded by how much including it would stretch each axis,
+# in that axis's OWN units — because the two axes are drawn differently: the target's x is
+# always log (step 4) while its y is always linear (step 5). So a very high GDP per capita
+# costs a fraction of a decade and is usually invisible, while a y outlier costs a multiple
+# of the whole span. Thresholds are deliberately about visible effect, not about statistical
+# outlierness: a symmetric IQR fence gets positive skewed indicators badly wrong (chart 1131,
+# cereal yield: Cape Verde at 40 kg/ha against a pack of 577-13,340 sits well inside a
+# +/-3*IQR fence, yet it is 14x below the lowest country).
+AGGREGATE_CODE_PREFIX = "OWID_"  # OWID-defined aggregates; real countries carry an ISO-3 code
+Y_STRETCH_FACTOR = 1.2  # including it widens the linear y span by >= this
+Y_PACK_FACTOR = 2.0  # ... or it sits this many times outside every other entity
+X_MATERIAL_DECADES = 0.3  # extra log-x width that shows even on a log axis
+
+# Which exclusion classes are a possible defect (a warning) rather than expected-and-handled
+# (context). Owned here so `build_review.py` splits its two boxes on the same rule.
+EXCLUSION_WARN_CLASSES = frozenset({"y-OUTLIER", "high-GDP-material", "aggregate", "unclear", "ungradeable"})
 POPULATION_ID = 953899  # "Population" — the default sizing indicator (-10000..2100)
 
 LINE_FAMILY = {"LineChart", "SlopeChart", "DiscreteBar", "Marimekko", "ScatterPlot"}
@@ -166,12 +184,160 @@ def year_range(var_id: int, engine) -> tuple[int, int] | None:
     return int(df["year"].min()), int(df["year"].max())
 
 
-def entities_at_year(var_id: int, year: int, tolerance: int, engine) -> set[str]:
+def values_at_year(var_id: int, year: int, tolerance: int, engine) -> dict[str, float]:
+    """Each entity's value at `year`, nearest year within tolerance winning.
+
+    Nearest-wins is Grapher's own tolerance resolution, so this is the value the reader
+    actually sees on the scatter rather than an arbitrary one from the window.
+    """
     df = load_var_data(var_id, engine)
     if df is None or df.empty:
-        return set()
-    in_window = df[(df["year"] >= year - tolerance) & (df["year"] <= year + tolerance)]
-    return set(in_window["entityName"].unique())
+        return {}
+    in_window = df[(df["year"] >= year - tolerance) & (df["year"] <= year + tolerance)].copy()
+    if in_window.empty:
+        return {}
+    in_window["_gap"] = (in_window["year"] - year).abs()
+    nearest = in_window.sort_values(["entityName", "_gap"]).groupby("entityName", observed=True).first()
+    return {str(k): float(v) for k, v in nearest["value"].items() if v == v}
+
+
+def entities_at_year(var_id: int, year: int, tolerance: int, engine) -> set[str]:
+    return set(values_at_year(var_id, year, tolerance, engine))
+
+
+def entity_codes(var_id: int, engine) -> dict[str, str]:
+    """entityName -> entityCode, off the frame `load_var_data` already holds.
+
+    `variable_data_df_from_s3` joins `entityCode` in alongside `entityName`, so telling an
+    OWID aggregate from a country costs no query of its own.
+    """
+    df = load_var_data(var_id, engine)
+    if df is None or df.empty or "entityCode" not in df.columns:
+        return {}
+    pairs = df[["entityName", "entityCode"]].drop_duplicates()
+    return {str(r["entityName"]): str(r["entityCode"] or "") for r in pairs.to_dict("records")}
+
+
+def grade_exclusion(
+    y: float | None,
+    x: float | None,
+    others_y: list[float],
+    others_x: list[float],
+    code: str | None,
+) -> tuple[str, str]:
+    """(class, why) for one entity the source excluded. Pure, so it is checkable without a DB.
+
+    The question is not whether the point is a statistical outlier but whether putting it back
+    changes what the reader sees — so each axis is measured in the units it is drawn in.
+    """
+    if (code or "").startswith(AGGREGATE_CODE_PREFIX):
+        return "aggregate", f"{code} is an OWID aggregate — it renders as one point among the countries"
+    if y is None or x is None:
+        return "no data", "no year has both a y and a GDP value, so matchingEntitiesOnly hides it regardless"
+    if not others_y or not others_x:
+        return "ungradeable", "no other entity has both values here, so there is no pack to compare against"
+
+    lo_y, hi_y = min(others_y), max(others_y)
+    span = hi_y - lo_y
+    stretch = (max(hi_y, y) - min(lo_y, y)) / span if span > 0 else float("inf")
+    above = y > hi_y * Y_PACK_FACTOR
+    below = 0 < y < lo_y / Y_PACK_FACTOR
+    if stretch >= Y_STRETCH_FACTOR or above or below:
+        why = f"y={y:,.4g} against the other {len(others_y)} at {lo_y:,.4g}-{hi_y:,.4g}"
+        if above or below:
+            factor = y / hi_y if above else lo_y / y
+            why += f" — {factor:,.1f}x {'above the highest' if above else 'below the lowest'}"
+        if stretch >= Y_STRETCH_FACTOR:
+            why += f"; stretches the y axis {stretch:.1f}x, and yAxis.max is global so the scatter cannot cap it alone"
+        return "y-OUTLIER", why
+
+    positive = [v for v in others_x if v > 0]
+    if not positive or x <= 0:
+        return "unclear", f"y={y:,.4g} sits inside the pack and x=${x:,.0f} cannot be placed on a log axis"
+    before = math.log10(max(positive) / min(positive))
+    after = math.log10(max(max(positive), x) / min(min(positive), x))
+    decades = after - before
+    if decades <= 0:
+        return (
+            "unclear",
+            f"y={y:,.4g} and x=${x:,.0f} sit with the other {len(others_y)} — putting it back stretches y "
+            f"{stretch:.2f}x and widens log x by nothing, so the exclusion was editorial rather than about "
+            f"the chart's shape",
+        )
+    if decades < X_MATERIAL_DECADES:
+        # Benign is a claim about the AXIS, which is the reason a wide-GDP point normally gets
+        # excluded and the reason a log x axis undoes it. It is not a claim that the figure is
+        # sound: Ireland's GDP is inflated by profit shifting and a Gulf state's by its expat
+        # denominator, so an author may have excluded one as bad data rather than as a bad shape.
+        return (
+            "high-GDP",
+            f"x=${x:,.0f} vs the highest other ${max(positive):,.0f} — only +{decades:.2f} of a decade on the "
+            f"target's log x axis (y stretch {stretch:.2f}x), so it costs the axis nothing; check the author did "
+            f"not mean the GDP figure itself is distorted",
+        )
+    return (
+        "high-GDP-material",
+        f"x=${x:,.0f} vs the highest other ${max(positive):,.0f} — +{decades:.2f} of a decade, wide enough to "
+        f"show even on a log x axis",
+    )
+
+
+def classify_exclusions(
+    excluded: list[str],
+    y_var_id: int,
+    gdp_var_id: int,
+    year: int,
+    tolerance: int,
+    engine,
+) -> list[dict]:
+    """Why each entity the source excluded was probably excluded, and whether it matters.
+
+    The target never inherits `excludedEntityNames` (they are global, so they would also hide
+    the entity from the line/bar/map views), which means every one of these entities reappears
+    on the migrated scatter. Two of the reasons an author excludes one have opposite
+    consequences here: a **y** outlier is weird non-GDP data and its return is a real defect,
+    while a merely **very high GDP per capita** is harmless because the target's x axis is
+    logarithmic — so grading them apart is what keeps the warning worth reading.
+
+    Lives here, and is imported by the reviewer and the redirect script, for the same reason
+    `log_y_axis_sources` does: getting it right in one script and forgetting it in another is
+    exactly how this went wrong once.
+    """
+    y_at = values_at_year(y_var_id, year, tolerance, engine)
+    x_at = values_at_year(gdp_var_id, year, tolerance, engine)
+    codes = {**entity_codes(gdp_var_id, engine), **entity_codes(y_var_id, engine)}
+    pack = sorted((set(y_at) & set(x_at)) - set(excluded))
+    others_y = [y_at[n] for n in pack]
+    others_x = [x_at[n] for n in pack]
+
+    # An entity absent at the default year may still be an outlier the reader meets by dragging
+    # the timeline, so fall back to its latest year with both values rather than calling it moot.
+    y_all = load_var_data(y_var_id, engine)
+    x_all = load_var_data(gdp_var_id, engine)
+
+    rows = []
+    for name in excluded:
+        y, x, used, exact = y_at.get(name), x_at.get(name), year, True
+        if y is None or x is None:
+            shared = _latest_shared_year(y_all, x_all, name)
+            if shared is not None:
+                used, exact = shared, False
+                y = values_at_year(y_var_id, shared, 0, engine).get(name)
+                x = values_at_year(gdp_var_id, shared, 0, engine).get(name)
+            else:
+                y = x = None
+        cls, why = grade_exclusion(y, x, others_y, others_x, codes.get(name))
+        rows.append({"entity": name, "cls": cls, "why": why, "year": used if y is not None else None, "exact": exact})
+    return rows
+
+
+def _latest_shared_year(y_df, x_df, entity: str) -> int | None:
+    if y_df is None or x_df is None or y_df.empty or x_df.empty:
+        return None
+    ys = set(y_df.loc[y_df["entityName"] == entity, "year"])
+    xs = set(x_df.loc[x_df["entityName"] == entity, "year"])
+    shared = ys & xs
+    return int(max(shared)) if shared else None
 
 
 def coverage_warning(y_min_year: int, gdp_var_id: int) -> str | None:
@@ -232,24 +398,44 @@ def log_y_axis_sources(chart_ids: Iterable[int]) -> set[int]:
     Lives here, and is imported by the handoff builder and the redirect script, because the
     exclusion is easy to get right in one place and forget in another.
     """
+    return {i for i, loss in source_lossiness(chart_ids).items() if loss["log"]}
+
+
+def source_lossiness(chart_ids: Iterable[int]) -> dict[int, dict]:
+    """Per SOURCE chart, the two things the migration cannot carry onto the target.
+
+    - `log`: a log y axis describing the non-GDP indicator. `yAxis` is global, so the target
+      keeps a linear default and the log survives only on a URL carrying `yScale=log`.
+    - `excluded`: `excludedEntityNames`, which the target never inherits (they are global and
+      would hide the entity from its line/bar/map views too), so each one reappears on the
+      migrated scatter.
+
+    Both come off the one config read, so the redirect script can grade a retirement without
+    fetching every source config a second time. `log_y_axis_sources` is the thin wrapper that
+    keeps the reversed-source exclusion here rather than in each of its callers.
+    """
     ids = tuple(sorted(set(chart_ids)))
     if not ids:
-        return set()
+        return {}
     df = OWID_ENV.read_sql(
         "SELECT c.id, cc.full ->> '$.yAxis.scaleType' AS scale_type, cc.full AS full_config "
         "FROM charts c JOIN chart_configs cc ON c.configId = cc.id WHERE c.id IN %(i)s",
         params={"i": ids},
     )
-    log_sources = set()
+    out: dict[int, dict] = {}
     for row in df.to_dict("records"):
-        if row["scale_type"] != "log":
-            continue
         cfg = row["full_config"] if isinstance(row["full_config"], dict) else json.loads(row["full_config"])
         y_dim = find_dim(cfg, "y") or {}
-        if y_dim.get("variableId") in ANY_GDP_VARIABLE_IDS:
-            continue  # reversed source: the log axis is the GDP one
-        log_sources.add(int(row["id"]))
-    return log_sources
+        # A reversed source (GDP on its y) is kept out of the log set: its `scaleType` describes
+        # the GDP axis, while the target's y is the non-GDP indicator, so proposing log there
+        # would make the wrong axis logarithmic. Its exclusions still apply.
+        reversed_source = y_dim.get("variableId") in ANY_GDP_VARIABLE_IDS
+        out[int(row["id"])] = {
+            "log": row["scale_type"] == "log" and not reversed_source,
+            "excluded": list(cfg.get("excludedEntityNames") or []),
+            "y_var_id": y_dim.get("variableId"),
+        }
+    return out
 
 
 def process_row(
@@ -435,9 +621,42 @@ def process_row(
             "WARN: stackMode=relative — scatter defaults to 'average annual change'; set to absolute to disable the default"
         )
 
+    # Resolved once, because two checks below need the same view: the year and tolerance the
+    # target's scatter actually opens on.
+    y_var_id = (tgt_y or {}).get("variableId")
+    tgt_tol = int((tgt_y or {}).get("display", {}).get("tolerance") or 0)
+    src_tol = int((src_y or {}).get("display", {}).get("tolerance") or 0)
+    default_year = None
+    if y_var_id is not None:
+        try:
+            default_year = resolve_default_year(cfg, int(y_var_id), gdp_var_id, engine)
+        except Exception as e:
+            notes.append(f"(default-year resolution failed: {e!s:.80})")
+
+    # A log y axis is the other thing the migration cannot carry (see step 5): `yAxis` is
+    # global, so the target stays linear and the log survives only on a URL that says
+    # `yScale=log`. Part 2's redirect and a hand-updated link carry it; a reader who clicks the
+    # scatter tab, and a key-chart slot (which has no query string at all — `chart_tags` has
+    # nowhere to put one), do not.
+    if not src_y_is_gdp and (src_cfg.get("yAxis") or {}).get("scaleType") == "log":
+        notes.append(
+            "WARN: source y axis is LOG — the target's scatter tab opens LINEAR, and only a URL carrying "
+            "yScale=log restores it. Weigh the retirement against how the old chart is referenced"
+        )
+
     excluded = src_cfg.get("excludedEntityNames")
+    exclusions: list[dict] = []
     if excluded:
-        notes.append(f"WARN: source excludes {excluded} (not applied on target)")
+        try:
+            if y_var_id is None or default_year is None:
+                raise ValueError("no y variable or default year to grade against")
+            exclusions = classify_exclusions(list(excluded), int(y_var_id), gdp_var_id, default_year, tgt_tol, engine)
+            worst = [r for r in exclusions if r["cls"] in EXCLUSION_WARN_CLASSES]
+            summary = ", ".join(f"{r['entity']} {r['cls']}" for r in exclusions)
+            lead = "WARN: " if worst else ""
+            notes.append(f"{lead}source excludes {len(exclusions)}, none applied — {summary}; see EXCLUDED ENTITIES")
+        except Exception as e:
+            notes.append(f"WARN: source excludes {excluded} (not applied on target); grading failed: {e!s:.80}")
 
     # A hidden timeline defeats Grapher's automatic single-year scatter. Normally
     # `checkSingleTimeSelectionPreferred` collapses the two time handles when the scatter
@@ -464,7 +683,6 @@ def process_row(
                 f"Un-hide the timeline or leave the scatter as a range"
             )
 
-    y_var_id = (tgt_y or {}).get("variableId")
     if y_var_id is not None:
         try:
             yr = year_range(int(y_var_id), engine)
@@ -477,19 +695,15 @@ def process_row(
 
     # 9) Tolerance recommendation
     try:
-        tgt_tol = int((tgt_y or {}).get("display", {}).get("tolerance") or 0)
-        src_tol = int((src_y or {}).get("display", {}).get("tolerance") or 0)
-        if src_tol > tgt_tol and y_var_id is not None:
-            year = resolve_default_year(cfg, int(y_var_id), gdp_var_id, engine)
-            if year is not None:
-                y_ents = entities_at_year(int(y_var_id), year, tgt_tol, engine)
-                x_ents = entities_at_year(gdp_var_id, year, tgt_tol, engine)
-                visible = y_ents & x_ents
-                if len(visible) < 15:
-                    notes.append(
-                        f"WARN: ~{len(visible)} entities would render on scatter at {year}; "
-                        f"source tolerance={src_tol}, target={tgt_tol} — consider raising target tolerance"
-                    )
+        if src_tol > tgt_tol and y_var_id is not None and default_year is not None:
+            y_ents = entities_at_year(int(y_var_id), default_year, tgt_tol, engine)
+            x_ents = entities_at_year(gdp_var_id, default_year, tgt_tol, engine)
+            visible = y_ents & x_ents
+            if len(visible) < 15:
+                notes.append(
+                    f"WARN: ~{len(visible)} entities would render on scatter at {default_year}; "
+                    f"source tolerance={src_tol}, target={tgt_tol} — consider raising target tolerance"
+                )
     except Exception as e:
         notes.append(f"(tolerance check failed: {e!s:.80})")
 
@@ -508,6 +722,7 @@ def process_row(
         "status": status,
         "notes": "; ".join(notes) or "(no changes)",
         "y_var_id": y_var_id,
+        "exclusions": exclusions,
     }
 
 
@@ -519,6 +734,30 @@ def print_action_table(results: list[dict]) -> None:
     for r in results:
         link = edit_link(r["chart"]) if isinstance(r["chart"], int) else ""
         print(f"{r['chart']:>6}  {r['src']:>6}  {r['gdp_source']:<13}  {r['status']:<8}  {link:<60}  {r['notes']}")
+
+
+def print_exclusion_table(results: list[dict]) -> None:
+    """The graded exclusions, with the numbers the one-line note has no room for.
+
+    Its own table for the same reason the display names get one: the `notes` column is a single
+    joined line, and the evidence for "this entity's return is a defect" is what makes the call
+    decidable — a reader who only sees the class has to re-derive it.
+    """
+    rows = [(r, e) for r in results for e in r.get("exclusions") or []]
+    if not rows:
+        return
+    print()
+    print("EXCLUDED ENTITIES (on the source, never applied to the target — so they reappear on the scatter)")
+    print(f"{'chart':>6}  {'entity':<26}  {'class':<18}  why")
+    print("-" * 190)
+    for r, e in rows:
+        year = "" if e["exact"] or e["year"] is None else f" [at {e['year']}, its latest year with both]"
+        print(f"{r['chart']:>6}  {e['entity'][:26]:<26}  {e['cls']:<18}  {e['why']}{year}")
+    print()
+    print(
+        "  y-OUTLIER / aggregate / unclear / ungradeable want a decision; high-GDP and no data are benign "
+        "(the target's x axis is log, and matchingEntitiesOnly hides an entity with no pair)."
+    )
 
 
 def print_display_name_table(api: AdminAPI, results: list[dict]) -> None:
@@ -618,6 +857,7 @@ def main() -> int:
 
     print(f"Target admin: {short_admin_host()}")
     print_action_table(results)
+    print_exclusion_table(results)
     print_display_name_table(api, results)
     return 0
 

--- a/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
+++ b/.claude/skills/add-gdp-scatter/scripts/apply_scatter_defaults.py
@@ -258,11 +258,20 @@ def grade_exclusion(
     # alone, which is a span ratio and so sign-agnostic.
     above = hi_y > 0 and y > hi_y * Y_PACK_FACTOR
     below = lo_y > 0 and 0 < y < lo_y / Y_PACK_FACTOR
-    if stretch >= Y_STRETCH_FACTOR or above or below:
+    # Zero or negative against a wholly positive pack is the LIMITING case of `below` — infinitely
+    # far below the lowest — but it cannot be expressed as a ratio, so `below`'s own `0 < y` guard
+    # excludes it. Without this it fell through to the GDP branch and could come back benign, even
+    # though the stretch test does not cover it either: a broad pack absorbs the extra span (y=0
+    # against 1..100 stretches the axis 1.01x). That is exactly the shape `below` exists for —
+    # chart 1131's Cape Verde is caught by `below` alone, its stretch being only 1.04x.
+    below_zero = y <= 0 < lo_y
+    if stretch >= Y_STRETCH_FACTOR or above or below or below_zero:
         why = f"y={y:,.4g} against the other {len(others_y)} at {lo_y:,.4g}-{hi_y:,.4g}"
         if above or below:
             factor = y / hi_y if above else lo_y / y
             why += f" — {factor:,.1f}x {'above the highest' if above else 'below the lowest'}"
+        elif below_zero:
+            why += " — at or below zero while every one of them is positive"
         if math.isinf(stretch):
             why += (
                 "; they all sit on one value, so it turns a zero-width y axis into a real range, and yAxis.max "

--- a/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
+++ b/.claude/skills/add-gdp-scatter/scripts/build_reference_handoff.py
@@ -500,12 +500,19 @@ def main() -> int:
     if key_charts:
         status = key_chart_target_status(key_charts, pairs)
         out += [
-            f"## 🔴 Key-chart slots ({len(key_charts)}) — invisible to the Part 2 audit",
+            f"## 🔴 Key-chart slots ({len(key_charts)}) — no redirect and no query string reach these",
             "",
-            "`redirect_to_scatter.py` never sees these: its audit counts wp/gdoc/explorer/narrative/"
-            "dataInsight/staticViz, and a key chart is a chart↔tag association "
-            "(`chart_tags.keyChartLevel`), not a row in any of them. Unpublishing the source 404s "
-            "nothing — the chart simply drops out of the topic page's key-chart list, silently.",
+            "A key chart is a chart↔tag association (`chart_tags.keyChartLevel`), not a row in any "
+            "reference table, so `get_chart_references` cannot count it — `redirect_to_scatter.py` "
+            "queries `chart_tags` itself for its `keych` column. Unpublishing the source 404s "
+            "nothing: the chart simply drops out of the topic page's key-chart list, silently.",
+            "",
+            "**A moved slot renders the target's DEFAULT view, not the scatter.** `GdocPost."
+            "loadRelatedCharts` selects only `chartId, slug, title, variantName, keyChartLevel` and "
+            "`RelatedCharts` renders `<GrapherWithFallback slug=…>`, so there is nowhere to put a "
+            "query string: neither `tab=scatter` nor a log row's `yScale=log` can travel here. Where "
+            "the topic page was featuring the scatter *because* it was a scatter, moving the "
+            "association is not equivalent — say so to the topic owner rather than moving it quietly.",
             "",
             "**Target on the page?** says whether the slot needs any work: ✅ the target is already "
             "a key chart on that page (nothing to move — the old slot just drops out), 🟡 the target "

--- a/.claude/skills/add-gdp-scatter/scripts/build_review.py
+++ b/.claude/skills/add-gdp-scatter/scripts/build_review.py
@@ -36,6 +36,7 @@ Usage::
 """
 
 import argparse
+import html
 import importlib.util
 import json
 import re
@@ -43,6 +44,7 @@ import sys
 from pathlib import Path
 
 from etl.config import OWID_ENV
+from etl.db import get_engine
 
 CHART_ID_RE = re.compile(r"/charts/(\d+)")
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
@@ -136,7 +138,50 @@ def default_tab_label(cfg: dict) -> str:
     return TAB_LABELS.get(tab, tab)
 
 
-def row_flags(src_cfg: dict, tgt_cfg: dict, is_log: bool) -> tuple[list[str], list[str]]:
+def esc(text: object) -> str:
+    """Escape config-derived text: the warning and context lists are injected with innerHTML."""
+    return html.escape(str(text), quote=False)
+
+
+def graded_exclusions(src_cfg: dict, tgt_cfg: dict) -> list[dict]:
+    """The source's exclusions, graded by the applier against the view this reviewer shows.
+
+    Graded here rather than re-derived: the classes and the warning/context split belong to
+    `apply_scatter_defaults`, so the reviewer says the same thing the applier's run said. A
+    failure degrades to one ungraded warning — better than a silent empty list, which would read
+    as "this chart excluded nothing".
+    """
+    excluded = src_cfg.get("excludedEntityNames") or []
+    if not excluded:
+        return []
+    applier = redirect.applier
+    try:
+        tgt_y = applier.find_dim(tgt_cfg, "y") or {}
+        y_var_id = tgt_y.get("variableId")
+        gdp_var_id = (applier.find_dim(tgt_cfg, "x") or {}).get("variableId")
+        if y_var_id is None or gdp_var_id is None:
+            raise ValueError("target has no y or no x dimension")
+        tol = int((tgt_y.get("display") or {}).get("tolerance") or 0)
+        engine = get_engine()
+        year = applier.resolve_default_year(tgt_cfg, int(y_var_id), int(gdp_var_id), engine)
+        if year is None:
+            raise ValueError("no year where both indicators have data")
+        return applier.classify_exclusions(list(excluded), int(y_var_id), int(gdp_var_id), year, tol, engine)
+    except Exception as e:
+        return [
+            {
+                "entity": ", ".join(str(x) for x in excluded),
+                "cls": "ungradeable",
+                "why": f"could not grade these ({e!s:.90})",
+                "year": None,
+                "exact": True,
+            }
+        ]
+
+
+def row_flags(
+    src_cfg: dict, tgt_cfg: dict, is_log: bool, exclusions: list[dict] | None = None
+) -> tuple[list[str], list[str]]:
     """(warnings, context) for one pair, computed from the two configs.
 
     The split is what keeps the "With warnings" filter worth using. **Warnings** are things
@@ -146,6 +191,7 @@ def row_flags(src_cfg: dict, tgt_cfg: dict, is_log: bool) -> tuple[list[str], li
     """
     warns: list[str] = []
     context: list[str] = []
+    exclusions = exclusions or []
     types = tgt_cfg.get("chartTypes") or ["LineChart", "DiscreteBar"]
 
     if "ScatterPlot" not in types:
@@ -167,11 +213,18 @@ def row_flags(src_cfg: dict, tgt_cfg: dict, is_log: bool) -> tuple[list[str], li
     if tgt_cfg.get("stackMode") == "relative":
         warns.append("stackMode=relative — the scatter opens on 'average annual change'")
 
-    excluded = src_cfg.get("excludedEntityNames") or []
-    if excluded:
-        warns.append(
-            f"old chart excluded {', '.join(excluded)} — NOT carried to the target, so they reappear on the scatter"
-        )
+    # Graded, because the two usual reasons for an exclusion have opposite consequences here: a
+    # y outlier's return is a real defect, while a merely very high GDP per capita is harmless on
+    # the target's log x axis. Grading them apart is what keeps this warning worth reading — an
+    # unclassified list of names fires on every row that has one and decides nothing. The classes
+    # and the warning/context split are the applier's (`EXCLUSION_WARN_CLASSES`).
+    for e in exclusions:
+        where = "" if e["exact"] or e["year"] is None else f" (measured at {e['year']}, its latest year with both)"
+        line = f"old chart excluded <b>{esc(e['entity'])}</b> — {e['cls']}: {esc(e['why'])}{where}"
+        if e["cls"] in redirect.applier.EXCLUSION_WARN_CLASSES:
+            warns.append(f"{line}. The target never inherits exclusions, so it is back on this scatter")
+        else:
+            context.append(f"{line} — back on the scatter, but harmless")
 
     # Expected-and-handled, so context rather than a warning: both routes to the scatter
     # clear the selection (a tab click via ensureEntitySelectionIsSensibleForTab, the
@@ -189,13 +242,20 @@ def row_flags(src_cfg: dict, tgt_cfg: dict, is_log: bool) -> tuple[list[str], li
     if tgt_cfg.get("minTime") == tgt_cfg.get("maxTime") and tgt_cfg.get("minTime") is not None:
         context.append(f"time is pinned in the config to {tgt_cfg.get('minTime')!r} for every view")
 
-    # Context, not a warning: it is the intended behavior. On screen because the pane is
-    # logarithmic while the target's own default is linear, and without saying so the reviewer
-    # reads that as the migration having changed the target's axis for everyone.
     if is_log:
+        # Two separate statements, which is why one is context and one is a warning. That the two
+        # panes differ is intended and only needs explaining (context). Whether a LINEAR scatter
+        # still tells the story the author chose a log axis for is a judgment nobody else in the
+        # workflow makes — and the reviewer is the one person looking at both shapes at once.
         context.append(
             "the retiring chart had a LOG y axis, so the redirect carries yScale=log and the Redirect "
             "view is logarithmic — the target's own default stays linear for its other tabs"
+        )
+        warns.append(
+            "the retiring chart's LOG y axis does not transfer: yAxis is global, so a reader who CLICKS "
+            "the scatter tab gets it linear, and a key-chart slot (no query string) can never get the log "
+            "at all. Compare the shapes — if linear misreads the relationship, flag the row: keeping the "
+            "standalone chart is a legitimate outcome"
         )
 
     return warns, context
@@ -222,7 +282,8 @@ def build_records(pairs: list[dict]) -> list[dict]:
         src, tgt = charts[src_id], charts[tgt_id]
         types = tgt["cfg"].get("chartTypes") or ["LineChart", "DiscreteBar"]
         scatter_pos = types.index("ScatterPlot") + 1 if "ScatterPlot" in types else 0
-        warns, context = row_flags(src["cfg"], tgt["cfg"], is_log=src_id in log_sources)
+        exclusions = graded_exclusions(src["cfg"], tgt["cfg"])
+        warns, context = row_flags(src["cfg"], tgt["cfg"], is_log=src_id in log_sources, exclusions=exclusions)
 
         records.append(
             {

--- a/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
+++ b/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
@@ -33,18 +33,28 @@ import importlib.util
 import json
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlsplit
 
 from apps.chart_sync.admin_api import AdminAPI
 from etl.config import OWID_ENV
+from etl.db import get_engine
 from etl.http import session as http_session
 
 
 def _load_sibling(name: str):
     """Import a script from this skill's own scripts directory."""
-    path = Path(__file__).resolve().parent / f"{name}.py"
+    return _load_module(name, Path(__file__).resolve().parent / f"{name}.py")
+
+
+def _load_shared(name: str):
+    """Import a find-chart-references module, so the surface definitions stay shared."""
+    return _load_module(name, Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts" / f"{name}.py")
+
+
+def _load_module(name: str, path: Path):
     if not path.exists():
         raise SystemExit(f"Cannot import {name}: {path} does not exist")
     spec = importlib.util.spec_from_file_location(name, path)
@@ -55,8 +65,12 @@ def _load_sibling(name: str):
 
 
 # The log-source question, and the reversed-source exclusion it depends on, are owned by the
-# applier so the two consumers cannot disagree.
+# applier so the three consumers cannot disagree.
 applier = _load_sibling("apply_scatter_defaults")
+# Featured metrics are matched by the sweep's own reader rather than a local query: the only
+# handle a `featured_metrics` row carries is a URL, and `LIKE '%/grapher/<slug>%'` cannot tell
+# `/grapher/foo` from `/grapher/foo-bar` (see `featured_metric_rows`).
+fr = _load_shared("find_references")
 
 SLUG_RE = re.compile(r"/grapher/([^/?#]+)")
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
@@ -284,6 +298,139 @@ def row_query(src_id: int | None, log_sources: set[int]) -> str:
     return f"{TARGET_QUERY}&{Y_SCALE_LOG}" if src_id in log_sources else TARGET_QUERY
 
 
+def key_chart_slots(src_ids: Iterable[int]) -> dict[int, list[str]]:
+    """Topic pages that feature each source as a key chart.
+
+    `get_chart_references` cannot see these — a key chart is a chart-to-tag association
+    (`chart_tags.keyChartLevel`), not a row in any reference table — so without this query the
+    audit's verdicts look clean while topic pages quietly depend on the chart being unpublished.
+    They are the reason a lossy retirement can be unfixable: `GdocPost.loadRelatedCharts` selects
+    only `chartId, slug, title, variantName, keyChartLevel` and `RelatedCharts` renders
+    `<GrapherWithFallback slug=...>`, so a key-chart slot has nowhere to put a query string —
+    neither `tab=scatter` nor `yScale=log` can reach it, at either the source or the target.
+    """
+    ids = tuple(sorted(set(src_ids)))
+    if not ids:
+        return {}
+    df = OWID_ENV.read_sql(
+        "SELECT ct.chartId, t.name FROM chart_tags ct JOIN tags t ON t.id = ct.tagId "
+        "WHERE ct.chartId IN %(i)s AND ct.keyChartLevel > 0 ORDER BY t.name",
+        params={"i": ids},
+    )
+    out: dict[int, list[str]] = {}
+    for row in df.to_dict("records"):
+        out.setdefault(int(row["chartId"]), []).append(str(row["name"]))
+    return out
+
+
+def featured_metric_slots(slugs: Iterable[str]) -> dict[str, list[str]]:
+    """Topic-page featured-metric slots holding each source slug, keyed by slug.
+
+    The other param-less surface, and the harsher one: a featured metric names a chart, an MDIM
+    view or an explorer view — never a chart's *tab* — so the scatter view cannot be featured at
+    all (see "Featured metrics" in SKILL.md). A lossy retirement whose source is featured is
+    therefore the case where the loss is not merely unrecoverable by URL but unrecoverable
+    outright, which is exactly what the RECONSIDER block exists to surface.
+    """
+    wanted = {f"/grapher/{s}": (s, None) for s in slugs if s and s != "-"}
+    if not wanted:
+        return {}
+    out: dict[str, list[str]] = {}
+    for row in fr.sweep_featured_metrics("chart", wanted):
+        out.setdefault(str(row["subject"]), []).append(str(row["where"]))
+    return out
+
+
+def lossy_reasons(loss: dict, tgt_cfg: dict, engine) -> list[str]:
+    """Why retiring this source loses something, in the reader's terms — or [] if it does not.
+
+    Only the losses that survive Part 2 count. A log y axis and the source's exclusions both do:
+    the redirect restores the log for a bare slug, but nothing restores it for a reader who
+    clicks the scatter tab or for a surface with no query string, and the exclusions are never
+    reinstated anywhere. The exclusion grading is the applier's, so this agrees with what Part 1
+    printed instead of second-guessing it.
+    """
+    reasons = []
+    if loss.get("log"):
+        reasons.append("log y axis (the target's scatter tab opens linear)")
+    excluded = loss.get("excluded") or []
+    if excluded:
+        try:
+            tgt_y = applier.find_dim(tgt_cfg, "y") or {}
+            y_var_id = tgt_y.get("variableId")
+            gdp_var_id = (applier.find_dim(tgt_cfg, "x") or {}).get("variableId")
+            if y_var_id is None or gdp_var_id is None:
+                raise ValueError("target has no y or no x dimension to grade against")
+            tol = int((tgt_y.get("display") or {}).get("tolerance") or 0)
+            year = applier.resolve_default_year(tgt_cfg, int(y_var_id), int(gdp_var_id), engine)
+            if year is None:
+                raise ValueError("no year where both indicators have data")
+            graded = applier.classify_exclusions(excluded, int(y_var_id), int(gdp_var_id), year, tol, engine)
+            bad = [g for g in graded if g["cls"] in applier.EXCLUSION_WARN_CLASSES]
+            if bad:
+                reasons.append(
+                    f"{len(bad)} exclusion(s) that matter: " + ", ".join(f"{g['entity']} {g['cls']}" for g in bad)
+                )
+        except Exception as e:
+            reasons.append(f"{len(excluded)} exclusion(s), ungraded ({e!s:.60})")
+    return reasons
+
+
+def print_reconsider(plan: list[dict]) -> None:
+    """The rows where the retirement costs the reader something no redirect gives back.
+
+    Its own block rather than a column, because this is the one verdict here that is warn-only:
+    a linear axis or a returning outlier is an editorial loss, not a broken page, so it cannot
+    be turned into `BLOCKED` the way a MANUAL reference is without training everyone to pass a
+    waiver flag — roughly a fifth of a batch is logarithmic (2026-08-14, batch 1: 3 of 14). A
+    column would be missed; a block with the blast radius next to it has to be answered.
+
+    The blast radius is split by whether the fix can travel: an article link or embed can be
+    hand-edited to carry `yScale=log`, while a key-chart slot cannot carry a query string at all
+    and a featured metric cannot even name a chart's tab.
+    """
+    rows = [r for r in plan if r.get("lossy")]
+    if not rows:
+        return
+    print(f"\nRECONSIDER — {len(rows)} retirement(s) lose something the redirect cannot give back")
+    print("  Warn-only by design: this is an editorial call, not a broken page. Answer each row with the")
+    print("  topic owner before --apply — keeping the standalone chart is a legitimate outcome.")
+    for rec in rows:
+        refs = rec.get("refs") or {}
+        fixable = sum(refs.get(k, 0) for k in ("postsGdocs", "postsWordpress"))
+        key_charts = rec.get("key_charts") or []
+        featured = rec.get("featured_metrics") or []
+        print(f"\n  {rec['src']}  ({rec.get('src_id') or '-'} -> {rec.get('tgt_id') or '-'})")
+        for reason in rec["lossy"]:
+            print(f"    loses: {reason}")
+        if fixable:
+            print(f"    fixable by hand: {fixable} article reference(s) — update the href to carry the params")
+        for label, names, why in (
+            ("key-chart slot", key_charts, "a chart_tags row has nowhere to put a query string"),
+            ("featured metric", featured, "a chart's TAB cannot be featured at all"),
+        ):
+            if names:
+                shown = ", ".join(names[:4]) + (f", +{len(names) - 4} more" if len(names) > 4 else "")
+                print(f"    CANNOT carry the fix: {len(names)} {label}(s) — {shown} ({why})")
+        if not fixable and not key_charts and not featured:
+            print("    no references found, so the loss is confined to readers who arrive by the old slug")
+        unfixable = len(key_charts) + len(featured)
+        verdict = (
+            "the loss lands on pages no query string reaches — decide before applying"
+            if unfixable
+            else "weigh it against the references above"
+        )
+        print(f"    -> {verdict}")
+        # Also on the row itself, so a reader of the PLAN table alone cannot miss it. Appended the
+        # same way --allow-manual-refs appends, so a BLOCKED note keeps its own explanation.
+        summary = "; ".join(rec["lossy"])
+        if unfixable:
+            parts = [f"{len(key_charts)} key-chart slot(s)"] if key_charts else []
+            parts += [f"{len(featured)} featured metric(s)"] if featured else []
+            summary += f"; {' + '.join(parts)} cannot carry the fix"
+        rec["note"] = (rec["note"] + "  " if rec["note"] else "") + f"[RECONSIDER: {summary}]"
+
+
 def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[dict]:
     """Resolve every pair and decide what apply would do — all read-only.
 
@@ -292,7 +439,18 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
     """
     rows: list[dict[str, Any]] = []
     for row in payload:
-        rec: dict[str, Any] = {"status": "", "note": "", "aliases": [], "refs": {}, "manual": False}
+        rec: dict[str, Any] = {
+            "status": "",
+            "note": "",
+            "aliases": [],
+            "refs": {},
+            "manual": False,
+            "key_charts": [],
+            "featured_metrics": [],
+            "loss": {},
+            "lossy": [],
+            "tgt_cfg": {},
+        }
         try:
             rec |= {"src": slug_from_url(row["grapher_url"]), "tgt": slug_from_url(row["target_chart_url"])}
         except (KeyError, ValueError) as e:
@@ -304,10 +462,20 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
     ids = chart_ids_for_slugs(slugs)
     existing = chart_redirects_for_slugs(slugs)
     site_sources, mdim_sources = shadowing_sources(slugs)
-    # Which sources carry a log y axis on the indicator (reversed sources excluded).
-    log_sources = applier.log_y_axis_sources({ids[r["src"]] for r in rows if r["src"] in ids})
+    # What each source carries that the target cannot: a log y axis on the indicator (reversed
+    # sources excluded) and its `excludedEntityNames`. One read, one owner — the log half also
+    # decides this row's stored query. The exclusions are only counted here; grading them costs
+    # indicator data, so `main` does that after `--verify` has had its chance to short-circuit.
+    loss = applier.source_lossiness({ids[r["src"]] for r in rows if r["src"] in ids})
+    log_sources = {i for i, v in loss.items() if v["log"]}
+    key_charts = key_chart_slots(loss.keys())
+    featured = featured_metric_slots(r["src"] for r in rows)
     for rec in rows:
-        rec["query"] = row_query(ids.get(rec["src"]), log_sources)
+        src_id = ids.get(rec["src"])
+        rec["query"] = row_query(src_id, log_sources)
+        rec["loss"] = loss.get(src_id, {})
+        rec["key_charts"] = key_charts.get(src_id, [])
+        rec["featured_metrics"] = featured.get(rec["src"], [])
 
     for rec in rows:
         if rec["status"] == "ERROR":
@@ -326,6 +494,7 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
         # Target-side guards. These are also the wrong-staging-server detector: a target
         # without a scatter tab usually means this env doesn't have the part-1 changes.
         tgt_cfg = api.get_chart_config(rec["tgt_id"])
+        rec["tgt_cfg"] = tgt_cfg
         if "ScatterPlot" not in (tgt_cfg.get("chartTypes") or []):
             rec |= {"status": "SKIPPED", "note": "target has no ScatterPlot tab (wrong env?)"}
             continue
@@ -599,7 +768,9 @@ def verify_redirects(plan: list[dict]) -> int:
                 print(f"{r['slug']:<72} {'OK':<11} {resp.status_code} -> {expected}")
             else:
                 failures += 1
-                print(f"{r['slug']:<72} {'MISMATCH':<11} {resp.status_code} -> {loc.path}?{loc.query}  (expected {expected})")
+                print(
+                    f"{r['slug']:<72} {'MISMATCH':<11} {resp.status_code} -> {loc.path}?{loc.query}  (expected {expected})"
+                )
         elif resp.status_code == 200:
             failures += 1
             print(f"{r['slug']:<72} {'NOT_LIVE':<11} 200 — CDN still serves the cached chart page; bake/purge pending")
@@ -610,7 +781,14 @@ def verify_redirects(plan: list[dict]) -> int:
             failures += 1
             print(f"{r['slug']:<72} {'HTTP ' + str(resp.status_code):<11} unexpected answer")
     total = len(df) + len(unmet)
-    print(f"\n{total - failures}/{total} OK" + (f" — {failures} not verified; re-run once the bake lands" if failures else " — every redirect serves its target"))
+    print(
+        f"\n{total - failures}/{total} OK"
+        + (
+            f" — {failures} not verified; re-run once the bake lands"
+            if failures
+            else " — every redirect serves its target"
+        )
+    )
     return 1 if failures else 0
 
 
@@ -669,14 +847,20 @@ def main() -> int:
         rec["refs"] = ref_counts(refs)
         rec["manual"] = sum(rec["refs"][k] for k in MANUAL_REF_KEYS) > 0
 
+    engine = get_engine()
+    for rec in audited:
+        rec["lossy"] = lossy_reasons(rec.get("loss") or {}, rec.get("tgt_cfg") or {}, engine)
+
     print("\nREFERENCES AUDIT (of the OLD source chart)")
-    print(f"{'src_slug':<58} {'src':>5} {'tgt':>5} {'manual':>7} {'aliases':>7}  counts")
-    print("-" * 140)
+    print(f"{'src_slug':<58} {'src':>5} {'tgt':>5} {'manual':>7} {'lossy':>6} {'keych':>6} {'aliases':>7}  counts")
+    print("-" * 155)
     for rec in plan:
         counts = " ".join(f"{REF_LABEL[k]}={v}" for k, v in rec.get("refs", {}).items())
+        n_key = len(rec.get("key_charts") or [])
         print(
             f"{rec['src']:<58} {str(rec.get('src_id') or '-'):>5} {str(rec.get('tgt_id') or '-'):>5} "
-            f"{'MANUAL' if rec.get('manual') else '':>7} {len(rec['aliases']):>7}  {counts}"
+            f"{'MANUAL' if rec.get('manual') else '':>7} {'LOSSY' if rec.get('lossy') else '':>6} "
+            f"{(n_key or ''):>6} {len(rec['aliases']):>7}  {counts}"
         )
     # MANUAL_REF_KEYS says these BLOCK the row, so make that true rather than leaving it to the
     # operator to notice the audit column and re-run: the apply loop gates purely on `status`, so a
@@ -698,7 +882,12 @@ def main() -> int:
     print("\n  manual = a redirect alone won't fix it: explorers / dataInsights / staticViz reference the old")
     print("           chart directly. Those rows are BLOCKED; re-point them, then --allow-manual-refs.")
     print("  narr   = narrative charts. NOT a blocker (see the table below), but they need replacing.")
+    print("  lossy  = the migrated scatter will not look like the chart it replaces (see RECONSIDER below).")
+    print("  keych  = key-chart slots on topic pages. Invisible to get_chart_references, and they carry no")
+    print("           query string, so they can never show the scatter view — moved or not.")
     print("  aliases = old slugs of the SOURCE chart; the unpublish deletes them, so they get re-pointed too.")
+
+    print_reconsider(plan)
 
     # ---- NARRATIVE CHARTS PARENTED TO THE OLD CHARTS ----
     by_id = {rec["src_id"]: rec for rec in audited}
@@ -728,7 +917,9 @@ def main() -> int:
         print("\n  Every target here is a plain chart, and a chart page has no 'Create narrative chart' control")
         print("  (it exists only on MDIM views), so creating the replacement is not a UI task. Same options as")
         print("  the handoff: leave the old one in place (it keeps rendering; its 'Explore the data' link")
-        print("  loses only the stored keys its params override), ask a developer to create it via the API, or wait for")
+        print(
+            "  loses only the stored keys its params override), ask a developer to create it via the API, or wait for"
+        )
         print("  the target to become an MDIM. SKILL.md 'Narrative charts' has the mechanism and citations.")
 
     # ---- ARTICLE LINKS THAT WON'T LAND ON THE SCATTER ----

--- a/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
+++ b/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
@@ -502,13 +502,11 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
     loss = applier.source_lossiness({ids[r["src"]] for r in rows if r["src"] in ids})
     log_sources = {i for i, v in loss.items() if v["log"]}
     key_charts = key_chart_slots(loss.keys())
-    featured = featured_metric_slots(r["src"] for r in rows)
     for rec in rows:
         src_id = ids.get(rec["src"])
         rec["query"] = row_query(src_id, log_sources)
         rec["loss"] = loss.get(src_id, {})
         rec["key_charts"] = key_charts.get(src_id, [])
-        rec["featured_metrics"] = featured.get(rec["src"], [])
 
     for rec in rows:
         if rec["status"] == "ERROR":
@@ -586,6 +584,22 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
                 "status": "BLOCKED",
                 "note": f"--skip-alias-repoint, but the unpublish would delete {len(rec['aliases'])} alias(es) of the source",
             }
+
+    # Featured metrics LAST, because they are matched by literal pathname and a slot may well name
+    # an inbound alias rather than the current slug — the aliases are only known once the loop
+    # above has read them. Unpublishing the source deletes every alias too, so a slot on an old
+    # slug empties just the same, and missing it would let RECONSIDER report no parameterless
+    # surface for a retirement that silently empties one.
+    featured = featured_metric_slots(
+        slug for rec in rows for slug in (rec["src"], *(a["slug"] for a in rec["aliases"])) if slug and slug != "-"
+    )
+    for rec in rows:
+        slots: list[str] = []
+        for slug in (rec["src"], *(a["slug"] for a in rec["aliases"])):
+            for tag in featured.get(slug, []):
+                if tag not in slots:
+                    slots.append(tag)
+        rec["featured_metrics"] = slots
     return rows
 
 
@@ -891,11 +905,27 @@ def main() -> int:
     rec_by_slug = {slug: rec for rec in audited for slug in (rec["src"], *(a["slug"] for a in rec["aliases"]))}
     query_by_slug = {slug: rec["query"] for slug, rec in rec_by_slug.items()}
     gdoc_rows = gdoc_references(tuple(sorted(query_by_slug)))
-    for row in gdoc_rows:
-        owner = rec_by_slug.get(row["slug"])
+
+    def count_ref(slug: str, kind: str) -> None:
+        owner = rec_by_slug.get(slug)
         if owner is not None:
-            key = "gdoc_links" if row["kind"] == "link" else "gdoc_embeds"
+            key = "gdoc_links" if kind == "link" else "gdoc_embeds"
             owner[key] = owner.get(key, 0) + 1
+
+    for row in gdoc_rows:
+        count_ref(row["slug"], row["kind"])
+
+    # Raw pasted URLs too. `gdoc_references` reads only `linkType IN ('grapher','guided-chart')`,
+    # so an author who pasted a full `/grapher/...` URL (stored as `linkType='url'`) is invisible
+    # to it — and since the carrier count is now the link/embed split rather than the aggregate
+    # `postsGdocs`, such a reference would otherwise be counted nowhere at all. Delegated to the
+    # sweep's own reader, which already unwraps Google redirect wrappers and skips archive hosts.
+    try:
+        url_rows = fr.sweep_gdoc_url_links({slug: {"id": rec.get("src_id")} for slug, rec in rec_by_slug.items()})
+        for row in url_rows:
+            count_ref(str(row["subject"]), "link" if row["kind"] == fr.LINK else "embed")
+    except Exception as e:
+        print(f"\n  (raw-URL gdoc sweep failed, link/embed counts may understate: {e!s:.80})")
 
     print("\nREFERENCES AUDIT (of the OLD source chart)")
     print(f"{'src_slug':<58} {'src':>5} {'tgt':>5} {'manual':>7} {'lossy':>6} {'keych':>6} {'aliases':>7}  counts")

--- a/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
+++ b/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
@@ -920,11 +920,24 @@ def main() -> int:
     # to it — and since the carrier count is now the link/embed split rather than the aggregate
     # `postsGdocs`, such a reference would otherwise be counted nowhere at all. Delegated to the
     # sweep's own reader, which already unwraps Google redirect wrappers and skips archive hosts.
+    # A failure here must not authorise the unpublish. `gdoc_references` above is unguarded and so
+    # already fails closed; guarding this one and continuing would have made the pair inconsistent
+    # — a reference sweep that could not run leaves the blast radius unknown, and `--apply` is
+    # exactly the step that acts on it. So: read-only runs report what they did gather and say the
+    # counts are short, while `--apply` refuses outright rather than unpublishing against a partial
+    # audit. There is deliberately no waiver flag: retry it, do not wave it through.
     try:
         url_rows = fr.sweep_gdoc_url_links({slug: {"id": rec.get("src_id")} for slug, rec in rec_by_slug.items()})
         for row in url_rows:
             count_ref(str(row["subject"]), "link" if row["kind"] == fr.LINK else "embed")
     except Exception as e:
+        if args.apply:
+            print(
+                f"\nREFUSED: the raw-URL gdoc reference sweep failed ({e!s:.80}). The references audit is "
+                f"incomplete, so --apply would unpublish sources whose links and embeds were never counted. "
+                f"Re-run without --apply to see the partial audit, then retry once it succeeds."
+            )
+            return 2
         print(f"\n  (raw-URL gdoc sweep failed, link/embed counts may understate: {e!s:.80})")
 
     print("\nREFERENCES AUDIT (of the OLD source chart)")

--- a/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
+++ b/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
@@ -341,7 +341,7 @@ def featured_metric_slots(slugs: Iterable[str]) -> dict[str, list[str]]:
     return out
 
 
-def lossy_reasons(loss: dict, tgt_cfg: dict, engine) -> list[str]:
+def lossy_reasons(loss: dict, tgt_cfg: dict, engine) -> list[dict]:
     """Why retiring this source loses something, in the reader's terms — or [] if it does not.
 
     Only the losses that survive Part 2 count. A log y axis and the source's exclusions both do:
@@ -349,10 +349,15 @@ def lossy_reasons(loss: dict, tgt_cfg: dict, engine) -> list[str]:
     clicks the scatter tab or for a surface with no query string, and the exclusions are never
     reinstated anywhere. The exclusion grading is the applier's, so this agrees with what Part 1
     printed instead of second-guessing it.
+
+    Each reason carries its `kind`, because the two have different recovery channels and
+    `print_reconsider` has to split the blast radius on that: a log axis travels on any URL that
+    keeps its params, while an exclusion travels on nothing at all. Reporting them together as
+    one "fixable" count overstated what editing an href achieves.
     """
-    reasons = []
+    reasons: list[dict] = []
     if loss.get("log"):
-        reasons.append("log y axis (the target's scatter tab opens linear)")
+        reasons.append({"kind": "log", "text": "log y axis (the target's scatter tab opens linear)"})
     excluded = loss.get("excluded") or []
     if excluded:
         try:
@@ -369,10 +374,14 @@ def lossy_reasons(loss: dict, tgt_cfg: dict, engine) -> list[str]:
             bad = [g for g in graded if g["cls"] in applier.EXCLUSION_WARN_CLASSES]
             if bad:
                 reasons.append(
-                    f"{len(bad)} exclusion(s) that matter: " + ", ".join(f"{g['entity']} {g['cls']}" for g in bad)
+                    {
+                        "kind": "exclusions",
+                        "text": f"{len(bad)} exclusion(s) that matter: "
+                        + ", ".join(f"{g['entity']} {g['cls']}" for g in bad),
+                    }
                 )
         except Exception as e:
-            reasons.append(f"{len(excluded)} exclusion(s), ungraded ({e!s:.60})")
+            reasons.append({"kind": "exclusions", "text": f"{len(excluded)} exclusion(s), ungraded ({e!s:.60})"})
     return reasons
 
 
@@ -385,9 +394,11 @@ def print_reconsider(plan: list[dict]) -> None:
     waiver flag — roughly a fifth of a batch is logarithmic (2026-08-14, batch 1: 3 of 14). A
     column would be missed; a block with the blast radius next to it has to be answered.
 
-    The blast radius is split by whether the fix can travel: an article link or embed can be
-    hand-edited to carry `yScale=log`, while a key-chart slot cannot carry a query string at all
-    and a featured metric cannot even name a chart's tab.
+    The blast radius is split by whether the fix can travel, and that depends on BOTH the loss
+    and the surface. Only a log axis has a recovery channel at all — `yScale=log` on a URL — and
+    only a prose link keeps it: an embed drops the query string, a key-chart slot has nowhere to
+    put one, and a featured metric cannot even name a chart's tab. An exclusion has no channel
+    anywhere, so for that loss every surface is unfixable and none of them counts as "by hand".
     """
     rows = [r for r in plan if r.get("lossy")]
     if not rows:
@@ -397,14 +408,23 @@ def print_reconsider(plan: list[dict]) -> None:
     print("  topic owner before --apply — keeping the standalone chart is a legitimate outcome.")
     for rec in rows:
         refs = rec.get("refs") or {}
-        fixable = sum(refs.get(k, 0) for k in ("postsGdocs", "postsWordpress"))
+        kinds = {r["kind"] for r in rec["lossy"]}
+        log_lost, excl_lost = "log" in kinds, "exclusions" in kinds
+        links, embeds = rec.get("gdoc_links", 0), rec.get("gdoc_embeds", 0)
+        # WordPress rows are prose links on the legacy mirror, so they group with the links.
+        carriers = links + refs.get("postsWordpress", 0)
         key_charts = rec.get("key_charts") or []
         featured = rec.get("featured_metrics") or []
         print(f"\n  {rec['src']}  ({rec.get('src_id') or '-'} -> {rec.get('tgt_id') or '-'})")
         for reason in rec["lossy"]:
-            print(f"    loses: {reason}")
-        if fixable:
-            print(f"    fixable by hand: {fixable} article reference(s) — update the href to carry the params")
+            print(f"    loses: {reason['text']}")
+        if log_lost and carriers:
+            print(f"    fixable by hand: {carriers} prose link(s) — add yScale=log to the href")
+        if embeds:
+            print(
+                f"    CANNOT carry the fix: {embeds} gdoc embed(s) (an embed renders the target's DEFAULT tab; "
+                f"no query string reaches it)"
+            )
         for label, names, why in (
             ("key-chart slot", key_charts, "a chart_tags row has nowhere to put a query string"),
             ("featured metric", featured, "a chart's TAB cannot be featured at all"),
@@ -412,22 +432,33 @@ def print_reconsider(plan: list[dict]) -> None:
             if names:
                 shown = ", ".join(names[:4]) + (f", +{len(names) - 4} more" if len(names) > 4 else "")
                 print(f"    CANNOT carry the fix: {len(names)} {label}(s) — {shown} ({why})")
-        if not fixable and not key_charts and not featured:
+        if excl_lost:
+            print("    NOTHING carries an exclusion back: the target never re-applies them, so every reference")
+            print("    above meets the returning entity however its href is written")
+        if not (carriers or embeds or key_charts or featured):
             print("    no references found, so the loss is confined to readers who arrive by the old slug")
-        unfixable = len(key_charts) + len(featured)
-        verdict = (
-            "the loss lands on pages no query string reaches — decide before applying"
-            if unfixable
-            else "weigh it against the references above"
-        )
+        # An embed is as unfixable as a key-chart slot — it was previously counted as "fixable",
+        # which is what made an embed-only log row look solved.
+        unfixable = embeds + len(key_charts) + len(featured)
+        if excl_lost:
+            verdict = "an exclusion cannot be restored anywhere — decide whether the scatter reads correctly with the entity back"
+        elif unfixable:
+            verdict = "the loss lands on pages no query string reaches — decide before applying"
+        elif carriers:
+            verdict = "every affected surface can carry the params — weigh the edit against keeping the chart"
+        else:
+            verdict = "the redirect carries yScale=log for old-slug arrivals; only a reader who clicks the target's scatter tab sees it linear"
         print(f"    -> {verdict}")
         # Also on the row itself, so a reader of the PLAN table alone cannot miss it. Appended the
         # same way --allow-manual-refs appends, so a BLOCKED note keeps its own explanation.
-        summary = "; ".join(rec["lossy"])
-        if unfixable:
-            parts = [f"{len(key_charts)} key-chart slot(s)"] if key_charts else []
-            parts += [f"{len(featured)} featured metric(s)"] if featured else []
+        summary = "; ".join(r["text"] for r in rec["lossy"])
+        parts = [f"{embeds} gdoc embed(s)"] if embeds else []
+        parts += [f"{len(key_charts)} key-chart slot(s)"] if key_charts else []
+        parts += [f"{len(featured)} featured metric(s)"] if featured else []
+        if parts:
             summary += f"; {' + '.join(parts)} cannot carry the fix"
+        if excl_lost:
+            summary += "; no surface can carry an exclusion back"
         rec["note"] = (rec["note"] + "  " if rec["note"] else "") + f"[RECONSIDER: {summary}]"
 
 
@@ -450,6 +481,8 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
             "loss": {},
             "lossy": [],
             "tgt_cfg": {},
+            "gdoc_links": 0,
+            "gdoc_embeds": 0,
         }
         try:
             rec |= {"src": slug_from_url(row["grapher_url"]), "tgt": slug_from_url(row["target_chart_url"])}
@@ -851,6 +884,19 @@ def main() -> int:
     for rec in audited:
         rec["lossy"] = lossy_reasons(rec.get("loss") or {}, rec.get("tgt_cfg") or {}, engine)
 
+    # Article references, split link vs embed, because RECONSIDER's blast radius turns on that:
+    # a prose link can be given `yScale=log`, an embed renders the target's default tab whatever
+    # its href says. Read once here and reused by the hand-edit table below. Aliases count too —
+    # an article linking an older slug lands on the same target.
+    rec_by_slug = {slug: rec for rec in audited for slug in (rec["src"], *(a["slug"] for a in rec["aliases"]))}
+    query_by_slug = {slug: rec["query"] for slug, rec in rec_by_slug.items()}
+    gdoc_rows = gdoc_references(tuple(sorted(query_by_slug)))
+    for row in gdoc_rows:
+        owner = rec_by_slug.get(row["slug"])
+        if owner is not None:
+            key = "gdoc_links" if row["kind"] == "link" else "gdoc_embeds"
+            owner[key] = owner.get(key, 0) + 1
+
     print("\nREFERENCES AUDIT (of the OLD source chart)")
     print(f"{'src_slug':<58} {'src':>5} {'tgt':>5} {'manual':>7} {'lossy':>6} {'keych':>6} {'aliases':>7}  counts")
     print("-" * 155)
@@ -923,15 +969,13 @@ def main() -> int:
         print("  the target to become an MDIM. SKILL.md 'Narrative charts' has the mechanism and citations.")
 
     # ---- ARTICLE LINKS THAT WON'T LAND ON THE SCATTER ----
-    # Aliases included: an article may well link the source chart's older slug. Each slug maps to
-    # the query of the row it belongs to — an alias is re-pointed carrying that same query (see
-    # repoint_alias), so it has the same keys to collide with. Per-row, because only a log source
-    # stores a `yScale` for a reference's own params to contradict.
-    query_by_slug = {
-        slug: rec["query"] for rec in audited for slug in (rec["src"], *(a["slug"] for a in rec["aliases"]))
-    }
+    # `gdoc_rows` and `query_by_slug` were read above for RECONSIDER's link/embed split. Aliases
+    # are included there: an article may well link the source chart's older slug, and an alias is
+    # re-pointed carrying that same query (see repoint_alias), so it has the same keys to collide
+    # with. Per-row, because only a log source stores a `yScale` for a reference's own params to
+    # contradict.
     refs = []
-    for r in gdoc_references(tuple(sorted(query_by_slug))):
+    for r in gdoc_rows:
         note = param_notes(r, query_by_slug[r["slug"]])
         if note:
             refs.append((r, note))

--- a/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
+++ b/.claude/skills/add-gdp-scatter/scripts/redirect_to_scatter.py
@@ -430,7 +430,14 @@ def print_reconsider(plan: list[dict]) -> None:
             ("featured metric", featured, "a chart's TAB cannot be featured at all"),
         ):
             if names:
-                shown = ", ".join(names[:4]) + (f", +{len(names) - 4} more" if len(names) > 4 else "")
+                # The count is per slot while the names are per topic, and one topic can hold
+                # several slots — so repeats are collapsed with a multiplicity rather than printed
+                # twice, and `len(names)` stays the true number of rows to re-point.
+                tally: dict[str, int] = {}
+                for n in names:
+                    tally[n] = tally.get(n, 0) + 1
+                labels = [n if c == 1 else f"{n} x{c}" for n, c in tally.items()]
+                shown = ", ".join(labels[:4]) + (f", +{len(labels) - 4} more" if len(labels) > 4 else "")
                 print(f"    CANNOT carry the fix: {len(names)} {label}(s) — {shown} ({why})")
         if excl_lost:
             print("    NOTHING carries an exclusion back: the target never re-applies them, so every reference")
@@ -593,12 +600,15 @@ def build_plan(api: AdminAPI, payload: list[dict], skip_aliases: bool) -> list[d
     featured = featured_metric_slots(
         slug for rec in rows for slug in (rec["src"], *(a["slug"] for a in rec["aliases"])) if slug and slug != "-"
     )
+    # One entry per SLOT, not per tag. A pathname can hold several slots under one topic tag —
+    # different `incomeGroup` rows, say — and each is a separate row someone has to re-point, so
+    # de-duplicating by tag name understated the count `print_reconsider` prints. There is nothing
+    # to de-duplicate anyway: the sweep visits each `featured_metrics` row once and matches it to a
+    # single pathname, and a slug appears once across a row's src plus its aliases.
     for rec in rows:
         slots: list[str] = []
         for slug in (rec["src"], *(a["slug"] for a in rec["aliases"])):
-            for tag in featured.get(slug, []):
-                if tag not in slots:
-                    slots.append(tag)
+            slots.extend(featured.get(slug, []))
         rec["featured_metrics"] = slots
     return rows
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

A source's **log y axis** and its **`excludedEntityNames`** are the two things the `/add-gdp-scatter` migration cannot carry onto the target:

- `yAxis` is global, so the target keeps a linear default and the log survives only on a URL carrying `yScale=log`;
- exclusions are global too, so they are never inherited — every excluded entity **reappears** on the migrated scatter.

The skill treated both as bookkeeping (`WARN: source excludes ['Monaco', 'Qatar']`, and nothing at all for the log axis). It now measures each loss and weighs it against how the old chart is referenced, so a human decides whether the retirement is worth doing at all.

## Grading the exclusions

`classify_exclusions` grades each excluded entity by **how much putting it back stretches each axis, in the units that axis is drawn in** — decades for the target's log x, span ratio for its linear y:

| class | verdict |
|---|---|
| `y-OUTLIER` | warning — the returning point changes the chart |
| `aggregate` | warning — an OWID aggregate among the countries |
| `high-GDP-material` | warning — high enough to widen even a log x axis |
| `unclear` / `ungradeable` | warning — needs a human |
| `high-GDP` | **context, benign** — the log x axis absorbs it |
| `no data` | context — `matchingEntitiesOnly` hides it anyway |

The warning set is the frozenset `EXCLUSION_WARN_CLASSES`, which both other scripts import and which the applier's own table footer prints, so the code and the prose cannot drift apart.

Real output, calibrated against all 22 published GDP scatters that carry exclusions:

```
  1131  Cape Verde     y-OUTLIER   y=40.3 against the other 88 at 577.4-1.334e+04 — 14.3x below the lowest
  5029  Australia      y-OUTLIER   y=3,243 against the other 81 at 0.347-582.5 — 5.6x above the highest;
                                   stretches the y axis 5.6x, and yAxis.max is global so the scatter
                                   cannot cap it alone
  1746  World          aggregate   OWID_WRL is an OWID aggregate — it renders as one point among the countries
  6305  Ireland        high-GDP    x=$131,338 vs the highest other $95,173 — only +0.14 of a decade on the
                                   target's log x axis, so it costs the axis nothing
```

A source excluding only Ireland and Luxembourg therefore comes out **not lossy at all** — which is the point of grading rather than listing. `benign` is a claim about the *axis*, and the note says so, since a very high GDP per capita can also be excluded because the figure itself is distorted.

Two calibration findings changed the design:

- **A symmetric IQR fence is the wrong test.** Cape Verde's 40.3 kg/ha sits well inside a ±3·IQR fence while being 14× below every other country. The axis-stretch measure catches it.
- **`aggregate` needs its own class.** 8 of the 22 sources exclude `World` or another OWID aggregate — the commonest case by far. Detected by the `OWID_` prefix on `entityCode`, which `load_var_data` already returns, so it costs no extra query and needs no name list.

Three properties keep the measurement honest rather than merely plausible:

- **The point and the pack are read at the same year.** An entity missing from the default year is graded at its own latest year with both indicators, and the peer pack is rebuilt at *that* year. Holding the pack at the default year while moving the point measures the indicator's trend instead of the entity.
- **The fallback year honours tolerance, and is searched over the whole timeline.** At a non-zero tolerance Grapher pairs a y value with a GDP value from a neighbouring year, so an entity whose two observations never share a raw year can still be a point the reader reaches by dragging the timeline. The year that pairs them can even be one where the entity has neither value — y in 2000 and GDP in 2002 at tolerance 1 meet at **2001** — so candidates are every year the two variables cover, not just the entity's own. Both narrower versions graded such an entity a benign `no data` and dropped it from the warning altogether.
- **`no data` is decided before the `OWID_` code.** An excluded aggregate with no pairable year is `no data`, not `aggregate`: the `aggregate` note claims the entity "renders as one point among the countries", and an entity with no pair renders nowhere, because `matchingEntitiesOnly` hides it. Checking the code first raised a warning, and a `RECONSIDER` row, on the strength of a sentence that was untrue of that entity.
- **The `Y_PACK_FACTOR` tests only run against a positive bound.** They are ratios: on a negative-valued indicator `hi_y × 2` sits *below* the pack, so an ordinary in-range value read as an outlier, and a pack topping out at exactly `0` divided by zero. Non-positive packs are graded on the span stretch alone, which is sign-agnostic and still catches a real outlier.
- **A value at or below zero under a wholly positive pack gets its own test.** It is the limiting case of "below the lowest" — infinitely far below — so no ratio expresses it, and the stretch does not cover it either, because a broad pack absorbs the extra width (y=0 against 1–100 stretches the axis 1.01×). This is why the pack tests matter more than the stretch for this shape of case: Cape Verde is caught by "below the lowest" alone, its stretch being 1.04×.

## The RECONSIDER block

Part 2's audit gains `lossy` and `keych` columns plus a block that splits the blast radius by whether the fix can travel at all:

```
RECONSIDER — 2 retirement(s) lose something the redirect cannot give back

  average-farm-size-vs-gdp  (5029 -> 1200)
    loses: log y axis (the target's scatter tab opens linear)
    loses: 1 exclusion(s) that matter: Australia y-OUTLIER
    fixable by hand: 3 prose link(s) — add yScale=log to the href
    CANNOT carry the fix: 1 gdoc embed(s) (an embed renders the target's DEFAULT tab; no query
                          string reaches it)
    CANNOT carry the fix: 2 key-chart slot(s) — Farm Size, Agricultural Production
                          (a chart_tags row has nowhere to put a query string)
    CANNOT carry the fix: 2 featured metric(s) — ... (a chart's TAB cannot be featured at all)
    NOTHING carries an exclusion back: the target never re-applies them, so every reference
    above meets the returning entity however its href is written
    -> an exclusion cannot be restored anywhere — decide whether the scatter reads correctly
       with the entity back
```

The split depends on **both the loss and the surface**, because the two losses have different recovery channels:

- a **log axis** travels on any URL that keeps its params — so a prose link is genuinely fixable by hand, and only for this loss;
- an **exclusion** travels on nothing at all. No href on any surface brings the entity back off the scatter, so an exclusion-only row reports no fixable count and poses one question only: does the chart still read correctly with the entity present?

Three surfaces can carry no query string, so even a log axis is simply gone for them:

- a **key-chart slot** — `GdocPost.loadRelatedCharts` selects only `chartId, slug, title, variantName, keyChartLevel`, and `RelatedCharts` renders `<GrapherWithFallback slug={activeChartSlug}>`. A moved slot therefore shows the target's **default** view, not the scatter — which the handoff now says explicitly;
- a gdoc **embed** — `makeGrapherLinkedChart` builds no query string;
- a **featured metric** — it names a chart, an MDIM view or an explorer view, never a chart's *tab*.

Counting embeds among the fixable references, as a first cut did, is what makes an unrecoverable row look solved — so they are tallied with the key-chart and featured-metric slots instead.

Both reference counts cover all three ways an article holds a chart: a prose link, a block embed, and a raw pasted `/grapher/…` URL. The last is stored as `linkType='url'`, which `gdoc_references` does not read, so it comes from `find_references.sweep_gdoc_url_links` — which also unwraps Google redirect wrappers and skips archived hosts.

**A reference sweep that fails blocks `--apply`.** `gdoc_references` is unguarded and so fails closed on its own; the raw-URL sweep is guarded only so a read-only audit still prints what it gathered, and under `--apply` it `REFUSED`s with a non-zero exit before any mutation is reachable. An incomplete references audit must not authorise an unpublish — the same principle that turns a `MANUAL` row into `BLOCKED`, applied to a count that is missing rather than alarming. No waiver flag: retry the sweep.

Key-chart slots are read from `chart_tags` directly, closing the blind spot the skill already documented. Featured metrics reuse `find_references.sweep_featured_metrics` rather than a local `LIKE`, which cannot tell `/grapher/foo` from `/grapher/foo-bar`; that sweep runs after the aliases are resolved and is fed every one of the source's slugs, since a slot may name an inbound alias and the unpublish deletes those too. The count is per **slot**, not per topic — one pathname can hold several slots under a single tag (different `incomeGroup` rows), each a separate row to re-point — so a repeated tag is shown with a multiplicity (`Agriculture x3`) instead of collapsing into one.

**Warn-only by design.** A `MANUAL` reference becomes `BLOCKED` because the unpublish would *break* an explorer or data insight. A lossy retirement breaks nothing — the chart still renders, linear, with an extra dot on it — so whether that is acceptable is a judgment about the chart, not a fact about the database. Roughly a fifth of a batch is logarithmic (batch 1: 3 of 14), so blocking those would mean a waiver flag on every run, and a flag passed every run stops being read. Instead the verdict gets its own block, a `[RECONSIDER: …]` suffix on the row's note in the PLAN table, and a checklist gate at item 13.

## Reviewer HTML

The topic owner is the one person looking at both shapes at once, so a log row now raises the question there — alongside the existing context line explaining why the two panes differ by design. Graded exclusions split across the warning and context boxes on the applier's own `EXCLUSION_WARN_CLASSES`, so the reviewer says what the applier's run said. Entity names are now escaped; that list was already being injected with `innerHTML`.

## Verification

- `grade_exclusion` is pure, and is checked over every class plus the edge cases: both-outlier, empty pack, a zero-spread pack (an entity sitting exactly on the pack's single value must not be an outlier), a negative pack, a pack topping out at zero, and a zero-or-negative value under a positive pack. The Cape Verde and Australia calibration cases are asserted unchanged, so a guard cannot quietly widen or narrow the thresholds.
- `classify_exclusions` checked against seeded data for the year properties: a trending indicator confirms the pack is rebuilt at the fallback year; an entity with y and GDP in adjacent years confirms the tolerance-aware fallback grades it instead of dismissing it; and an entity with y in 2000 and GDP in 2002 confirms the gap year 2001 is found once other entities put it on the timeline.
- The aggregate ordering checked in both directions, since `aggregate` must keep firing where it applies: `OWID_WRL` without pairable values is `no data` and asserted **not** a warning class, `OWID_WRL` with values is still `aggregate` and asserted a warning class.
- The failed-sweep refusal checked on control flow: the refusal returns ahead of the only `apply_row` call site, `gdoc_references` is confirmed still unguarded, and the read-only path still reports the shortfall.
- `print_reconsider` checked across the loss × surface matrix — exclusion-only with articles, a log row with only embeds, a log row with only links, everything at once, and a log row with no references — asserting that no unrecoverable row reports a fixable count.
- The classifier end-to-end against 9 production charts, by seeding the module's own data cache from the public data API (no MySQL needed).
- `featured_metric_slots` exact-pathname matching, including a `foo` / `foo-bar` near-miss.
- `--verify` still short-circuits *before* the new grading, so the closing report pays nothing for it.
- `ruff check` + `ruff format` clean on all five scripts (**note: CI does not cover `.claude/` — `SRC` in the Makefile excludes it — so these were run by hand**); codespell clean; frontmatter still parses with `internal: true`.
- The key-chart claim was read out of `owid-grapher` rather than inferred, and `key_chart_slots`' SQL was checked against production.

## Still open

- **No full live dry run yet, and this now matters more.** The local dev MySQL was down, so `redirect_to_scatter.py`'s new tables were exercised function-by-function rather than in one pass. Three parts of the audit are DB-backed and verified only structurally — the alias-aware featured-metric sweep, the raw-URL reference sweep, and the link/embed carrier counts. The next batch should get a real `--apply`-less run before anyone acts on a `RECONSIDER` verdict. It is read-only, so it is safe to do at any time.
- **`featured_metrics` is not on the public Datasette**, so that matching was verified on synthetic rows plus the shared reader it delegates to.
- **`excludedEntityIds` / `excludedEntities` / `includedEntityNames`** — the older schema keys and the inclusion-allowlist form. No script in the skill reads them today, so a source using one still produces no warning. Worth a follow-up.
- Thresholds (`Y_STRETCH_FACTOR` 1.2, `Y_PACK_FACTOR` 2.0, `X_MATERIAL_DECADES` 0.3) are calibrated on 22 charts, not tuned. Every note prints the measurement, so a wrong call is visible rather than silent.
- The PR is still a **draft**; it has had six Codex rounds with every finding addressed, but no human review. The newest verdict covers `f9043aa2d8`, one commit behind head: the final fixes (the non-positive-y test and the per-slot featured count) are themselves unreviewed.
