### PR TITLE
🐛 Use Epoch's model registry for FrontierMath model names

### DIFF
--- a/etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.model_names.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.model_names.yml
@@ -1,0 +1,12 @@
+# Model names we set ourselves, keyed on Epoch's "Model version" string.
+#
+# Names normally come from Epoch's own model registry (`epoch_capabilities_index.csv`, shipped in the same
+# snapshot archive as the benchmark). Add an entry here only when that registry cannot tell two models
+# apart, or when the name it gives is unusable in a chart. The step asserts that no two models end up with
+# the same name, so a new clash fails the build instead of quietly merging them into one entity.
+#
+# The context window or reasoning effort is still appended automatically, so write the model name alone.
+names:
+  # Epoch calls both the preview and the general-availability build "Gemini 2.5 Pro (Jun 2025)", and neither
+  # version string carries a date, so nothing else separates them.
+  gemini-2.5-pro-preview-06-05: Gemini 2.5 Pro (preview)

--- a/etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.py
+++ b/etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.py
@@ -1,207 +1,91 @@
-"""Process FrontierMath benchmark data for garden step."""
+"""Process FrontierMath benchmark data for garden step.
+
+Entities are individual model evaluations, named from Epoch's own model registry rather than parsed out of
+its version strings. The registry (`epoch_capabilities_index.csv`) travels in the same snapshot archive as
+the benchmark itself and covers every model version Epoch publishes a benchmark score for.
+"""
 
 import re
 from datetime import datetime
 
