### PR TITLE
🐝 collections: Make grapher_schema the single place an MDIM pins its schema

### DIFF
--- a/.claude/skills/create-multidim/SKILL.md
+++ b/.claude/skills/create-multidim/SKILL.md
@@ -123,6 +123,8 @@ The ETL has built-in change detection — if you modify the config, it will auto
 # (etl/config.py) when authoring a new MDIM, then leave it alone: Grapher migrates outdated
 # configs forward, but skips migration entirely when no version is given.
 grapher_schema: "011"
+# Never put `$schema` inside a view's `config` block: Grapher lets the view value override this
+# collection-level pin, so the two silently disagree. ETL warns when that happens.
 
 title:
   title: "Chart Title"

--- a/.claude/skills/sync-grapher-schema/SKILL.md
+++ b/.claude/skills/sync-grapher-schema/SKILL.md
@@ -127,6 +127,6 @@ Every multidim config pins `grapher_schema: "NNN"` (enforced by `test_multidim_c
 
 The one thing to check: step 2 repoints multidim view-config validation at the new version, so a config that is no longer valid under `MMM` will now fail `Collection.validate_schema()`. Fix the config *and* bump only that config's pin, since at that point it genuinely was re-authored against `MMM`.
 
-Views can also carry their own `$schema` inside a `config` block (grep `etl/steps/export/multidim` for `\$schema`), which overrides the collection-level pin. Same rule applies.
+Views can also carry their own `$schema` inside a `config` block, which **overrides** the collection-level pin (grapher spreads the view config last). As of #6705 follow-up no step does this any more, and ETL warns if one reappears — so treat a hit from `grep -rn '\$schema' etl/steps/export/multidim` as something to remove rather than to bump.
 
 One caveat on "leave the pins alone": that holds for pins that are *true*. A pin that contradicts its own config body — pinned `005` while the config uses `chartTypes`, which only exists from `006` (the 005→006 migration creates it) — is stale, not a record, and leaving it makes grapher run migrations over a config they were never meant to touch. Check a suspicious pin against the properties of that schema version (`curl https://files.ourworldindata.org/schemas/grapher-schema.NNN.json`) and correct it to the version the config is actually written against.

--- a/docs/guides/data-work/mdims.md
+++ b/docs/guides/data-work/mdims.md
@@ -123,6 +123,8 @@ In this example, we note that we can group together indicators from any dataset.
 
     The one exception is a pin that **contradicts the config body** — e.g. pinned `005` while the config uses `chartTypes`, a field that only exists from `006` onwards (the 005→006 migration is what creates it). That is a stale pin rather than a record, and leaving it means Grapher runs migrations over a config they were never meant to touch. Correct such a pin to the version the config is actually written against.
 
+    **Pin it in one place only.** A view's own `config` may also carry a `$schema`, and Grapher lets that value *win* over the collection pin — while being far less visible, since it usually sits in a Python dict rather than on line 1 of the YAML. ETL logs a warning when a view shadows the collection pin; don't add new ones. If you need to know what version an MDIM actually declares, the collection pin is the answer unless that warning fires.
+
     This field is MDIM-only. Explorers reach Grapher through the legacy TSV path, which has no equivalent.
 
 !!! tip "Learn more about the structure of MDIMs in [:fontawesome-brands-github: their schema](https://github.com/owid/etl/blob/master/schemas/multidim-schema.json)"

--- a/docs/guides/data-work/mdims.md
+++ b/docs/guides/data-work/mdims.md
@@ -125,6 +125,18 @@ In this example, we note that we can group together indicators from any dataset.
 
     **Pin it in one place only.** A view's own `config` may also carry a `$schema`, and Grapher lets that value *win* over the collection pin — while being far less visible, since it usually sits in a Python dict rather than on line 1 of the YAML. ETL logs a warning when a view shadows the collection pin; don't add new ones. If you need to know what version an MDIM actually declares, the collection pin is the answer unless that warning fires.
 
+    **The pin appears under three different names**, which is worth knowing before you go looking for it:
+
+    | Where | Key | Value |
+    |---|---|---|
+    | config YAML | `grapher_schema` | `"011"` |
+    | `export/multidim/…/<name>.config.json` | `grapher_schema` | `"011"` |
+    | Grapher DB / admin API payload | `grapherConfigSchema` | `https://…/grapher-schema.011.json` |
+
+    The generated JSON keeps the authored short form because `CollectionSet.read()` loads it back through `Collection.from_dict`; only the upsert payload is camelized and resolved to a full URL. So grepping the generated JSON for `grapherConfigSchema` finds nothing even when the pin is working perfectly.
+
+    Note also that while `DEFAULT_GRAPHER_SCHEMA` equals the version everything pins, a working pin and a dropped one look identical in the database. ETL logs a warning when a collection falls back to the default, which is the signal to trust.
+
     This field is MDIM-only. Explorers reach Grapher through the legacy TSV path, which has no equivalent.
 
 !!! tip "Learn more about the structure of MDIMs in [:fontawesome-brands-github: their schema](https://github.com/owid/etl/blob/master/schemas/multidim-schema.json)"

--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -39,7 +39,7 @@ from etl.collection.utils import (
     unique_records,
     validate_indicators_in_db,
 )
-from etl.config import OWID_ENV, OWIDEnv
+from etl.config import DEFAULT_GRAPHER_SCHEMA, OWID_ENV, OWIDEnv
 from etl.files import yaml_dump
 from etl.paths import EXPORT_DIR, SCHEMAS_DIR
 
@@ -288,6 +288,9 @@ class Collection(MDIMBase):
 
         # Warn about view configs that shadow the collection-level schema pin
         self.warn_on_view_schema_overrides()
+
+        # Warn when no version is pinned and we fall back to the vendored default
+        self.warn_if_grapher_schema_unpinned()
 
         # Sort views based on dimension order
         self.sort_views_based_on_dimensions()
@@ -680,6 +683,21 @@ class Collection(MDIMBase):
                 f"({schema}), which overrides the collection-level `grapher_schema` "
                 f"({resolve_grapher_schema(self.grapher_schema)}). Remove it and pin the whole "
                 "collection with the top-level `grapher_schema` field instead."
+            )
+
+    def warn_if_grapher_schema_unpinned(self):
+        """Warn when the collection pins no schema version and the default is used.
+
+        The fallback is `DEFAULT_GRAPHER_SCHEMA`, so grapher is told the config already matches the
+        version this repo vendors. That is usually true, but it means a config authored against an
+        older schema would skip migration. It also makes "pinned" and "defaulted" indistinguishable
+        in the database while the two happen to agree — so say so out loud instead.
+        """
+        if self.grapher_schema is None:
+            log.warning(
+                f"Collection '{self.catalog_path}' pins no `grapher_schema`; falling back to "
+                f"{DEFAULT_GRAPHER_SCHEMA}. Add a top-level `grapher_schema` to the config YAML "
+                "recording the version its view configs were authored against."
             )
 
     def validate_description_keys(self):

