### PR TITLE
📜🤖 Teach the Figma skills to batch MCP calls

### DIFF
--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -30,6 +30,7 @@ Read [GUIDELINES.md](GUIDELINES.md) (sibling file) before editing any chart — 
 > | Which text slots the step fills vs. leaves to the template | `/create-static-viz` | this skill's Step 6 |
 > | Type and palette — the step sets neither, this page owns both | this skill | `/create-static-viz` defers to it |
 > | The design vocabulary (per chart type, labeling, colors) | [GUIDELINES.md](GUIDELINES.md) | both |
+> | How Figma MCP calls are batched, and what is serial | this skill (**Round-trip budget**) | both |
 >
 > The asymmetry worth remembering: **that skill owns the data, the geometry and the proportions; this
 > one owns the type and the palette.** A change that crosses that line belongs in both files.
@@ -42,6 +43,33 @@ Two more sibling files own a route each, and both replace rather than supplement
 | [BESPOKE-SVG.md](BESPOKE-SVG.md) | the input is a **bespoke visualization** — a client-rendered React viz with no `.svg` endpoint. Covers getting a chart-only SVG out of one; after that this page applies unchanged. |
 
 Three sibling skills do the text work this one depends on, and Step 8c calls them: **`/adversarial-data-review`** (is the FAUST true of the indicator, and is the data), **`/check-metadata-style`** (the Writing and Style Guide) and **`/check-metadata-typos`** (codespell). Anything they turn up is an upstream fix in the garden step, not a Figma edit.
+
+## Round-trip budget
+
+Every Figma MCP call is a network hop to Figma's hosted connector: **7–10 s for `use_figma`, ~10 s for `get_screenshot`**, flat regardless of how big the script is. A run makes 120–190 of them. So the round trips are where the wall-clock goes — not the SVG exports (0.24 s each, under 2 s for a whole run) and not the response payloads (~1.5 KB per `use_figma`). Measured across five sessions: **16–28 minutes of pure MCP latency per chart**, with every single call issued on its own.
+
+**Fan out independent calls — one message, 4–6 at a time.** The connector serves them concurrently: eight screenshots issued together came back **4.1× faster** than serially (79.7 s of work in 19.4 s of wall clock). It admits about four or five at once, and per-call latency inflates past that — 8.2 s for the first of eight, 13.2 s for the last — so **4–6 per message is the sweet spot and more just queues.** This is the `figma-use` skill's own instruction too: issue the N calls in one message, and don't await one before issuing the next.
+
+Reads fan out freely. **Writes only when they target different pages** — a script may switch pages only once, so two `use_figma` writes aimed at the same page in one message race each other.
+
+What is independent, and today is not batched:
+
+- **The palette harvest.** `search_design_system` caps at ~14 results against a 24-fill palette, so it takes one group query plus ~11 by-name queries. Every one of them is independent.
+- **Screenshots of different frames or pages.** Issue them together, then `curl` all the returned URLs in one bash call, then Read each. A screenshot is otherwise three tool calls, and a run takes 14–70 of them.
+- **Every format in a multi-format run**, and every frame of a `chart-rows` set — separate pages and frames, so the writes fan out as well as the reads.
+- **Any survey of N nodes.** The pass that wrote GUIDELINES.md screenshotted 272 chart-library nodes one at a time: 2.7 hours, every call an independent read.
+- **The Step 8c property sweeps** — font sizes, stroke weights, dash patterns, fills, polylines. Those are reads of a single page, so they collapse into *one* `use_figma` returning one JSON. `scripts/verify_templates.js` already does exactly this for ten templates.
+- **The arrow probe's baseline render.** The both-hidden picture is the same for every arrow on the frame: take it once, then one hide-render per shape. N arrows costs `N + 2` screenshots instead of `4N`.
+
+**What is serial for a reason — don't collapse these:**
+
+| Sequence | Why |
+|---|---|
+| trim → position → read height | `leadingTrim` does not update `height` within the call that sets it (Step 7) |
+| original → clone → fill texts → measure band → export embed → fit | the band is not knowable until the real title and subtitle have reflowed the header (Step 3) |
+| one page per `use_figma` call | `page.children` on a page you have not switched to returns a short list *without erroring* (Gotchas) |
+
+And a bigger batch is a bigger loss: `use_figma` is atomic, so a script that throws on its last line reverts the whole pass. Stay inside the plugin's ~10-logical-operations-per-call guidance.
 
 ## The yearly Charts file — node map (2026)
 

--- a/.claude/skills/create-static-viz/SKILL.md
+++ b/.claude/skills/create-static-viz/SKILL.md
@@ -48,6 +48,13 @@ Two companions in this directory:
 - **`scripts/verify_static_viz.py`** — mechanical check that the emitted files honor the Figma
   handoff contract. Run it before showing anyone the chart.
 