+import pandas as pd
+from owid.catalog import Table
+from owid.catalog import processing as pr
+from structlog import get_logger
+
+from etl.files import ruamel_load
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-# Pre-compile regex patterns for performance
-PATTERNS = {
-    "date": re.compile(r"(\d{4})-?(\d{2})-?(\d{2})"),
-    "context_size": re.compile(r"(\d+K|max)$"),
-    "claude_numeric": re.compile(r"claude-(\d+)-(\d+)-(\w+)", re.IGNORECASE),
-    "claude_variant": re.compile(r"claude-(\w+)-(\d+(?:\.\d+)?)", re.IGNORECASE),
-    "gpt_version": re.compile(r"gpt-([\d.]+)(?:-(\w+))?", re.IGNORECASE),
-    "gpt_fallback": re.compile(r"gpt-(\w+)", re.IGNORECASE),
-    "grok": re.compile(r"grok-(\d+)(?:-(\w+))?(?:-(\w+))?", re.IGNORECASE),
-    "o_model": re.compile(r"(o\d+)(?:-(\w+))?"),
-    "gemini": re.compile(r"gemini-([\d.]+)-?(\w+)?-?(\w+)?", re.IGNORECASE),
-    "deepseek": re.compile(r"deepseek-?(.+)?", re.IGNORECASE),
-    "mistral": re.compile(r"mistral-(\w+)-(\d+)", re.IGNORECASE),
-    "qwen": re.compile(r"qwen(\d+)?-?(.+)?", re.IGNORECASE),
-    "kimi": re.compile(r"kimi-?(.+)?", re.IGNORECASE),
-    "llama": re.compile(r"llama-(\d+)-?(.+)?", re.IGNORECASE),
-    "glm": re.compile(r"glm-([\d.]+)", re.IGNORECASE),
-}
+log = get_logger()
+
+# Some model version strings embed the build date ("claude-opus-4-5-20251101"). It is occasionally the only
+# thing separating two evaluations that Epoch gives the same name — both GPT-4o builds are called "GPT-4o" —
+# so it has to survive into the entity name.
+DATE_IN_VERSION = re.compile(r"(\d{4})-?(\d{2})-?(\d{2})")
+
+# Epoch is inconsistent about putting the date in its own names: "Claude 3.5 Sonnet (October 2024)" for one
+# build, plain "Claude 3.5 Sonnet" for another. Don't append a second date to the ones that already have one.
+DATE_IN_NAME = re.compile(r"\((?:[A-Z][a-z]{2,9}\s+)?\d{4}\)\s*$")
 
 
-def _extract_metadata(model_version: str) -> tuple[str, str, str, bool]:
-    """Extract date, suffixes, and clean model name from version string."""
-    # Handle paths first
-    if "/" in model_version:
-        model_version = model_version.split("/")[-1]
-
-    # Extract performance suffix (_high, _medium, _low, _xhigh, etc.)
-    perf_suffix = ""
-    if "_" in model_version:
-        parts = model_version.rsplit("_", 1)
-        suffix_word = parts[1].lower()
-        if suffix_word in {"high", "medium", "low", "xhigh", "xlow"}:
-            model_version = parts[0]
-            perf_suffix = f", {parts[1]}"
-
-    # Extract date
-    date_str = ""
-    has_date = False
-    date_match = PATTERNS["date"].search(model_version)
-    if date_match:
-        try:
-            year, month, day = date_match.groups()
-            date_obj = datetime(int(year), int(month), int(day))
-            date_str = f" ({date_obj.strftime('%b %Y')})"
-            has_date = True
-            model_version = PATTERNS["date"].sub("", model_version).rstrip("-")
-        except ValueError:
-            pass
-
-    # Extract context size suffix (_16K, _32K, etc.)
-    context_suffix = ""
-    if "_" in model_version:
-        parts = model_version.rsplit("_", 1)
-        if PATTERNS["context_size"].match(parts[1]):
-            context_suffix = f", {parts[1]}"
-            model_version = parts[0]
-
-    return model_version, date_str, f"{context_suffix}{perf_suffix}", has_date
+def date_suffix(model_version: str) -> str:
+    """Render the build date embedded in a model version string, e.g. " (Nov 2025)"."""
+    match = DATE_IN_VERSION.search(model_version)
+    if match is None:
+        return ""
+    year, month, day = match.groups()
+    try:
+        return datetime(int(year), int(month), int(day)).strftime(" (%b %Y)")
+    except ValueError:
+        return ""
 
 
-def _format_claude(model_version: str) -> str:
-    """Format Claude model names."""
-    # Try numeric pattern first (claude-3-5-sonnet)
-    match = PATTERNS["claude_numeric"].match(model_version)
-    if match:
-        return f"Claude {match.group(1)}.{match.group(2)} {match.group(3).title()}"
-    # Try variant pattern (claude-opus-4)
-    match = PATTERNS["claude_variant"].match(model_version)
-    if match:
-        return f"Claude {match.group(1).title()} {match.group(2)}"
-    return model_version
+def setting_suffix(model_version: str) -> str:
+    """Render the context window or reasoning effort Epoch appends after an underscore, e.g. ", max".
+
+    Everything after the first underscore is kept verbatim. The vocabulary is open-ended (max, xhigh, none,
+    unknown, minimal, 32K, ...) and dropping a token we don't recognize would merge two evaluations of the
+    same model into a single entity.
+    """
+    _, _, setting = model_version.partition("_")
+    return f", {setting}" if setting else ""
 
 
-def _format_gpt(model_version: str) -> str:
-    """Format GPT model names."""
-    match = PATTERNS["gpt_version"].match(model_version)
-    if match:
-        variant = f" {match.group(2)}" if match.group(2) else ""
-        return f"GPT {match.group(1)}{variant}"
-    match = PATTERNS["gpt_fallback"].match(model_version)
-    return f"GPT {match.group(1)}" if match else model_version
+def build_model_name(model_version: str, epoch_name: str | None, overrides: dict[str, str]) -> str:
+    """Compose the entity name for one evaluation: model name, build date if needed, then the setting."""
+    if model_version in overrides:
+        return f"{overrides[model_version]}{setting_suffix(model_version)}"
 
-
-def _format_grok(model_version: str) -> str:
-    """Format Grok model names."""
-    match = PATTERNS["grok"].match(model_version)
-    if match:
-        # Filter out date-like patterns (4-8 digit numbers)
-        variants = "".join(f" {g}" for g in match.groups()[1:] if g and not (g.isdigit() and 4 <= len(g) <= 8))
-        return f"Grok {match.group(1)}{variants}"
-    return model_version
-
-
-def _format_mistral(model_version: str) -> str:
-    """Format Mistral model names with date parsing."""
-    match = PATTERNS["mistral"].match(model_version)
-    if match:
-        variant = match.group(1).title()
-        year_month = match.group(2)
-        if len(year_month) == 4:
-            try:
-                date_obj = datetime(int(f"20{year_month[:2]}"), int(year_month[2:]), 1)
-                return f"Mistral {variant} ({date_obj.strftime('%b %Y')})"
-            except ValueError:
-                pass
-        return f"Mistral {variant}"
-    return model_version
-
-
-def _format_generic(pattern_name: str, prefix: str, model_version: str) -> str:
-    """Format models with simple patterns."""
-    match = PATTERNS[pattern_name].match(model_version)
-    if not match:
+    if epoch_name is None or pd.isna(epoch_name):
+        # Epoch curates no name for a handful of older open-weight checkpoints. Show its version string
+        # rather than guessing at one: unlovely, but unambiguous and conspicuous enough to get fixed.
         return model_version
 