--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -286,6 +286,9 @@ class Collection(MDIMBase):
         # Check that no view carries a corrupted description_key
         self.validate_description_keys()
 
+        # Warn about view configs that shadow the collection-level schema pin
+        self.warn_on_view_schema_overrides()
+
         # Sort views based on dimension order
         self.sort_views_based_on_dimensions()
 
@@ -655,6 +658,29 @@ class Collection(MDIMBase):
         for view in self.views:
             if view.is_grouped:
                 sanity_check_grouped_view(view)
+
+    def warn_on_view_schema_overrides(self):
+        """Warn when a view config carries its own `$schema`, shadowing `grapher_schema`.
+
+        Grapher applies the collection pin as `{$schema: grapherConfigSchema, **view.config}`, so a
+        view's own `$schema` wins — and it is far less visible than the collection pin on line 1 of
+        the config YAML. That combination has bitten us before: a config pinned at an old version
+        while its body used fields from a newer one, so Grapher ran migrations over a config they
+        were never meant to touch. Pin the collection instead.
+        """
+        overrides = defaultdict(int)
+        for view in self.views:
+            config = view.config
+            if isinstance(config, dict) and "$schema" in config:
+                overrides[config["$schema"]] += 1
+
+        for schema, n_views in sorted(overrides.items()):
+            log.warning(
+                f"Collection '{self.catalog_path}': {n_views} view(s) set `$schema` in their config "
+                f"({schema}), which overrides the collection-level `grapher_schema` "
+                f"({resolve_grapher_schema(self.grapher_schema)}). Remove it and pin the whole "
+                "collection with the top-level `grapher_schema` field instead."
+            )
 
     def validate_description_keys(self):
         """Fail on a view whose `description_key` list cannot be real content.

--- a/etl/steps/export/multidim/education/latest/children_out_of_school.py
+++ b/etl/steps/export/multidim/education/latest/children_out_of_school.py
@@ -47,7 +47,6 @@ EXCLUSION_REGEX = re.compile("|".join(EXCLUSION_PATTERNS), re.IGNORECASE)
 
 # Main chart configuration
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "hasMapTab": True,

--- a/etl/steps/export/multidim/education/latest/completion_rates.py
+++ b/etl/steps/export/multidim/education/latest/completion_rates.py
@@ -16,7 +16,6 @@ COLOR_GIRLS = "#E56E5A"
 
 # Common configuration for all charts
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "yAxis": {"min": 0, "max": 100},

--- a/etl/steps/export/multidim/education/latest/education_spending.py
+++ b/etl/steps/export/multidim/education/latest/education_spending.py
@@ -14,7 +14,6 @@ COLOR_TERTIARY = "#B16214"
 
 # Common configuration for all charts
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "hasMapTab": True,

--- a/etl/steps/export/multidim/education/latest/enrolment_rates.py
+++ b/etl/steps/export/multidim/education/latest/enrolment_rates.py
@@ -30,7 +30,6 @@ ENROLLMENT_TYPE_DESCRIPTION_KEY = [
 ]
 
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "hasMapTab": True,
     "tab": "map",
     "originUrl": "ourworldindata.org/education",

--- a/etl/steps/export/multidim/education/latest/literacy.py
+++ b/etl/steps/export/multidim/education/latest/literacy.py
@@ -17,7 +17,6 @@ COLOR_GIRLS = "#E56E5A"
 
 # Common configuration for all charts
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "yAxis": {"min": 0, "max": 100},

--- a/etl/steps/export/multidim/education/latest/pisa_performance.py
+++ b/etl/steps/export/multidim/education/latest/pisa_performance.py
@@ -16,7 +16,6 @@ COLOR_GIRLS = "#E56E5A"
 
 # Common configuration for all charts
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "yAxis": {"min": 350, "max": 550},

--- a/etl/steps/export/multidim/education/latest/proficiency.py
+++ b/etl/steps/export/multidim/education/latest/proficiency.py
@@ -21,7 +21,6 @@ COLOR_STUDENTS = "#4C6A9C"
 
 # Common configuration for all charts
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "yAxis": {"min": 0, "max": 100},

--- a/etl/steps/export/multidim/education/latest/teachers.py
+++ b/etl/steps/export/multidim/education/latest/teachers.py
@@ -38,7 +38,6 @@ TRAINED_TEACHER_PATTERN = r"^(se_pre_tcaq_zs|se_prm_tcaq_zs|se_sec_tcaq_lo_zs|se
 
 # Main chart configuration for individual views (maps)
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "hasMapTab": True,

--- a/etl/steps/export/multidim/education/latest/women_teachers.py
+++ b/etl/steps/export/multidim/education/latest/women_teachers.py
@@ -21,7 +21,6 @@ WOMEN_TEACHER_PATTERN = r"percentage_of_teachers_in_(primary|secondary|tertiary)
 
 # Main chart configuration
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "originUrl": "ourworldindata.org/education",
     "hideAnnotationFieldsInTitle": {"time": True},
     "hasMapTab": True,

--- a/etl/steps/export/multidim/education/latest/years_of_schooling.py
+++ b/etl/steps/export/multidim/education/latest/years_of_schooling.py
@@ -33,7 +33,6 @@ METRIC_TYPE_DESCRIPTION_KEY = [
 
 
 MULTIDIM_CONFIG = {
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     "hasMapTab": True,
     "tab": "map",
     "originUrl": "ourworldindata.org/education",

--- a/etl/steps/export/multidim/health/latest/vaccination_introductions.py
+++ b/etl/steps/export/multidim/health/latest/vaccination_introductions.py
@@ -1,10 +1,8 @@
-from etl.config import DEFAULT_GRAPHER_SCHEMA
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 MULTIDIM_CONFIG = {
-    "$schema": DEFAULT_GRAPHER_SCHEMA,
     "hasMapTab": True,
     "chartTypes": [],
     "tab": "map",

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -83,6 +83,9 @@
                     "Leave the pin alone once set — it records what the config was authored against, which is what lets Grapher migrate it after a breaking change."
                 ],
                 [
+                    "Pin here and nowhere else. A `$schema` inside a view's `config` overrides this field (grapher spreads the view config last) while being much less visible, so the two silently disagree. ETL logs a warning when a view shadows this pin."
+                ],
+                [
                     "The exception is a pin that contradicts the config body (e.g. pinned `005` while using `chartTypes`, which only exists from `006`). That is a stale pin, not a record: Grapher would run migrations over a config they were never meant to touch. Correct it to the version the config is actually written against."
                 ]
             ],

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -2407,3 +2407,33 @@ def test_explorer_rejects_grapher_schema():
 
     with pytest.raises(ValueError, match="only supported for multidim collections"):
         Explorer.from_dict(_make_minimal_config(grapher_schema="011", config={"explorerTitle": "T"}))
+
+
+def test_warn_on_view_schema_overrides(capsys):
+    """
+    Test Collection.warn_on_view_schema_overrides - a view `$schema` shadowing the collection pin
+    is surfaced, since Grapher lets the view value win and it is much less visible.
+
+    structlog writes to stdout rather than through stdlib logging, hence capsys not caplog.
+    """
+    collection = Collection.from_dict(
+        _make_minimal_config(
+            grapher_schema="011",
+            views=[
+                {
+                    "dimensions": {"metric": "total"},
+                    "indicators": {"y": [{"catalogPath": "grapher/ns/2024-01-01/ds/tb#ind"}]},
+                    "config": {"$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json"},
+                }
+            ],
+        )
+    )
+    collection.warn_on_view_schema_overrides()
+    out = capsys.readouterr().out
+    assert "grapher-schema.008.json" in out
+    assert "grapher-schema.011.json" in out
+    assert "grapher_schema" in out
+
+    # A view without its own `$schema` stays quiet.
+    Collection.from_dict(_make_minimal_config(grapher_schema="011")).warn_on_view_schema_overrides()
+    assert capsys.readouterr().out == ""

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -2437,3 +2437,18 @@ def test_warn_on_view_schema_overrides(capsys):
     # A view without its own `$schema` stays quiet.
     Collection.from_dict(_make_minimal_config(grapher_schema="011")).warn_on_view_schema_overrides()
     assert capsys.readouterr().out == ""
+
+
+def test_warn_if_grapher_schema_unpinned(capsys):
+    """
+    Test Collection.warn_if_grapher_schema_unpinned - an unpinned collection says so.
+
+    Without this, a config that silently relies on the DEFAULT_GRAPHER_SCHEMA fallback is
+    indistinguishable in the database from one that pins the same version deliberately.
+    """
+    Collection.from_dict(_make_minimal_config()).warn_if_grapher_schema_unpinned()
+    out = capsys.readouterr().out
+    assert "pins no `grapher_schema`" in out
+
+    Collection.from_dict(_make_minimal_config(grapher_schema="011")).warn_if_grapher_schema_unpinned()
+    assert capsys.readouterr().out == ""

--- a/tests/collections/test_core_create.py
+++ b/tests/collections/test_core_create.py
@@ -1118,3 +1118,52 @@ class TestCreateCollectionMultipleTables:
                 # The user's input config object must not have been mutated.
                 assert len(config["views"]) == 1
                 assert config["views"][0]["indicators"]["y"][0]["catalogPath"] == "manual_view#stages"
+
+
+def test_create_collection_preserves_grapher_schema_from_table():
+    """
+    Test create_collection - the `grapher_schema` pin survives the table-driven path.
+
+    Some configs (e.g. corruption_barometer, causes_of_death, migration_flows) get their dimension
+    choices from the table rather than the YAML, so the config dict is rebuilt on the way through.
+    The pin must not be lost in that rebuild. Uses a non-default version so a dropped pin can't be
+    masked by the DEFAULT_GRAPHER_SCHEMA fallback.
+    """
+    from unittest.mock import patch
+
+    from owid.catalog import Table, Variable
+    from owid.catalog.meta import VariableMeta
+
+    from etl.collection.core.create import create_collection
+
+    tb = Table(
+        {"country": ["USA", "CAN"], "year": [2020, 2020], "deaths__sex_male": [1, 2]},
+        short_name="tb",
+    )
+    tb["deaths__sex_male"] = Variable(
+        tb["deaths__sex_male"],
+        name="deaths__sex_male",
+        metadata=VariableMeta(original_short_name="deaths", dimensions={"sex": "male"}),
+    )
+
+    config = {
+        "grapher_schema": "007",
+        "title": {"title": "T", "title_variant": "v"},
+        "default_selection": ["World"],
+        "dimensions": [],
+        "views": [],
+    }
+
+    with (
+        patch("etl.collection.core.utils.process_views"),
+        patch("etl.collection.core.create._get_expand_path_mode", return_value="table"),
+    ):
+        c = create_collection(
+            config_yaml=config,
+            dependencies=set(),
+            catalog_path="ns/latest/ds#short",
+            tb=tb,
+        )
+
+    assert c.grapher_schema == "007"
+    assert c.to_dict()["grapher_schema"] == "007"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

Follow-up to #6705. Pinning `grapher_schema` in the YAML wasn't the whole story: a view's own `$schema` inside a `config` block **overrides** it, because grapher spreads the view config last ([`multiDim.ts#L274`](https://github.com/owid/owid-grapher/blob/master/adminSiteServer/multiDim.ts#L274)):

```ts
viewGrapherConfig = grapherConfigSchema ? { $schema: grapherConfigSchema, ...view.config } : view.config
```

The less visible declaration wins. Read back from the configs ETL actually sent (`multi_dim_data_pages.config`), the 10 `education` MDIMs pinned `011` in YAML but stored **239 published views as `008`**.

### Changes

- **Drop the remaining 11 view-level `$schema` entries** — 10 × `education/*.py` at `008`, plus `vaccination_introductions.py` which set it to `DEFAULT_GRAPHER_SCHEMA` (same anti-pattern, currently correct). Those MDIMs now inherit `011` from their collection pin.
- **Warn at `save()`** when a view config shadows the collection pin, so a future copy-paste is visible rather than silent.

`grep -rn '\$schema' etl/steps/export/multidim` is now empty: every MDIM declares its version in exactly one place, on line 1 of its config YAML. That also makes the cheap YAML-based check correct — previously you had to read the generated JSON, since two sources could disagree.

### Verification

Output is unchanged. All 20 education config dicts were run through grapher's own `migrateGrapherConfigToLatestVersion`:

```
20 configs checked, 0 altered by migration (ignoring $schema itself)
```

so declaring `011` instead of `008` produces byte-identical view configs. 187 collection/schema tests pass, `make check` and `make docs.pre` green.

### Effective pin, before this PR (all MDIMs, published + unpublished)

| effective pin | views | where |
|---|---|---|
| `011` | 4090 | working as intended |
| `008` | 239 | 10 published `education` MDIMs — fixed here |
| `007` | 20 | one orphaned row (below) |
| none | 5162 | 8 orphaned rows (below) |

### Not fixed here: 9 orphaned DB rows

No active step produces these, so no config edit reaches them — they need deleting (or, for two of them, their step re-enabling). Reported, not touched, since deleting MDIM rows plus their `chart_configs` is a production mutation and the "stale" call rests on name matching:

| Row | views | why unpinned |
|---|---|---|
| `health/latest/causes_of_death#causes_of_death` | 5034 | config YAML exists but no `.py`; DAG entry commented out |
| `health/…/vaccination_introductions#mdd-vaccination-introductions-who` | 20 | old slug-style name; carries view `$schema: 007` |
| `health/…/vaccination_coverage#mdd-vaccination-who` | 47 | old slug-style name |
| `wb/latest/world_bank_pip#poverty` | 44 | renamed → `wb/latest/poverty_pip` |
| `covid/latest/covid#dummy` / `#test_combined` / `#covid_boosters` | 18 / 12 / 2 | no YAML |
| `covid/latest/covid#covid_vax_breakdowns` | 2 | YAML exists, commented out in `covid.py` |
| `worldbank_wdi/latest/wdi#ilostat_national_vs_modeled` | 3 | renamed → `ilostat_comparison` |

Every MDIM an active step *does* produce is pinned at `011` — 40 published + 29 unpublished.
