### PR TITLE
🔨 Render wizard charts with the grapher npm package

### DIFF
--- a/apps/wizard/utils/components.py
+++ b/apps/wizard/utils/components.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import random
 import re
 import urllib.parse
@@ -23,6 +24,16 @@ from etl.config import OWID_ENV, OWIDEnv
 from etl.grapher.model import Variable
 
 log = get_logger()
+
+# Grapher is consumed as a published npm package (`@ourworldindata/grapher`). The built
+# bundles of every release are also served on our Tailnet, which is all a browser needs —
+# unlike the npm registry, these URLs require no auth token. Set GRAPHER_PACKAGE_URL to
+# pin a version (e.g. .../ourworldindata/grapher/v0.1.0) instead of tracking the latest.
+GRAPHER_PACKAGE_URL = os.environ.get(
+    "GRAPHER_PACKAGE_URL",
+    "https://owid-packages.tail6e23.ts.net/ourworldindata/grapher/latest",
+).rstrip("/")
+
 
 HORIZONTAL_STYLE = """<style class="hide-element">
     /* Hides the style container and removes the extra spacing */
@@ -175,6 +186,33 @@ def mdim_chart(url: str, view: dict, height: int = 600, default_display: str | N
     return st.iframe(f"{url}{query_string}", height=height, width=int(1.6 * height))
 
 
+def _grapher_html(chart_config: dict[str, Any], owid_env: OWIDEnv, height: int = 600) -> str:
+    """Build the HTML that mounts a Grapher chart with the `@ourworldindata/grapher` package."""
+    config = deepcopy(chart_config)
+
+    # Env-specific URLs Grapher uses for its share / embed / edit links.
+    config["bakedGrapherURL"] = f"{owid_env.base_site}/grapher"
+    config["adminBaseUrl"] = owid_env.base_site
+
+    return f"""
+    <link rel="stylesheet" href="https://ourworldindata.org/fonts.css" />
+    <link rel="stylesheet" href="{GRAPHER_PACKAGE_URL}/grapher.css" />
+    <style>
+        html, body {{ margin: 0; padding: 0; }}
+        /* The chart fills its container, so the container needs an explicit size. */
+        #grapher {{ width: 100%; height: {height}px; }}
+    </style>
+    <div id="grapher"></div>
+    <script type="module">
+        import {{ GrapherLoader }} from "{GRAPHER_PACKAGE_URL}/grapher.standalone.min.js";
+        GrapherLoader.fromApi({{
+            config: {json.dumps(config, default=default_converter)},
+            dataApiUrl: "{owid_env.indicators_url}/",
+        }}).mount(document.getElementById("grapher"));
+    </script>
+    """
+
+
 def _chart_html(chart_config: dict[str, Any], owid_env: OWIDEnv, height=600, **kwargs):
     """Plot a Grapher chart using the Grapher API.
 