-    groups = [g for g in match.groups() if g]
-    if not groups:
-        return prefix
-
-    if pattern_name == "gemini":
-        variants = "".join(f" {g.title()}" if i == 1 else f" {g}" for i, g in enumerate(groups[1:], 1))
-        return f"{prefix} {groups[0]}{variants}"
-    elif pattern_name in {"qwen", "llama"}:
-        version = groups[0] if len(groups) > 0 else ""
-        if len(groups) > 1:
-            # Filter out date-like patterns (4-8 digit numbers at the end)
-            variant_parts = groups[1].split("-")
-            variant_parts = [p for p in variant_parts if not (p.isdigit() and 4 <= len(p) <= 8)]
-            variant = " ".join(variant_parts).title()
-        else:
-            variant = ""
-        return f"{prefix}{version} {variant}".strip()
-    elif pattern_name in {"deepseek", "kimi"}:
-        variant = groups[0].replace("-", " ").title() if groups else ""
-        return f"{prefix} {variant}".strip() if variant else prefix
-    elif pattern_name == "o_model":
-        variant = f" {groups[1]}" if len(groups) > 1 else ""
-        return f"{groups[0]}{variant}"
-    elif pattern_name == "glm":
-        return f"{prefix} {groups[0]}"
-
-    return model_version
+    date = "" if DATE_IN_NAME.search(epoch_name) else date_suffix(model_version)
+    return f"{epoch_name}{date}{setting_suffix(model_version)}"
 
 
-def format_model_name(model_version: str) -> str:
-    """
-    Format technical model names into human-readable format.
+def sanity_check_inputs(tb: Table, tb_registry: Table) -> None:
+    """Check the benchmark table and the model registry before joining them."""
+    assert not tb[["model_version", "release_date"]].isna().any().any(), "Benchmark rows are missing a key."
+    assert not tb_registry.duplicated("model_version").any(), "Model registry lists a version twice."
+    # Scores are published as fractions. If Epoch ever switched to percentages, multiplying by 100 below
+    # would silently put every model at a hundred times its real score.
+    assert tb["mean_score"].between(0, 1).all(), "Scores outside 0-1: are they still published as fractions?"
 
-    Examples:
-        claude-3-5-sonnet-20240620 -> Claude 3.5 Sonnet (Jun 2024)
-        gpt-4o-2024-08-06 -> GPT-4o (Aug 2024)
-        o1-mini-2024-09-12_high -> o1-mini (Sep 2024, high)
-        grok-3-mini-beta_high -> Grok 3-mini-beta (high)
-    """
-    # Extract metadata
-    model_version, date_str, suffix_str, has_date = _extract_metadata(model_version)
 
-    # Dispatch to appropriate formatter based on model family
-    model_lower = model_version.lower()
-
-    if "claude" in model_lower:
-        model_name = _format_claude(model_version)
-    elif model_version.startswith("gpt-"):
-        model_name = _format_gpt(model_version)
-    elif "grok" in model_lower:
-        model_name = _format_grok(model_version)
-    elif model_version.startswith("o") and model_version[1:2].isdigit():
-        model_name = _format_generic("o_model", "", model_version)
-    elif "gemini" in model_lower:
-        model_name = _format_generic("gemini", "Gemini", model_version)
-    elif "deepseek" in model_lower:
-        model_name = _format_generic("deepseek", "DeepSeek", model_version)
-    elif "mistral" in model_lower:
-        model_name = _format_mistral(model_version)
-    elif "qwen" in model_lower:
-        model_name = _format_generic("qwen", "Qwen", model_version)
-    elif "kimi" in model_lower:
-        model_name = _format_generic("kimi", "Kimi", model_version)
-    elif "llama" in model_lower:
-        model_name = _format_generic("llama", "Llama", model_version)
-    elif "glm" in model_lower:
-        model_name = _format_generic("glm", "GLM", model_version)
-    else:
-        model_name = model_version
-
-    # Combine date and suffixes
-    if has_date:
-        final_name = f"{model_name}{date_str}{suffix_str}"
-    elif suffix_str:
-        final_name = f"{model_name}{suffix_str}"
-    else:
-        final_name = model_name
-
-    return final_name.strip()
+def sanity_check_outputs(tb: Table) -> None:
+    """Check that no two models were given the same name, and that the scores survived processing."""
+    models = tb[["model_version", "model_name"]].drop_duplicates()
+    collisions = models[models.duplicated("model_name", keep=False)].sort_values("model_name")
+    # Two models sharing a name become one entity holding several observations, which grapher renders as a
+    # single connected series instead of separate points. Pin one of them in the overrides file.
+    assert collisions.empty, f"Distinct models share a name:\n{collisions.to_string(index=False)}"
+    assert tb["mean_score"].between(0, 100).all(), "Scores outside 0-100%."
+    assert tb.columns[tb.isna().all()].empty, "Output has a fully empty column."
 
 
 def run() -> None:
@@ -212,16 +96,38 @@ def run() -> None:
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("frontiermath")
 
-    # Read table from meadow dataset.
+    # Read tables from meadow dataset.
     tb = ds_meadow.read("epoch_benchmark_data")
+    tb_registry = ds_meadow.read("model_registry")
+
+    # Load the names we set ourselves, where the registry cannot or should not decide.
+    with paths.side_file(f"{paths.short_name}.model_names.yml").open() as f:
+        overrides = ruamel_load(f)["names"] or {}
+
+    sanity_check_inputs(tb, tb_registry)
 
     #
     # Process data.
     #
     tb["mean_score"] = tb["mean_score"] * 100
 
-    # Format model names to be human-readable
-    tb["model_version"] = tb["model_version"].apply(format_model_name)
+    # Name each evaluation from Epoch's registry.
+    evaluations = len(tb)
+    tb = pr.merge(tb, tb_registry, on="model_version", how="left")
+    assert len(tb) == evaluations, "The registry join changed the number of evaluations."
+
+    unnamed = sorted(set(tb.loc[tb["model_name"].isna(), "model_version"]))
+    if unnamed:
+        log.warning(f"Not in Epoch's model registry, falling back to the version string: {unnamed}")
+
+    tb["model_name"] = [
+        build_model_name(version, name, overrides) for version, name in zip(tb["model_version"], tb["model_name"])
+    ]
+
+    sanity_check_outputs(tb)
+
+    tb["model_version"] = tb["model_name"]
+    tb = tb.drop(columns=["model_name"])
 
     tb = tb.format(["release_date", "model_version"])
     #