+**When you do make a Figma MCP call, batch it.** Every call is a ~7–10 s network hop to the hosted
+connector, so a handful issued one at a time is the difference between seconds and minutes. The
+connector serves concurrent calls — eight screenshots in one message measured 4.1× faster than
+serially — and admits about four or five at once, so **put independent calls in one message, 4–6 at
+a time.** Reads always; writes only when they target different pages. `/create-figma-chart` →
+**Round-trip budget** has the full rule and the list of what is genuinely serial.
+
 **What this skill does not decide:** colors, fonts, background, the logo, and any visual treatment
 the template provides. Those are applied in Figma. The ETL step owns the *data*, the *structure*
 (which text slots exist, in what order), the *proportions*, and the *axis conventions*. Setting a


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

`/create-figma-chart` runs feel slow, and the assumption was that the chart SVG exports were to blame. They are not: a grapher SVG comes back in **0.24 s**, and every `curl` in a whole run totals under two seconds.

The time is in Figma MCP round trips. Measured per-call: **7–10 s for `use_figma`, ~10 s for `get_screenshot`**, flat regardless of script size, against a hosted connector that cannot be tuned locally.

## What the connector actually does

Eight `get_screenshot` calls issued in one message:

```
sum of durations = 79.7s    wall-clock span = 19.4s    concurrency factor = 4.12x
```

Concurrent, but with a ceiling: per-call latency inflated from 8.2 s for the first to 13.2 s for the eighth, so it admits only about four or five at a time. Hence the rule this PR adds: **4–6 independent calls per message, not unbounded fan-out.**

## How much batching actually happens today

Measured by sweeping each session's call intervals for peak simultaneous in-flight calls:

| Session | Figma calls | Peak concurrent | Calls overlapping the previous one |
|---|---|---|---|
| `cc48830c` | 279 | **1** | 0% |
| `d4a6cb90` | 124 | **1** | 0% |
| `077dfe6f` | 140 | 2 | 1% |
| `b0bf3f2c` | 152 | 5 | 9% |
| `12e600d2` | 188 | 6 | 9% |
| `05e4ba0d` | 304 | **14** | **81%** |

So it is uneven rather than absent: **two sessions never batched at all** and two more barely did, while one batched heavily. A run that never batches spends 16–28 minutes in pure serial round trips.

The heavily-batched session is the instructive one. Its 273 `get_screenshot` calls averaged **35.5 s** against ~10 s everywhere else — because it ran at **peak 14 in flight**, well past what the connector serves. That is the same curve the probe showed (8.2 s at one → 13.2 s at eight queued → 35.5 s at fourteen), and it is the direct evidence for capping fan-out at 4–6 rather than "as many as possible".

The `figma-use` plugin skill already mandates fan-out ("you MUST issue the N tool calls in one message"). This skill mentioned parallelism once in 1,452 lines and otherwise taught only the serial constraints, so a run had nothing telling it either to batch or where to stop.

## The change

A `## Round-trip budget` section that names:

- the call-sets that are independent — the palette harvest (~11 by-name queries against a ~14-result cap), screenshots of different frames, every format in a multi-format run, node surveys, the Step 8c property sweeps (collapsible into one `use_figma`, as `verify_templates.js` already does for ten templates), and the arrow probe's shared both-hidden baseline (`N + 2` screenshots instead of `4N`);
- that reads fan out freely but **writes only across different pages**, since a `use_figma` script may switch pages once;
- **the 4–6 ceiling**, with the latency curve that justifies it;
- the three sequences that are serial *for a reason*, so they don't get "optimized" away: `leadingTrim` not settling within its own call, the band-measurement ordering, and one page per call.

A short form is mirrored into `/create-static-viz`, and the policy is registered in the paired-skill contract table since it now lives half in each file.

## How to verify this — and one metric that does NOT work

**Do not use a calls-per-assistant-message histogram.** The transcript writes one entry per tool call whether or not the calls were batched, so the histogram reports `{1: N}` for a provably concurrent run — I confirmed this against the 8-call probe above, which the histogram scored as eight singletons. An earlier draft of this PR used that metric and drew the wrong conclusion from it.

The valid signal is **interval overlap**: sweep `tool_use` → `tool_result` timestamps for peak simultaneous in-flight calls, and count how many calls start before the previous one finished. That is what the table above reports, and it is what a follow-up run should be measured against.

Targets for a real run: peak concurrency in the **4–6** band rather than 1 or 14, and total Figma calls down from 124–188.

## Not done here

The payoff is not yet measured across a whole run at the recommended cadence. The 4.12× is a clean-room probe of eight independent reads; a real run mixes fan-outable work with genuinely serial work, so expect less.

This also *grows* `SKILL.md` by 3.3 KB, against a file already read in full on every run. That is deliberate — the section is spine material. Cutting the preload is the next change in the series (#6721).