@@ -185,26 +223,7 @@ def _chart_html(chart_config: dict[str, Any], owid_env: OWIDEnv, height=600, **k
     owid_env : OWIDEnv
         Environment configuration. This is needed to access the correct API (changes between servers).
     """
-    chart_config_tmp = deepcopy(chart_config)
-
-    chart_config_tmp["bakedGrapherURL"] = f"{owid_env.base_site}/grapher"
-    chart_config_tmp["adminBaseUrl"] = owid_env.base_site
-    chart_config_tmp["dataApiUrl"] = f"{owid_env.indicators_url}/"
-
-    HTML = f"""
-    <link href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i|Playfair+Display:400,700&amp;display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="https://ourworldindata.org/assets/owid.css" />
-    <div class="StandaloneGrapherOrExplorerPage">
-        <main>
-            <figure data-grapher-src></figure>
-        </main>
-        <script> document.cookie = "isAdmin=true;max-age=31536000" </script>
-        <script type="module" src="https://ourworldindata.org/assets/owid.mjs"></script>
-        <script type="module">
-            var jsonConfig = {json.dumps(chart_config_tmp, default=default_converter)}; window.renderSingleGrapherOnGrapherPage({{ config: jsonConfig, dataApiUrl: "{owid_env.data_api_url}/v1/indicators/", catalogUrl: "{owid_env.catalog_url}" }});
-        </script>
-    </div>
-    """
+    HTML = _grapher_html(chart_config, owid_env, height=height)
 
     components.html(HTML, height=height, width=int(1.6 * height), **kwargs)
 

--- a/tests/apps/wizard/utils/test_components.py
+++ b/tests/apps/wizard/utils/test_components.py
@@ -1,9 +1,12 @@
+import json
+import re
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 import streamlit as st
 
-from apps.wizard.utils.components import url_persist
+from apps.wizard.utils.components import GRAPHER_PACKAGE_URL, _grapher_html, url_persist
 
 
 @pytest.fixture
@@ -153,3 +156,35 @@ def test_url_persist_invalid_option_raises_value_error(mock_component, mock_quer
             wrapped(key="color", options=["blue", "green"])
 
         assert "not in options" in str(exc_info.value)
+
+
+class MockEnv:
+    """The only two OWIDEnv attributes `_grapher_html` reads."""
+
+    base_site = "http://staging-site-my-branch"
+    indicators_url = "https://api-staging.owid.io/staging-site-my-branch/v1/indicators"
+
+
+def test_grapher_html_mounts_the_grapher_package():
+    """The chart is rendered by the published `@ourworldindata/grapher` bundle, fed the
+    env's own data API and a config that survives the round-trip to JSON."""
+    html = _grapher_html(
+        {"title": "Life expectancy", "dimensions": [{"property": "y", "variableId": np.int64(42)}]},
+        MockEnv(),
+        height=480,
+    )  # ty: ignore[invalid-argument-type]
+
+    assert f'import {{ GrapherLoader }} from "{GRAPHER_PACKAGE_URL}/grapher.standalone.min.js"' in html
+    assert f'href="{GRAPHER_PACKAGE_URL}/grapher.css"' in html
+    assert f'dataApiUrl: "{MockEnv.indicators_url}/"' in html
+    assert "height: 480px" in html
+
+    match = re.search(r"config: (\{.*\}),\n", html)
+    assert match is not None, "config is not embedded as a single-line JSON object"
+    config = json.loads(match.group(1))
+
+    # numpy ints (which come out of the grapher DB) must not break serialization
+    assert config["dimensions"] == [{"property": "y", "variableId": 42}]
+    # Grapher builds its share / embed / edit links from these
+    assert config["adminBaseUrl"] == MockEnv.base_site
+    assert config["bakedGrapherURL"] == f"{MockEnv.base_site}/grapher"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Every chart the wizard draws (chart-diff, anomalist, narrative-chart comparison) was rendered by pulling the live site's `owid.mjs` bundle off ourworldindata.org and calling `window.renderSingleGrapherOnGrapherPage` — an undocumented global we don't own and that nothing guarantees will keep its signature. Now that Grapher ships as a package, this switches those charts to `GrapherLoader` from `@ourworldindata/grapher`, loaded from the release bundles on our Tailnet. The rendered chart is unchanged; what changes is where the JS comes from.

_Skim — one function. The one thing worth a real look is the Tailnet dependency under "Consequence"._

## How it works

`_chart_html`'s body moved into a pure `_grapher_html(config, env, height)` (so it's testable without Streamlit) and now emits:

```js
GrapherLoader.fromApi({ config, dataApiUrl: "<env>/v1/indicators/" }).mount(el)
```

`fromApi` needs the config's `dimensions` to know which indicators to fetch — every config we pass has them (`bake_chart_config` always writes one, DB chart configs and narrative-chart `configFull` carry theirs). A config without `dimensions` renders an empty chart rather than throwing: `fetchInputTableForConfig` returns early on an empty list.

The `#grapher` container gets an explicit `height` in CSS. That's load-bearing: `GrapherLoader` disables Grapher's own ideal-bounds sizing and makes the container the single source of truth for size, so a zero-height container renders nothing.

Dropped, each because the package makes it dead weight:

- `assets/owid.css` — the whole site stylesheet, where `grapher.css` is what the chart actually needs.
- The Google-fonts `<link>` for Lato/Playfair → `https://ourworldindata.org/fonts.css`, which is what the package readme recommends and what its own demo page uses.
- `document.cookie = "isAdmin=true"` — set on the Streamlit component's own origin, so it was never sent to ourworldindata.org in the first place.
- `catalogUrl` — `GrapherLoader` has no equivalent; it only mattered to the site's archival-page path.