--- a/etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.py
+++ b/etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.py
@@ -6,11 +6,12 @@ the benchmark itself and covers every model version Epoch publishes a benchmark 
 """
 
 import re
+from collections import defaultdict
+from collections.abc import Iterable
 from datetime import datetime
 
 import pandas as pd
 from owid.catalog import Table
-from owid.catalog import processing as pr
 from structlog import get_logger
 
 from etl.files import ruamel_load
@@ -68,8 +69,13 @@ def build_model_name(model_version: str, epoch_name: str | None, overrides: dict
     return f"{epoch_name}{date}{setting_suffix(model_version)}"
 
 
+def build_model_names(model_versions: Iterable[str], epoch_names: dict, overrides: dict[str, str]) -> dict[str, str]:
+    """Map every model version in the benchmark to the name it is shown under."""
+    return {version: build_model_name(version, epoch_names.get(version), overrides) for version in model_versions}
+
+
 def sanity_check_inputs(tb: Table, tb_registry: Table) -> None:
-    """Check the benchmark table and the model registry before joining them."""
+    """Check the benchmark table and the model registry before using them."""
     assert not tb[["model_version", "release_date"]].isna().any().any(), "Benchmark rows are missing a key."
     assert not tb_registry.duplicated("model_version").any(), "Model registry lists a version twice."
     # Scores are published as fractions. If Epoch ever switched to percentages, multiplying by 100 below
@@ -77,13 +83,21 @@ def sanity_check_inputs(tb: Table, tb_registry: Table) -> None:
     assert tb["mean_score"].between(0, 1).all(), "Scores outside 0-1: are they still published as fractions?"
 
 
-def sanity_check_outputs(tb: Table) -> None:
-    """Check that no two models were given the same name, and that the scores survived processing."""
-    models = tb[["model_version", "model_name"]].drop_duplicates()
-    collisions = models[models.duplicated("model_name", keep=False)].sort_values("model_name")
+def sanity_check_names(names: dict[str, str]) -> None:
+    """Check that no two models were given the same name."""
+    versions_by_name = defaultdict(list)
+    for version, name in names.items():
+        versions_by_name[name].append(version)
+    collisions = {name: versions for name, versions in versions_by_name.items() if len(versions) > 1}
     # Two models sharing a name become one entity holding several observations, which grapher renders as a
     # single connected series instead of separate points. Pin one of them in the overrides file.
-    assert collisions.empty, f"Distinct models share a name:\n{collisions.to_string(index=False)}"
+    assert not collisions, "Distinct models share a name:\n" + "\n".join(
+        f"  {name!r} <- {versions}" for name, versions in sorted(collisions.items())
+    )
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    """Check that the scores survived processing."""
     assert tb["mean_score"].between(0, 100).all(), "Scores outside 0-100%."
     assert tb.columns[tb.isna().all()].empty, "Output has a fully empty column."
 
@@ -111,23 +125,18 @@ def run() -> None:
     #
     tb["mean_score"] = tb["mean_score"] * 100
 
-    # Name each evaluation from Epoch's registry.
-    evaluations = len(tb)
-    tb = pr.merge(tb, tb_registry, on="model_version", how="left")
-    assert len(tb) == evaluations, "The registry join changed the number of evaluations."
+    # Rename each model version to the name Epoch gives it in its registry.
+    epoch_names = tb_registry.set_index("model_version")["model_name"].to_dict()
+    names = build_model_names(tb["model_version"].unique(), epoch_names, overrides)
+    sanity_check_names(names)
 
-    unnamed = sorted(set(tb.loc[tb["model_name"].isna(), "model_version"]))
+    unnamed = sorted(version for version in names if pd.isna(epoch_names.get(version)))
     if unnamed:
         log.warning(f"Not in Epoch's model registry, falling back to the version string: {unnamed}")
 
-    tb["model_name"] = [
-        build_model_name(version, name, overrides) for version, name in zip(tb["model_version"], tb["model_name"])
-    ]
+    tb["model_version"] = tb["model_version"].map(names)
 
     sanity_check_outputs(tb)
-
-    tb["model_version"] = tb["model_name"]
-    tb = tb.drop(columns=["model_name"])
 
     tb = tb.format(["release_date", "model_version"])
     #

--- a/etl/steps/data/meadow/artificial_intelligence/2026-01-30/frontiermath.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2026-01-30/frontiermath.py
@@ -19,6 +19,9 @@ def run() -> None:
     # Extract frontiermath.csv from the zip file.
     with snap.extracted() as archive:
         tb = archive.read("frontiermath.csv", safe_types=False)
+        # Epoch's model registry ships in the same archive and maps every model version string used across
+        # its benchmark files to a curated human-readable name.
+        tb_registry = archive.read("epoch_capabilities_index.csv", safe_types=False)
 
     tb = tb.reset_index(drop=True)
 
@@ -27,8 +30,18 @@ def run() -> None:
 
     tb = tb.format(["release_date", "model_version"])
 
+    # Keep only the name; the registry's "Display name" column is populated for about half its rows, so it
+    # cannot be relied on to name every model.
+    tb_registry = tb_registry.reset_index(drop=True)
+    tb_registry = tb_registry[["Model version", "Model name"]]
+    # Every table read from an archive is named after the snapshot, so the second one needs an explicit
+    # short name to avoid clashing with the benchmark table.
+    tb_registry = tb_registry.format(["model_version"], short_name="model_registry")
+
     #
     # Save outputs.
     #
-    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(
+        tables=[tb, tb_registry], check_variables_metadata=True, default_metadata=snap.metadata
+    )
     ds_meadow.save()

--- a/tests/test_frontiermath_model_names.py
+++ b/tests/test_frontiermath_model_names.py
@@ -60,21 +60,26 @@ def test_model_missing_from_the_registry_falls_back_to_its_version_string():
 def test_sanity_check_rejects_two_models_with_one_name():
     step = load_step_module()
 
-    def output(names):
-        return Table(
-            pd.DataFrame(
-                {
-                    "model_version": ["claude-opus-4-6_max", "claude-opus-4-8_max"],
-                    "model_name": names,
-                    "mean_score": [40.7, 47.2],
-                }
-            )
+    with pytest.raises(AssertionError, match="share a name"):
+        step.sanity_check_names(
+            {"claude-opus-4-6_max": "Claude Opus 4, max", "claude-opus-4-8_max": "Claude Opus 4, max"}
         )
 
-    with pytest.raises(AssertionError, match="share a name"):
-        step.sanity_check_outputs(output(["Claude Opus 4, max", "Claude Opus 4, max"]))
+    step.sanity_check_names(
+        {"claude-opus-4-6_max": "Claude Opus 4.6, max", "claude-opus-4-8_max": "Claude Opus 4.8, max"}
+    )
 
-    step.sanity_check_outputs(output(["Claude Opus 4.6, max", "Claude Opus 4.8, max"]))
+
+def test_build_model_names_covers_every_version():
+    step = load_step_module()
+    epoch_names = {"claude-opus-4-6_max": "Claude Opus 4.6", "claude-opus-4-8_max": "Claude Opus 4.8"}
+    names = step.build_model_names(epoch_names, epoch_names, {})
+    assert names == {
+        "claude-opus-4-6_max": "Claude Opus 4.6, max",
+        "claude-opus-4-8_max": "Claude Opus 4.8, max",
+    }
+    # A version the registry has never heard of still gets an entry, so nothing silently drops out.
+    assert step.build_model_names(["mystery-model"], epoch_names, {}) == {"mystery-model": "mystery-model"}
 
 
 def test_sanity_check_rejects_scores_that_are_no_longer_fractions():

--- a/tests/test_frontiermath_model_names.py
+++ b/tests/test_frontiermath_model_names.py
@@ -1,0 +1,96 @@
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from owid.catalog import Table
+
+STEP_PATH = Path(__file__).parents[1] / "etl/steps/data/garden/artificial_intelligence/2026-01-30/frontiermath.py"
+
+
+def load_step_module():
+    spec = importlib.util.spec_from_file_location("frontiermath", STEP_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_minor_version_survives():
+    step = load_step_module()
+    # Two builds Epoch names apart must not end up as one entity.
+    assert step.build_model_name("claude-opus-4-6_max", "Claude Opus 4.6", {}) == "Claude Opus 4.6, max"
+    assert step.build_model_name("claude-opus-4-8_max", "Claude Opus 4.8", {}) == "Claude Opus 4.8, max"
+
+
+def test_build_date_is_appended_only_when_the_name_lacks_one():
+    step = load_step_module()
+    # Epoch reuses one name for both GPT-4o builds, so the date in the version string does the separating.
+    assert step.build_model_name("gpt-4o-2024-08-06", "GPT-4o", {}) == "GPT-4o (Aug 2024)"
+    assert step.build_model_name("gpt-4o-2024-11-20", "GPT-4o", {}) == "GPT-4o (Nov 2024)"
+    # ...but Epoch sometimes dates the name itself, and then a second date would be appended on top.
+    name = "Claude 3.5 Sonnet (October 2024)"
+    assert step.build_model_name("claude-3-5-sonnet-20241022", name, {}) == name
+
+
+def test_unrecognized_setting_is_kept():
+    step = load_step_module()
+    # "none" is outside the usual high/medium/low vocabulary; dropping it would merge this evaluation with
+    # a bare "gpt-5.1-2025-11-13" run.
+    assert step.build_model_name("gpt-5.1-2025-11-13_none", "GPT-5.1", {}) == "GPT-5.1 (Nov 2025), none"
+
+
+def test_override_replaces_the_name_but_keeps_the_setting():
+    step = load_step_module()
+    overrides = {"gemini-2.5-pro-preview-06-05": "Gemini 2.5 Pro (preview)"}
+    assert step.build_model_name("gemini-2.5-pro-preview-06-05", "Gemini 2.5 Pro (Jun 2025)", overrides) == (
+        "Gemini 2.5 Pro (preview)"
+    )
+    assert step.build_model_name("claude-opus-4-6_max", "Claude Opus 4.6", {"claude-opus-4-6_max": "Opus"}) == (
+        "Opus, max"
+    )
+
+
+def test_model_missing_from_the_registry_falls_back_to_its_version_string():
+    step = load_step_module()
+    assert step.build_model_name("Baichuan2-13B-Chat", None, {}) == "Baichuan2-13B-Chat"
+    assert step.build_model_name("Baichuan2-13B-Chat", pd.NA, {}) == "Baichuan2-13B-Chat"
+
+
+def test_sanity_check_rejects_two_models_with_one_name():
+    step = load_step_module()
+
+    def output(names):
+        return Table(
+            pd.DataFrame(
+                {
+                    "model_version": ["claude-opus-4-6_max", "claude-opus-4-8_max"],
+                    "model_name": names,
+                    "mean_score": [40.7, 47.2],
+                }
+            )
+        )
+
+    with pytest.raises(AssertionError, match="share a name"):
+        step.sanity_check_outputs(output(["Claude Opus 4, max", "Claude Opus 4, max"]))
+
+    step.sanity_check_outputs(output(["Claude Opus 4.6, max", "Claude Opus 4.8, max"]))
+
+
+def test_sanity_check_rejects_scores_that_are_no_longer_fractions():
+    step = load_step_module()
+    inputs = Table(
+        pd.DataFrame(
+            {
+                "model_version": ["claude-opus-4-8_max"],
+                "release_date": ["2026-05-28"],
+                "mean_score": [47.24],
+            }
+        )
+    )
+    registry = Table(pd.DataFrame({"model_version": ["claude-opus-4-8_max"], "model_name": ["Claude Opus 4.8"]}))
+    with pytest.raises(AssertionError, match="still published as fractions"):
+        step.sanity_check_inputs(inputs, registry)
+
+    inputs["mean_score"] = [0.4724]
+    step.sanity_check_inputs(inputs, registry)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

FrontierMath model names were parsed out of Epoch's version strings with per-vendor regexes. `claude_variant` is unanchored, so `claude-opus-4-8` matched only `claude-opus-4` and the minor version was dropped — **making Claude Opus 4.6 and Opus 4.8 the same entity**. Six other classes of mangling came with it: `gpt-4o` → "GPT 4", `qwen3.5-plus` → "Qwen3 .5 Plus", `qwen-max` → "Qwenmax", `gpt-5.1-…_none` → "GPT 5.1 _none (Nov 2025)". 35 of 101 rows affected, 34 of them already live.

Epoch publishes a curated name for every model in `epoch_capabilities_index.csv`, inside the benchmark archive we already download — 839 models, covering all 101 rows here. So the regexes are gone: meadow reads the registry as a second table, and garden composes `Model name` + the build date (only when Epoch's own name doesn't already carry one) + the context/effort setting.

Two safeguards replace the guessing. `frontiermath.model_names.yml` holds names we set ourselves — one entry today, for the Gemini 2.5 Pro preview that Epoch names identically to the GA build. And an assert fails the step if two models ever end up sharing a name: that's the case that turns two models into one entity with several observations, which grapher draws as a single connected arrow instead of separate points. It is what the pending Epoch refresh in #6336 would otherwise have done to Opus 4.6 and 4.8, so **merge this first** and let that refresh rebuild with the two already distinct.

## Verification

- Staging rebuilt the chain: 82 of 100 labels renamed on the current snapshot (83 of 101 on #6336's).
- `build_model_name` run over both the current snapshot and #6336's: no two models share a name in either, and every model is named by the registry.
- 7 unit tests in `tests/test_frontiermath_model_names.py`; `make check` clean.
- `ai-frontiermath-over-time` re-renders on staging with all nine of its labelled series, and no connected-arrow series.

## Open items

- **The chart diff needs approving.** 10 of the 12 entities pinned in `ai-frontiermath-over-time`'s `selectedEntityNames` are renamed by this PR. I've rewritten them on staging, but if the diff isn't approved, chart-sync skips the config and production keeps a selection pointing at ten entities that no longer exist — the chart quietly drops to two series.
- **Nothing flagged that automatically.** chart-diff reported "No charts for review" after the rename landed on staging: the dataset's `dataEditedAt` predates the staging server's creation, so `get_charts_with_modified_data` filtered it out. The chart only surfaced once its config changed. Worth a look separately — an entity rename that silently empties a chart's selection is exactly what chart-diff should be catching.
- **Preview markers.** Epoch's names drop "preview"/"pre-release" on 6 rows (3 Gemini previews, 3 GPT-5.5 pre-release runs). Left as Epoch has them — they don't collide today, and the assert will catch it when a GA build lands.
- No adversarial data review or empty-entity audit: this changes entity labels only, adds no dataset version, and remaps no indicators.