Kept `bakedGrapherURL` and `adminBaseUrl` in the config: they're `GrapherProgrammaticInterface` fields, they survive `fromApi`'s spread into `GrapherState`, and they're what point the share/embed links and the admin edit pencil at the right environment.

## Consequence: charts now need Tailscale in the browser

Chart JS/CSS comes from `owid-packages.tail6e23.ts.net`, not from public ourworldindata.org. Anyone running the wizard is already on the tailnet (staging DBs, admin API, `api-staging.owid.io`), so in practice this is not a new requirement — but it is a new failure mode: off the tailnet, charts silently stay blank where they previously rendered.

`GRAPHER_PACKAGE_URL` defaults to `.../grapher/latest`, so the wizard tracks each release automatically. Set it to `.../grapher/v0.1.0` to pin a version.

## Deliberately not converted

`grapher_chart_from_url`, `mdim_chart` / `explorer_chart`, and the `chart-preview` VS Code extension's `embedCharts.js` all embed a *live page* by URL (a slug, an explorer, an MDim view). `GrapherLoader` takes a config plus indicator IDs, not a slug, so there's nothing to port them to. They stay iframes.

All call sites go through the one function this changes:

```bash
grep -rn "grapher_chart(\|renderSingleGrapher\|owid.mjs" --include="*.py" . | grep -v "^./.venv"
```

→ 8 `grapher_chart(...)` calls (6 in chart-diff, 1 in anomalist, 1 in the helper itself), 0 remaining references to the old bundle.

## Verified

Rendered the exact HTML `_grapher_html` emits for four real production chart configs (`life-expectancy`, `annual-co2-emissions-per-country`, `life-expectancy-vs-gdp-per-capita`, `population`) in Chrome, each inside an iframe as Streamlit serves it. Line, bar, scatter, and map tabs all draw; timeline, entity selector with its search/sort/filter panel, the download/share/favourite buttons, the "Data source" footer, and the sources modal (title, WYSK bullets, last-updated, date range, unit, admin edit pencil) all render correctly off `grapher.css` alone. Browser console is empty — no errors, no warnings.

The new test asserts the emitted HTML imports the package bundle and links its CSS, that `dataApiUrl` follows the passed environment, and that the config round-trips through JSON with numpy ints intact (the grapher DB hands us `np.int64` variable IDs, and `default_converter` is the only thing keeping that serializable).

Also rendered against this branch's own staging data API (`api-staging.owid.io/staging-site-grapher-npm`) rather than only production, since that's the path chart-diff actually takes — same result, clean console.

Finally, checked chart-diff itself on this branch's staging wizard, which was the one thing the standalone pages couldn't answer: side-by-side in `st.columns(2)`, Streamlit narrows each component iframe to the column (645px, not the 960px `width` argument) and the chart lays itself out to fit — 643x598 per side, both fully rendered, nothing clipped. To get a diff to look at, one chart's subtitle was nudged on staging and then reverted; chart-diff is back to "No chart modifications found".

<details>
<summary>Package details for whoever picks this up next</summary>

- Docs live in owid-grapher at `packages/@ourworldindata/grapher/readme.md`; `demo.html` in that directory is a runnable three-loader example.
- The Tailnet bundle host serves `grapher.css`, `grapher.js` (ESM, React external), `grapher.standalone.min.js` (3 MB, React bundled in — what we use), `grapher.d.ts`, and `package.json` per released version, plus a `latest/` alias. It sends `access-control-allow-origin: *` and `cache-control: max-age=300`, and needs no auth token — unlike installing from the private registry at `packages.owid.io`.
- These URLs aren't documented in owid-grapher yet; they came from the release announcement.
- There's a playground of six live demos (one per `GrapherLoader` factory, each with its source) at `vibe.owid.io/reports/grapher-package-playground/`. It's a bundler consumer of the earlier `@owid/grapher` GitHub-Packages preview rather than the standalone bundle, so it doesn't cover the URL route this PR takes, but it independently lands on the same two setup requirements: `grapher.css` and `https://ourworldindata.org/fonts.css`, with an explicitly sized container.

</details>
