### PR TITLE
🎉🤖 Add solve_export.py and measure_fit.js to cut Figma round trips

### DIFF
--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -274,10 +274,17 @@ head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <ht
 > Run it from the repo root through the venv — `.venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py …`;
 > it is committed non-executable like the rest of that directory.
 > `--band 508x371 --slug <slug>` returns the solved `imFontSize`, the `imWidth`/`imHeight` to
-> request, the predicted content box, the scale into the band, the gap it predicts at each end, the
-> final label size, and the finished `curl`. It also carries the model's own self-test
-> (`--self-test`, which reproduces both worked examples below to within 1.4px and round-trips the
-> band arithmetic exactly) and the `--thumbnail` route for a 302-wide chart.
+> request, the predicted content box, the **height-first** scale into the band, the leftover width
+> the x-map has to close, the final label size, and the finished `curl`. Two things to read it by:
+> it reports the leftover width rather than a predicted gap, because the gap is exact by
+> construction once you fit the height (Step 7) — that leftover is the same quantity
+> `measure_fit.js` reports as `xMapShortfall`, and it is the aspect miss expressed in px; and every
+> number comes from the **rounded** `imFontSize`, since that is what the URL carries, so the label
+> size quoted is the one the `curl` will actually produce (it prints the ideal font alongside when
+> rounding moves it). It also carries the model's own self-test (`--self-test`, which reproduces
+> both worked examples below to within 1.4px, round-trips the band arithmetic exactly, and checks
+> that a reflected second pass still lands its `--target-label`) and the `--thumbnail` route for a
+> 302-wide chart.
 >
 > **It solves for `band − 2×--gap`, not for the band** — the gap below is a requirement of the fit,
 > so a solve that ignores it lands the chart edge to edge and you re-export. `--gap` defaults to 14

--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -271,14 +271,22 @@ head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <ht
 ```
 
 > **[`scripts/solve_export.py`](scripts/solve_export.py) does this arithmetic — don't do it by hand.**
-> `--band 508x371 --target-label 13.5 --slug <slug>` returns the solved `imFontSize`, the
-> `imWidth`/`imHeight` to request, the predicted content box, the scale into the band, the final
-> label size, and the finished `curl`. It also carries the model's own self-test
-> (`--self-test`, which reproduces both worked examples below to within 1.4px) and the
-> `--thumbnail` route for a 302-wide chart. Verified end to end: for a 508×371 band it solved
-> `imFontSize=28, imWidth=1346` and predicted 828×616 — grapher returned **829×616** with
-> `font-size="21"`, landing labels at exactly 13.5px. After you have measured a real import, feed
-> `--content-aspect` back in for the one correction.
+> `--band 508x371 --slug <slug>` returns the solved `imFontSize`, the `imWidth`/`imHeight` to
+> request, the predicted content box, the scale into the band, the gap it predicts at each end, the
+> final label size, and the finished `curl`. It also carries the model's own self-test
+> (`--self-test`, which reproduces both worked examples below to within 1.4px and round-trips the
+> band arithmetic exactly) and the `--thumbnail` route for a 302-wide chart.
+>
+> **It solves for `band − 2×--gap`, not for the band** — the gap below is a requirement of the fit,
+> so a solve that ignores it lands the chart edge to edge and you re-export. `--gap` defaults to 14
+> and takes 30 for the Instagram portrait. For a 508×371 band that makes the target 508×343, and the
+> solve returns `imFontSize=29, imWidth=1448`, predicting an 818.8×552.8 content box that scales to
+> 508×343 — 14px at each end. Verified end to end at `--gap 0` (i.e. filling the band, which is what
+> this script did before the gap was reserved): it solved `imFontSize=28, imWidth=1346` and predicted
+> 828×616, and grapher returned **829×616** with `font-size="21"`, landing labels at exactly 13.5px —
+> so the canvas model is confirmed against the real renderer; it is the target fed into it that the
+> gap changes. After you have measured a real import, run the `nextPass` command that
+> `measure_fit.js` prints rather than passing the measured aspect back yourself — see Step 7.
 
 **The aspect you request is the *canvas*, not the chart — solve for the padding or you will re-export every page.** Grapher insets the drawing inside the SVG it hands back, so the group Figma imports is smaller than the declared size, and it is the *group* that has to fill the template band. Measured on this file's charts, the inset is close to **1.4 × `imFontSize` on each axis** (at `imFontSize=32`: declared 901×566 → content 857×520; at 30: 862×591 → 818.9×550). So don't request the aspect you want — request the aspect that *yields* it, by solving
 

--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -271,6 +271,8 @@ head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <ht
 ```
 
 > **[`scripts/solve_export.py`](scripts/solve_export.py) does this arithmetic — don't do it by hand.**
+> Run it from the repo root through the venv — `.venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py …`;
+> it is committed non-executable like the rest of that directory.
 > `--band 508x371 --slug <slug>` returns the solved `imFontSize`, the `imWidth`/`imHeight` to
 > request, the predicted content box, the scale into the band, the gap it predicts at each end, the
 > final label size, and the finished `curl`. It also carries the model's own self-test

--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -270,6 +270,16 @@ curl -sL "https://ourworldindata.org/grapher/<slug>.svg?<params>&imType=uncaptio
 head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <html
 ```
 
+> **[`scripts/solve_export.py`](scripts/solve_export.py) does this arithmetic — don't do it by hand.**
+> `--band 508x371 --target-label 13.5 --slug <slug>` returns the solved `imFontSize`, the
+> `imWidth`/`imHeight` to request, the predicted content box, the scale into the band, the final
+> label size, and the finished `curl`. It also carries the model's own self-test
+> (`--self-test`, which reproduces both worked examples below to within 1.4px) and the
+> `--thumbnail` route for a 302-wide chart. Verified end to end: for a 508×371 band it solved
+> `imFontSize=28, imWidth=1346` and predicted 828×616 — grapher returned **829×616** with
+> `font-size="21"`, landing labels at exactly 13.5px. After you have measured a real import, feed
+> `--content-aspect` back in for the one correction.
+
 **The aspect you request is the *canvas*, not the chart — solve for the padding or you will re-export every page.** Grapher insets the drawing inside the SVG it hands back, so the group Figma imports is smaller than the declared size, and it is the *group* that has to fill the template band. Measured on this file's charts, the inset is close to **1.4 × `imFontSize` on each axis** (at `imFontSize=32`: declared 901×566 → content 857×520; at 30: 862×591 → 818.9×550). So don't request the aspect you want — request the aspect that *yields* it, by solving
 
 ```

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -393,10 +393,17 @@ Verify against the actual clone with `get_metadata` (the templates evolve; the g
 > (`2×target − measured`), not at the measured aspect itself — solving for what you already got moves
 > the next export further off, by about the same margin again. On the case recorded above (target
 > 1.4810 on a 508×371 band, group measured 1.4342) passing the measured aspect back lands a 2.4px
-> gap where 14 was wanted, and the reflection lands 14.0. `nextPass` carries the band, the `--gap`
-> and the corrected aspect already; when the measurement is more than 15% off the target it drops the
+> gap where 14 was wanted, and the reflection lands 14.0. `nextPass` carries the band, the `--gap`,
+> the `--target-label` and the corrected aspect already — set `targetGap` and `targetLabel` in its
+> `CONFIG` to whatever the first export used, or a portrait solved for 15px labels comes back at 13.5
+> purely from re-solving the aspect. When the measurement is more than 15% off the target it drops the
 > correction and tells you to solve fresh, because that far out is a wrong export or leftover
 > furniture, not a near-miss.
+>
+> It also reports `excluded` as `{requested, matched, unmatched}` rather than a count, and warns on
+> any `hideIds` entry that names nothing under the group: an id copied from another page excludes
+> nothing, and a bare count would report that as a success while the aspect still carried the
+> connectors.
 >
 > Cross-checked read-only against three live templates; every field matched `verify_templates.js`'s
 > expected geometry, Static Vertical's `1015.81` footer included.

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -370,6 +370,23 @@ The table gives one number per template — the band you fit a chart into — an
 
 Verify against the actual clone with `get_metadata` (the templates evolve; the geometry above is a 2026 snapshot). These are **frame-local** coordinates, and `x`/`y` are relative to a node's parent — so append the embed to the template clone **before** positioning it. Left parented to the page (where Step 5 puts imported nodes), the same numbers land it near the page origin, on top of the reference chart. One wrinkle in the same rule: **a GROUP is transparent for coordinates**, so once the imported chart is inside the template, its descendants report `x`/`y` in the *template frame's* space, not the group's — which is what makes the frame-local numbers above directly usable on the plot's internals.
 
+> **[`scripts/measure_fit.js`](../scripts/measure_fit.js) returns every number in this step in one
+> read-only `use_figma` call** — the band off the *filled* clone, the content box, the header's
+> sizing (including whether it actually `reflows`), and, given the imported group, its measured
+> bbox, content aspect, the uniform scale to the content width and the resulting gap per end. It
+> resolves header and footer with the same structural rule as `verify_templates.js`, so a renamed
+> frame cannot silently return `null`.
+>
+> Two things it does that hand-probing tends to get wrong. It reports **rendered** line counts
+> (height ÷ lineHeight) rather than counting `\n`, because a *wrapped* title has no newline in it
+> and an explicit-break count reports a two-line title as one. And `hideIds` computes the group's
+> bbox **as if** `connectors` and the year markers were hidden, without hiding them — so the aspect
+> you get is the one you will actually fit, with the file untouched. Feed that `contentAspect`
+> straight into `solve_export.py --content-aspect`.
+>
+> Cross-checked read-only against three live templates; every field matched `verify_templates.js`'s
+> expected geometry, Static Vertical's `1015.81` footer included.
+
 **The header reflows itself — don't reposition it.** Every template's header block is a flat vertical auto-layout of `[title, subtitle]` (the logo is a sibling, not a child — see the node map), so a title that grows from two lines to three pushes the subtitle down and grows the header on its own. Set `characters`, then **read the new `header.y + header.height` back** and measure the band from that; any y you computed before the text went in is stale. Measured on the portrait: a two-line title gives a 135 band bottom, three lines 199.
 
 **The logo no longer sets a floor under that** — it is a sibling of the header, not a child, so it contributes nothing to the header's height and a one-line title buys the full reduction. What the logo still constrains is *width*: the title node is sized narrower than the content box to clear it (737.84 against 818 on Static Vertical, 428 against 508 on the 540-wide set), which is the number a title has to be measured against. Read the band back rather than deriving it from line counts either way.

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -377,12 +377,26 @@ Verify against the actual clone with `get_metadata` (the templates evolve; the g
 > resolves header and footer with the same structural rule as `verify_templates.js`, so a renamed
 > frame cannot silently return `null`.
 >
-> Two things it does that hand-probing tends to get wrong. It reports **rendered** line counts
+> Three things it does that hand-probing tends to get wrong. It reports **rendered** line counts
 > (height ÷ lineHeight) rather than counting `\n`, because a *wrapped* title has no newline in it
-> and an explicit-break count reports a two-line title as one. And `hideIds` computes the group's
+> and an explicit-break count reports a two-line title as one. `hideIds` computes the group's
 > bbox **as if** `connectors` and the year markers were hidden, without hiding them — so the aspect
-> you get is the one you will actually fit, with the file untouched. Feed that `contentAspect`
-> straight into `solve_export.py --content-aspect`.
+> you get is the one you will actually fit, with the file untouched. And it takes the content box
+> from the **header** (`header.x`/`header.width`, as `verify_templates.js` does) rather than from a
+> union over `frame.children`: by this step the chart is already appended to the clone, so a union
+> would include the not-yet-fitted group, inflate the box to the group's own width, and report a
+> scale of ≈1 — "nothing to do" — which is the one answer the script exists to produce. The union is
+> still reported as `contentBoxFromRows` for cross-checking, with the group excluded.
+>
+> **Run the `nextPass` command it prints; do not feed the measured aspect back yourself.** The
+> second pass has to aim at the *reflection* of the measured aspect about the target
+> (`2×target − measured`), not at the measured aspect itself — solving for what you already got moves
+> the next export further off, by about the same margin again. On the case recorded above (target
+> 1.4810 on a 508×371 band, group measured 1.4342) passing the measured aspect back lands a 2.4px
+> gap where 14 was wanted, and the reflection lands 14.0. `nextPass` carries the band, the `--gap`
+> and the corrected aspect already; when the measurement is more than 15% off the target it drops the
+> correction and tells you to solve fresh, because that far out is a wrong export or leftover
+> furniture, not a near-miss.
 >
 > Cross-checked read-only against three live templates; every field matched `verify_templates.js`'s
 > expected geometry, Static Vertical's `1015.81` footer included.

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -373,7 +373,10 @@ Verify against the actual clone with `get_metadata` (the templates evolve; the g
 > **[`scripts/measure_fit.js`](../scripts/measure_fit.js) returns every number in this step in one
 > read-only `use_figma` call** — the band off the *filled* clone, the content box, the header's
 > sizing (including whether it actually `reflows`), and, given the imported group, its measured
-> bbox, content aspect, the uniform scale to the content width and the resulting gap per end. It
+> bbox, content aspect, the **height-first** scale this step fits with (`TARGET_H / chart.height`,
+> as `fitScaleToBandH`) and the leftover width the x-map has to close (`xMapShortfall`). It reports
+> the height-first factor deliberately: the gap comes out right by construction once you fit the
+> height, so the leftover width — not the gap — is what tells you the aspect still needs a pass. It
 > resolves header and footer with the same structural rule as `verify_templates.js`, so a renamed
 > frame cannot silently return `null`.
 >

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -16,10 +16,11 @@
 //                118 to 70.
 //     groupId  — optional; the imported chart group, once it exists. Give it and you also get the
 //                group's bbox, its content aspect, and the scale needed to fit the band.
-//     hideIds  — optional; nodes to EXCLUDE from the group's measured bbox (grapher's `connectors`
-//                and year markers extend past the plot). This computes the bbox as if they were
-//                hidden, WITHOUT hiding them — so the aspect you get is the one you will actually
-//                fit, and the file is untouched. reference/FITTING.md: hiding the elbows moved a
+//     hideIds  — optional; nodes to EXCLUDE from the group's measured bbox AND from the font-size
+//                histogram (grapher's `connectors` and year markers extend past the plot). This
+//                computes both as if they were hidden, WITHOUT hiding them — so the aspect you get
+//                is the one you will actually fit, the histogram covers only text that survives,
+//                and the file is untouched. reference/FITTING.md: hiding the elbows moved a
 //                measured aspect from 1.6026 to 1.5558, turning a 14px gap into 9.5px.
 //
 // The `nextPass` field in the output is the finished second-pass command — run it as printed. Do
@@ -137,8 +138,14 @@ const blocksReflow = (c) => {
   }
   if ("layoutGrow" in c && c.layoutGrow) return "layoutGrow";
   if ("layoutSizingVertical" in c && c.layoutSizingVertical === "FIXED") return "layoutSizingVertical FIXED";
-  if (c.type === "TEXT" && (c.textAutoResize === "NONE" || c.textAutoResize === "TRUNCATE")) {
-    return `textAutoResize ${c.textAutoResize}`;
+  // HEIGHT exactly, which is the invariant reference/NODE-MAP.md documents and verify_templates.js
+  // already enforces (`textAutoResize ${ar} != HEIGHT`). Listing the modes that block instead lets
+  // WIDTH_AND_HEIGHT through, and that one is not reflow-safe: the box hugs the text on BOTH axes, so
+  // a long title grows sideways on one line instead of wrapping to a second. The header height then
+  // does not track the copy at all — the failure this predicate exists to catch — and the title runs
+  // toward the logo and the frame edge while the band keeps its placeholder value.
+  if (c.type === "TEXT" && c.textAutoResize !== "HEIGHT") {
+    return `textAutoResize ${c.textAutoResize} (not HEIGHT)`;
   }
   return null;
 };
@@ -189,9 +196,15 @@ if (groupNode) {
   collect(g);
   const unmatched = hideIds.filter((id) => !seen.has(id));
 
+  // The font histogram is collected in THIS traversal, not a second findAllWithCriteria pass. A
+  // separate pass sees neither the hideIds subtrees nor an invisible ancestor — `visible` is a local
+  // flag, so a text inside a hidden group still reads as visible — and would report label sizes for
+  // text the fitted chart will not contain, which is the histogram's whole job to get right.
+  const visibleTexts = [];
   const walk = (n) => {
     if (hide.has(n.id)) return;
     if ("visible" in n && !n.visible) return;
+    if (n.type === "TEXT") visibleTexts.push(n);
     if ("children" in n && n.children.length) {
       n.children.forEach(walk);
       return;
@@ -253,11 +266,10 @@ if (groupNode) {
     }
   }
 
-  // font-size histogram, and what each size becomes once scaled in
+  // font-size histogram, and what each size becomes once scaled in. Built from the bbox traversal's
+  // own text nodes, so it describes exactly the labels the measured aspect was taken over.
   const sizes = {};
-  const texts = g.findAllWithCriteria ? g.findAllWithCriteria({ types: ["TEXT"] }) : [];
-  for (const t of texts) {
-    if (!t.visible) continue;
+  for (const t of visibleTexts) {
     const fs = typeof t.fontSize === "number" ? t.fontSize : "mixed";
     sizes[fs] = (sizes[fs] || 0) + 1;
   }

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -234,9 +234,11 @@ if (groupNode) {
     const measured = w / h;
     // --target-label has to travel with the correction: solve_export.py defaults to 13.5, so a
     // portrait solved at 15 would come back with smaller text purely from re-solving the aspect.
+    // Runnable as printed, from the repo root: these scripts are committed non-executable like every
+    // other script in this directory, and the repo rule is that Python goes through the venv.
     const cmd =
-      `scripts/solve_export.py --band ${contentW}x${r(band.height)} --gap ${gap}` +
-      ` --target-label ${targetLabel}`;
+      ".venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py" +
+      ` --band ${contentW}x${r(band.height)} --gap ${gap} --target-label ${targetLabel}`;
     group.target = { aspect: r(target), gap, usableHeight: r(usable) };
     // The reflection only cancels a small model error. A group that is far off the target is not a
     // near-miss to correct but something else — the wrong export, or furniture still in the bbox —

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -22,15 +22,21 @@
 //                fit, and the file is untouched. reference/FITTING.md: hiding the elbows moved a
 //                measured aspect from 1.6026 to 1.5558, turning a 14px gap into 9.5px.
 //
-// Feed `contentAspect` from the output straight into
-//   scripts/solve_export.py --band <W>x<H> --content-aspect <A>
-// which then emits the corrected curl. Those two together are what remove the re-export per page.
+// The `nextPass` field in the output is the finished second-pass command — run it as printed. Do
+// NOT hand-build it by feeding the measured aspect back as `--content-aspect`: the solve would then
+// aim at the aspect you already got, which moves the export further from the target rather than onto
+// it. `nextPass` passes the REFLECTION `2*target - measured` instead, so the same model error that
+// put the group off-target cancels. Worked through on the docs' own case (solved 1.6026, measured
+// 1.5558): feeding 1.5558 back doubles the error, the reflection lands on the target.
 
 const CONFIG = {
   frameId: "5332:75", // the template clone
   groupId: null, // the imported chart group, or null
   hideIds: [], // e.g. ["I123:4;5:6"] for connectors / year markers
+  targetGap: 14, // px per end the fit aims for; 12-16 on 540-wide frames, 30 on the IG portrait
 };
+
+const hideIds = CONFIG.hideIds || [];
 
 const r = (v) => (v === null || v === undefined ? null : Math.round(v * 100) / 100);
 
@@ -77,15 +83,54 @@ if (footer && "children" in footer && footer.children.length) {
 const bandTop = header ? r(header.y + header.height) : null;
 const band = bandTop !== null && footerTop !== null ? { top: bandTop, bottom: r(footerTop), height: r(footerTop - bandTop) } : null;
 
-// --- content box: the horizontal inset the template's own rows sit at.
-const rows = frame.children.filter((c) => c !== logo && "absoluteBoundingBox" in c && c.absoluteBoundingBox);
-const contentX = rows.length ? r(Math.min(...rows.map((c) => c.x))) : null;
-const contentW = rows.length ? r(Math.max(...rows.map((c) => c.x + c.width)) - contentX) : null;
+// --- content box: taken from the HEADER, exactly as verify_templates.js does it (`header.x` /
+// `header.width`), because by Step 7 the imported chart is already a child of this frame — the docs
+// require appending it before positioning — and a union over `frame.children` would then include the
+// not-yet-fitted group. That inflates the box to the group's own width and `scaleToContentW` comes
+// out near 1, i.e. "no scaling needed", which is the one answer this script exists to produce.
+const contentX = header ? r(header.x) : null;
+const contentW = header ? r(header.width) : null;
+
+// The union over the template's own rows, kept as a cross-check and NOT used for the scale. The
+// group and the logo are excluded — the group via its top-level ancestor, since it is the ancestor,
+// not the group itself, that sits in `frame.children`. On the 540-wide and 850-wide families this
+// agrees with the header box (16/508 and 16/818); on the 302-wide small templates it does not, since
+// their header hugs its own text width (206-278) — but that format has no fit step at all
+// (reference/FITTING.md), so the header box is the right primary everywhere this script is used.
+const groupNode = CONFIG.groupId ? await figma.getNodeByIdAsync(CONFIG.groupId) : null;
+if (CONFIG.groupId && !groupNode) throw new Error(`groupId ${CONFIG.groupId} not found`);
+let groupAncestor = null;
+if (groupNode) {
+  let n = groupNode;
+  while (n && n.parent && n.parent !== frame) n = n.parent;
+  groupAncestor = n && n.parent === frame ? n : null;
+}
+const rows = frame.children.filter(
+  (c) => c !== logo && c !== groupAncestor && "absoluteBoundingBox" in c && c.absoluteBoundingBox,
+);
+const rowsX = rows.length ? r(Math.min(...rows.map((c) => c.x))) : null;
+const rowsW = rows.length ? r(Math.max(...rows.map((c) => c.x + c.width)) - rowsX) : null;
 
 // --- header sizing: does the band actually move with the copy?
 // FIXED with a FILL child does NOT reflow — the band stays at the placeholder value however short
 // the title, and the slack is absorbed by the flexible child's box instead, burying dead air under
 // the subtitle. Nothing renders wrong, so it survives a screenshot.
+//
+// Every property that can pin the height has to be in the predicate, not just the parent's sizing
+// mode: a child that is vertically FIXED, or a TEXT that does not auto-resize its height, keeps its
+// box whatever the copy does, so an AUTO parent still hugs a constant. Reporting `reflows: true`
+// there suppresses the warning in exactly the case it exists for. An ABSOLUTE child is out of the
+// auto-layout flow entirely and cannot pin anything, so it is skipped rather than counted against.
+const blocksReflow = (c) => {
+  if ("layoutPositioning" in c && c.layoutPositioning === "ABSOLUTE") return null;
+  if ("layoutGrow" in c && c.layoutGrow) return "layoutGrow";
+  if ("layoutSizingVertical" in c && c.layoutSizingVertical === "FIXED") return "layoutSizingVertical FIXED";
+  if (c.type === "TEXT" && (c.textAutoResize === "NONE" || c.textAutoResize === "TRUNCATE")) {
+    return `textAutoResize ${c.textAutoResize}`;
+  }
+  return null;
+};
+
 const headerSizing = header
   ? {
       primaryAxisSizingMode: header.primaryAxisSizingMode,
@@ -101,19 +146,19 @@ const headerSizing = header
         textAutoResize: c.type === "TEXT" ? c.textAutoResize : null,
         layoutSizingVertical: "layoutSizingVertical" in c ? c.layoutSizingVertical : null,
         layoutGrow: "layoutGrow" in c ? c.layoutGrow : null,
+        layoutPositioning: "layoutPositioning" in c ? c.layoutPositioning : null,
+        // why this child pins the header's height, or null if it doesn't
+        blocksReflow: blocksReflow(c),
       })),
-      reflows:
-        header.primaryAxisSizingMode === "AUTO" &&
-        header.children.every((c) => !("layoutGrow" in c) || c.layoutGrow === 0),
+      reflows: header.primaryAxisSizingMode === "AUTO" && header.children.every((c) => blocksReflow(c) === null),
     }
   : null;
 
 // --- the imported group
 let group = null;
-if (CONFIG.groupId) {
-  const g = await figma.getNodeByIdAsync(CONFIG.groupId);
-  if (!g) throw new Error(`groupId ${CONFIG.groupId} not found`);
-  const hide = new Set(CONFIG.hideIds || []);
+if (groupNode) {
+  const g = groupNode;
+  const hide = new Set(hideIds);
 
   // Union the bboxes of visible leaves, skipping the hideIds subtrees. Doing it from leaves is what
   // lets us answer "what would the aspect be with the connectors hidden" without hiding anything.
@@ -137,15 +182,17 @@ if (CONFIG.groupId) {
   };
   walk(g);
 
+  if (!Number.isFinite(x0)) throw new Error(`groupId ${CONFIG.groupId} has no visible, non-excluded leaf to measure`);
+
   const raw = g.absoluteBoundingBox;
   const w = x1 - x0,
     h = y1 - y0;
   group = {
     id: g.id,
     name: g.name,
-    declared: { w: r(raw.width), h: r(raw.height), aspect: r(raw.width / raw.height) },
+    declared: raw ? { w: r(raw.width), h: r(raw.height), aspect: r(raw.width / raw.height) } : null,
     measured: { w: r(w), h: r(h), aspect: r(w / h) },
-    excluded: CONFIG.hideIds.length,
+    excluded: hideIds.length,
     // What Step 7 actually asks for: the uniform factor that makes the group span the content
     // width. rescale(), never resize() — resize stretches children through their constraints and
     // silently rewraps every text box in the chart.
@@ -153,6 +200,29 @@ if (CONFIG.groupId) {
     heightAtThatScale: contentW ? r((h * contentW) / w) : null,
     gapPerEnd: contentW && band ? r((band.height - (h * contentW) / w) / 2) : null,
   };
+
+  // The second pass, solved rather than guessed. `target` is the aspect the group has to have for
+  // the gap to come out at targetGap; `measured` is what it actually came back as; the export to
+  // request next is the one solved for the reflection of the measured aspect about the target.
+  const gap = CONFIG.targetGap;
+  const usable = band ? band.height - 2 * gap : null;
+  if (contentW && usable > 0) {
+    const target = contentW / usable;
+    const measured = w / h;
+    const cmd = `scripts/solve_export.py --band ${contentW}x${r(band.height)} --gap ${gap}`;
+    group.target = { aspect: r(target), gap, usableHeight: r(usable) };
+    // The reflection only cancels a small model error. A group that is far off the target is not a
+    // near-miss to correct but something else — the wrong export, or furniture still in the bbox —
+    // and reflecting it would ask for an absurd aspect, so fall back to a plain first-pass solve.
+    if (Math.abs(measured - target) / target <= 0.15) {
+      group.nextPass = `${cmd} --content-aspect ${(2 * target - measured).toFixed(4)}`;
+    } else {
+      group.nextPass = cmd;
+      group.nextPassNote =
+        `measured aspect ${r(measured)} is more than 15% off the ${r(target)} target, too far for a ` +
+        "one-step correction — solve it fresh (command above), and check the export and the hideIds first.";
+    }
+  }
 
   // font-size histogram, and what each size becomes once scaled in
   const sizes = {};
@@ -172,8 +242,9 @@ if (CONFIG.groupId) {
 }
 
 return {
-  frame: { id: frame.id, name: frame.name, w: r(fb.width), h: r(fb.height) },
-  contentBox: { x: contentX, w: contentW },
+  frame: { id: frame.id, name: frame.name, w: fb ? r(fb.width) : null, h: fb ? r(fb.height) : null },
+  contentBox: { x: contentX, w: contentW, from: header ? "header" : null },
+  contentBoxFromRows: { x: rowsX, w: rowsW },
   header: header ? { id: header.id, name: header.name, y: r(header.y), h: r(header.height) } : null,
   footer: footer ? { id: footer.id, name: footer.name, y: r(footer.y), h: r(footer.height), layoutMode: footer.layoutMode } : null,
   band,
@@ -182,13 +253,16 @@ return {
   // Read these before trusting the numbers above.
   notes: [
     headerSizing && headerSizing.reflows === false
-      ? "HEADER DOES NOT REFLOW — the band is a constant, not a measurement. Fix the CLONE (primaryAxisSizingMode AUTO, both children HUG + HEIGHT, layoutGrow 0), never the shared template, and say so in your report."
+      ? "HEADER DOES NOT REFLOW — the band is a constant, not a measurement. Check each child's `blocksReflow` for which property pins it. Fix the CLONE (primaryAxisSizingMode AUTO, both children HUG + HEIGHT, layoutGrow 0), never the shared template, and say so in your report."
       : null,
-    CONFIG.groupId && CONFIG.hideIds.length === 0
+    contentW !== null && rowsW !== null && Math.abs(contentW - rowsW) > 1
+      ? `contentBox from the header (${contentX}/${contentW}) disagrees with the union of the template's other rows (${rowsX}/${rowsW}). The header is the one to trust on any template with a fit step; a difference here means either a header that hugs its text (the 302-wide small templates do, and they have no fit step) or a row that has been moved — look before you scale.`
+      : null,
+    CONFIG.groupId && hideIds.length === 0
       ? "hideIds is empty — if the chart has `connectors` or year markers, the measured aspect includes them and will move once you hide them. Pass their ids."
       : null,
-    group && group.gapPerEnd !== null && (group.gapPerEnd < 12 || group.gapPerEnd > 16)
-      ? `gapPerEnd ${group.gapPerEnd} is outside the 12-16px target — re-solve the export with scripts/solve_export.py --content-aspect ${group.measured.aspect}`
+    group && group.gapPerEnd !== null && Math.abs(group.gapPerEnd - CONFIG.targetGap) > 2
+      ? `gapPerEnd ${group.gapPerEnd} is more than 2px off the ${CONFIG.targetGap}px target — re-export with the \`nextPass\` command above (read \`nextPassNote\` first if it is set).`
       : null,
   ].filter(Boolean),
 };

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -118,11 +118,27 @@ const contentW = header ? r(header.width) : null;
 // (reference/FITTING.md), so the header box is the right primary everywhere this script is used.
 const groupNode = CONFIG.groupId ? await figma.getNodeByIdAsync(CONFIG.groupId) : null;
 if (CONFIG.groupId && !groupNode) throw new Error(`groupId ${CONFIG.groupId} not found`);
+// The group has to be INSIDE this frame, and failing to reach it is an error rather than a null to
+// carry on from. Step 2 puts the original grapher chart on the page beside the template clone, so the
+// page always holds at least two chart groups whose ids are copied by hand off `get_metadata` — and
+// measuring the reference chart against the clone's band produces no error, no empty result and no
+// visible clue: a plausible aspect, a plausible scale, and a `nextPass` that re-exports at the wrong
+// aspect. Everything below this point measures against `frame`, so a group from anywhere else makes
+// every number a mismatched pair.
 let groupAncestor = null;
 if (groupNode) {
   let n = groupNode;
   while (n && n.parent && n.parent !== frame) n = n.parent;
   groupAncestor = n && n.parent === frame ? n : null;
+  if (!groupAncestor) {
+    throw new Error(
+      `groupId ${CONFIG.groupId} ("${groupNode.name}") is not inside frameId ${CONFIG.frameId} ` +
+        `("${frame.name}") — walking up its parents never reached that frame, so the band, the ` +
+        `content box and the fit scale would all describe a different node than the group. Check ` +
+        `you did not copy the id of the ORIGINAL chart sitting beside the clone, or of a group on ` +
+        `another page.`,
+    );
+  }
 }
 const rows = frame.children.filter(
   (c) => c !== logo && c !== groupAncestor && "absoluteBoundingBox" in c && c.absoluteBoundingBox,

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -34,9 +34,14 @@ const CONFIG = {
   groupId: null, // the imported chart group, or null
   hideIds: [], // e.g. ["I123:4;5:6"] for connectors / year markers
   targetGap: 14, // px per end the fit aims for; 12-16 on 540-wide frames, 30 on the IG portrait
+  targetLabel: 13.5, // final label px the first export was solved for; the portrait ladder uses 15
 };
 
+// Normalized CONFIG reads, so deleting a line from the block above degrades to the house default
+// rather than emitting `undefined` into the command this script prints.
 const hideIds = CONFIG.hideIds || [];
+const targetGap = CONFIG.targetGap ?? 14;
+const targetLabel = CONFIG.targetLabel ?? 13.5;
 
 const r = (v) => (v === null || v === undefined ? null : Math.round(v * 100) / 100);
 
@@ -119,10 +124,17 @@ const rowsW = rows.length ? r(Math.max(...rows.map((c) => c.x + c.width)) - rows
 // Every property that can pin the height has to be in the predicate, not just the parent's sizing
 // mode: a child that is vertically FIXED, or a TEXT that does not auto-resize its height, keeps its
 // box whatever the copy does, so an AUTO parent still hugs a constant. Reporting `reflows: true`
-// there suppresses the warning in exactly the case it exists for. An ABSOLUTE child is out of the
-// auto-layout flow entirely and cannot pin anything, so it is skipped rather than counted against.
+// there suppresses the warning in exactly the case it exists for.
+//
+// ABSOLUTE splits by type, and the distinction is the whole question this predicate answers — "does
+// the band move with the copy?". An absolutely positioned TEXT is out of the auto-layout flow, so
+// editing it cannot grow the header at all: the band stops tracking that copy entirely, which is
+// worse than a pinned height, not safer. Any other absolute child is decoration that cannot pin the
+// parent either way, so it is skipped rather than counted against.
 const blocksReflow = (c) => {
-  if ("layoutPositioning" in c && c.layoutPositioning === "ABSOLUTE") return null;
+  if ("layoutPositioning" in c && c.layoutPositioning === "ABSOLUTE") {
+    return c.type === "TEXT" ? "layoutPositioning ABSOLUTE (text out of the flow)" : null;
+  }
   if ("layoutGrow" in c && c.layoutGrow) return "layoutGrow";
   if ("layoutSizingVertical" in c && c.layoutSizingVertical === "FIXED") return "layoutSizingVertical FIXED";
   if (c.type === "TEXT" && (c.textAutoResize === "NONE" || c.textAutoResize === "TRUNCATE")) {
@@ -166,6 +178,17 @@ if (groupNode) {
     y0 = Infinity,
     x1 = -Infinity,
     y1 = -Infinity;
+  // Which hideIds actually named a node under this group. A mistyped or copied-from-another-page id
+  // excludes nothing, and reporting the requested count as `excluded` would then hide the one clue
+  // that the aspect still contains the connectors — a silent no-op dressed up as a success.
+  const seen = new Set();
+  const collect = (n) => {
+    seen.add(n.id);
+    if ("children" in n) n.children.forEach(collect);
+  };
+  collect(g);
+  const unmatched = hideIds.filter((id) => !seen.has(id));
+
   const walk = (n) => {
     if (hide.has(n.id)) return;
     if ("visible" in n && !n.visible) return;
@@ -192,7 +215,7 @@ if (groupNode) {
     name: g.name,
     declared: raw ? { w: r(raw.width), h: r(raw.height), aspect: r(raw.width / raw.height) } : null,
     measured: { w: r(w), h: r(h), aspect: r(w / h) },
-    excluded: hideIds.length,
+    excluded: { requested: hideIds.length, matched: hideIds.length - unmatched.length, unmatched },
     // What Step 7 actually asks for: the uniform factor that makes the group span the content
     // width. rescale(), never resize() — resize stretches children through their constraints and
     // silently rewraps every text box in the chart.
@@ -204,12 +227,16 @@ if (groupNode) {
   // The second pass, solved rather than guessed. `target` is the aspect the group has to have for
   // the gap to come out at targetGap; `measured` is what it actually came back as; the export to
   // request next is the one solved for the reflection of the measured aspect about the target.
-  const gap = CONFIG.targetGap;
+  const gap = targetGap;
   const usable = band ? band.height - 2 * gap : null;
   if (contentW && usable > 0) {
     const target = contentW / usable;
     const measured = w / h;
-    const cmd = `scripts/solve_export.py --band ${contentW}x${r(band.height)} --gap ${gap}`;
+    // --target-label has to travel with the correction: solve_export.py defaults to 13.5, so a
+    // portrait solved at 15 would come back with smaller text purely from re-solving the aspect.
+    const cmd =
+      `scripts/solve_export.py --band ${contentW}x${r(band.height)} --gap ${gap}` +
+      ` --target-label ${targetLabel}`;
     group.target = { aspect: r(target), gap, usableHeight: r(usable) };
     // The reflection only cancels a small model error. A group that is far off the target is not a
     // near-miss to correct but something else — the wrong export, or furniture still in the bbox —
@@ -261,8 +288,11 @@ return {
     CONFIG.groupId && hideIds.length === 0
       ? "hideIds is empty — if the chart has `connectors` or year markers, the measured aspect includes them and will move once you hide them. Pass their ids."
       : null,
-    group && group.gapPerEnd !== null && Math.abs(group.gapPerEnd - CONFIG.targetGap) > 2
-      ? `gapPerEnd ${group.gapPerEnd} is more than 2px off the ${CONFIG.targetGap}px target — re-export with the \`nextPass\` command above (read \`nextPassNote\` first if it is set).`
+    group && group.excluded.unmatched.length
+      ? `hideIds NOT FOUND under the group: ${group.excluded.unmatched.join(", ")}. Nothing was excluded for them, so the measured aspect still contains whatever they were meant to remove. Re-read the ids off this group — an id from another page or another chart looks identical and excludes nothing.`
+      : null,
+    group && group.gapPerEnd !== null && Math.abs(group.gapPerEnd - targetGap) > 2
+      ? `gapPerEnd ${group.gapPerEnd} is more than 2px off the ${targetGap}px target — re-export with the \`nextPass\` command above (read \`nextPassNote\` first if it is set).`
       : null,
   ].filter(Boolean),
 };

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -1,0 +1,194 @@
+// measure_fit.js — everything Step 7 needs to fit a chart, in ONE read-only use_figma call.
+//
+// Step 7 otherwise takes several separate probes: read the band off the filled clone, read the
+// clone's content box, read the imported group's bbox, read the font-size histogram. At ~8-10s per
+// MCP round trip that is a minute of latency for four numbers that come from one traversal.
+//
+// Read-only. It sets no property and creates no node, so it needs no approval to run against the
+// shared Charts file (the skill's checkpoint rule covers writes).
+//
+// USAGE
+//   Fill in CONFIG and paste the whole file as one `use_figma` call.
+//     frameId  — the TEMPLATE CLONE, after Step 6 has filled its texts. Measuring an unfilled
+//                clone gives you the placeholder band, which is the mistake reference/NODE-MAP.md
+//                warns about: the header hugs its text, so the band moves when the real title
+//                lands. A one-line title + one-line subtitle takes Static Vertical's band from
+//                118 to 70.
+//     groupId  — optional; the imported chart group, once it exists. Give it and you also get the
+//                group's bbox, its content aspect, and the scale needed to fit the band.
+//     hideIds  — optional; nodes to EXCLUDE from the group's measured bbox (grapher's `connectors`
+//                and year markers extend past the plot). This computes the bbox as if they were
+//                hidden, WITHOUT hiding them — so the aspect you get is the one you will actually
+//                fit, and the file is untouched. reference/FITTING.md: hiding the elbows moved a
+//                measured aspect from 1.6026 to 1.5558, turning a 14px gap into 9.5px.
+//
+// Feed `contentAspect` from the output straight into
+//   scripts/solve_export.py --band <W>x<H> --content-aspect <A>
+// which then emits the corrected curl. Those two together are what remove the re-export per page.
+
+const CONFIG = {
+  frameId: "5332:75", // the template clone
+  groupId: null, // the imported chart group, or null
+  hideIds: [], // e.g. ["I123:4;5:6"] for connectors / year markers
+};
+
+const r = (v) => (v === null || v === undefined ? null : Math.round(v * 100) / 100);
+
+// How many lines a TEXT node actually renders on. `lineHeight` may be AUTO or a percentage, so
+// resolve it to px first; fall back to 1.2x the font size, which is Figma's AUTO factor.
+const renderedLines = (t) => {
+  const fs = typeof t.fontSize === "number" ? t.fontSize : null;
+  const lh = t.lineHeight;
+  let px = null;
+  if (lh && lh.unit === "PIXELS") px = lh.value;
+  else if (lh && lh.unit === "PERCENT" && fs) px = (lh.value / 100) * fs;
+  else if (fs) px = fs * 1.2;
+  return px ? Math.max(1, Math.round(t.height / px)) : null;
+};
+
+const frame = await figma.getNodeByIdAsync(CONFIG.frameId);
+if (!frame) throw new Error(`frameId ${CONFIG.frameId} not found`);
+
+// A node is only readable once its page is loaded, and a script may switch pages once.
+let page = frame;
+while (page && page.type !== "PAGE") page = page.parent;
+if (page && figma.currentPage !== page) await figma.setCurrentPageAsync(page);
+
+const fb = frame.absoluteBoundingBox;
+
+// --- header and footer, resolved STRUCTURALLY (topmost / bottommost auto-layout child).
+// Names are not stable across design edits and a whole generation of them has already been
+// replaced; verify_templates.js uses this same resolver for the same reason. Match ANY direction:
+// DI's footer is HORIZONTAL, and a VERTICAL-only filter silently drops it.
+const logo = frame.children.find((c) => /^logo/i.test(c.name) || /^Logos\//.test(c.name)) || null;
+const autos = frame.children
+  .filter((c) => "layoutMode" in c && c.layoutMode !== "NONE" && c !== logo)
+  .sort((a, b) => a.y - b.y);
+const header = autos[0] || null;
+const footer = autos.length > 1 ? autos[autos.length - 1] : null;
+
+// A source row raised inside its footer lifts the band above the footer's own y.
+let footerTop = footer ? footer.y : null;
+if (footer && "children" in footer && footer.children.length) {
+  const minChildY = Math.min(...footer.children.map((c) => c.y));
+  footerTop = footer.y + Math.min(0, minChildY);
+}
+
+const bandTop = header ? r(header.y + header.height) : null;
+const band = bandTop !== null && footerTop !== null ? { top: bandTop, bottom: r(footerTop), height: r(footerTop - bandTop) } : null;
+
+// --- content box: the horizontal inset the template's own rows sit at.
+const rows = frame.children.filter((c) => c !== logo && "absoluteBoundingBox" in c && c.absoluteBoundingBox);
+const contentX = rows.length ? r(Math.min(...rows.map((c) => c.x))) : null;
+const contentW = rows.length ? r(Math.max(...rows.map((c) => c.x + c.width)) - contentX) : null;
+
+// --- header sizing: does the band actually move with the copy?
+// FIXED with a FILL child does NOT reflow — the band stays at the placeholder value however short
+// the title, and the slack is absorbed by the flexible child's box instead, burying dead air under
+// the subtitle. Nothing renders wrong, so it survives a screenshot.
+const headerSizing = header
+  ? {
+      primaryAxisSizingMode: header.primaryAxisSizingMode,
+      itemSpacing: header.itemSpacing,
+      children: header.children.map((c) => ({
+        name: c.name,
+        type: c.type,
+        h: r(c.height),
+        // RENDERED lines, inferred from height / lineHeight. Counting `\n` in `characters` is the
+        // trap: a wrapped title has no newline in it, so an explicit-break count reports a
+        // two-line placeholder as 1 and the band arithmetic below looks wrong for no reason.
+        lines: c.type === "TEXT" ? renderedLines(c) : null,
+        textAutoResize: c.type === "TEXT" ? c.textAutoResize : null,
+        layoutSizingVertical: "layoutSizingVertical" in c ? c.layoutSizingVertical : null,
+        layoutGrow: "layoutGrow" in c ? c.layoutGrow : null,
+      })),
+      reflows:
+        header.primaryAxisSizingMode === "AUTO" &&
+        header.children.every((c) => !("layoutGrow" in c) || c.layoutGrow === 0),
+    }
+  : null;
+
+// --- the imported group
+let group = null;
+if (CONFIG.groupId) {
+  const g = await figma.getNodeByIdAsync(CONFIG.groupId);
+  if (!g) throw new Error(`groupId ${CONFIG.groupId} not found`);
+  const hide = new Set(CONFIG.hideIds || []);
+
+  // Union the bboxes of visible leaves, skipping the hideIds subtrees. Doing it from leaves is what
+  // lets us answer "what would the aspect be with the connectors hidden" without hiding anything.
+  let x0 = Infinity,
+    y0 = Infinity,
+    x1 = -Infinity,
+    y1 = -Infinity;
+  const walk = (n) => {
+    if (hide.has(n.id)) return;
+    if ("visible" in n && !n.visible) return;
+    if ("children" in n && n.children.length) {
+      n.children.forEach(walk);
+      return;
+    }
+    const b = n.absoluteBoundingBox;
+    if (!b || b.width === 0 || b.height === 0) return;
+    x0 = Math.min(x0, b.x);
+    y0 = Math.min(y0, b.y);
+    x1 = Math.max(x1, b.x + b.width);
+    y1 = Math.max(y1, b.y + b.height);
+  };
+  walk(g);
+
+  const raw = g.absoluteBoundingBox;
+  const w = x1 - x0,
+    h = y1 - y0;
+  group = {
+    id: g.id,
+    name: g.name,
+    declared: { w: r(raw.width), h: r(raw.height), aspect: r(raw.width / raw.height) },
+    measured: { w: r(w), h: r(h), aspect: r(w / h) },
+    excluded: CONFIG.hideIds.length,
+    // What Step 7 actually asks for: the uniform factor that makes the group span the content
+    // width. rescale(), never resize() — resize stretches children through their constraints and
+    // silently rewraps every text box in the chart.
+    scaleToContentW: contentW ? r(contentW / w) : null,
+    heightAtThatScale: contentW ? r((h * contentW) / w) : null,
+    gapPerEnd: contentW && band ? r((band.height - (h * contentW) / w) / 2) : null,
+  };
+
+  // font-size histogram, and what each size becomes once scaled in
+  const sizes = {};
+  const texts = g.findAllWithCriteria ? g.findAllWithCriteria({ types: ["TEXT"] }) : [];
+  for (const t of texts) {
+    if (!t.visible) continue;
+    const fs = typeof t.fontSize === "number" ? t.fontSize : "mixed";
+    sizes[fs] = (sizes[fs] || 0) + 1;
+  }
+  group.fontSizes = Object.entries(sizes)
+    .sort((a, b) => b[1] - a[1])
+    .map(([size, n]) => ({
+      size: size === "mixed" ? "mixed" : Number(size),
+      count: n,
+      afterScale: size === "mixed" || !group.scaleToContentW ? null : r(Number(size) * group.scaleToContentW),
+    }));
+}
+
+return {
+  frame: { id: frame.id, name: frame.name, w: r(fb.width), h: r(fb.height) },
+  contentBox: { x: contentX, w: contentW },
+  header: header ? { id: header.id, name: header.name, y: r(header.y), h: r(header.height) } : null,
+  footer: footer ? { id: footer.id, name: footer.name, y: r(footer.y), h: r(footer.height), layoutMode: footer.layoutMode } : null,
+  band,
+  headerSizing,
+  group,
+  // Read these before trusting the numbers above.
+  notes: [
+    headerSizing && headerSizing.reflows === false
+      ? "HEADER DOES NOT REFLOW — the band is a constant, not a measurement. Fix the CLONE (primaryAxisSizingMode AUTO, both children HUG + HEIGHT, layoutGrow 0), never the shared template, and say so in your report."
+      : null,
+    CONFIG.groupId && CONFIG.hideIds.length === 0
+      ? "hideIds is empty — if the chart has `connectors` or year markers, the measured aspect includes them and will move once you hide them. Pass their ids."
+      : null,
+    group && group.gapPerEnd !== null && (group.gapPerEnd < 12 || group.gapPerEnd > 16)
+      ? `gapPerEnd ${group.gapPerEnd} is outside the 12-16px target — re-solve the export with scripts/solve_export.py --content-aspect ${group.measured.aspect}`
+      : null,
+  ].filter(Boolean),
+};

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -22,6 +22,12 @@
 //                is the one you will actually fit, the histogram covers only text that survives,
 //                and the file is untouched. reference/FITTING.md: hiding the elbows moved a
 //                measured aspect from 1.6026 to 1.5558, turning a 14px gap into 9.5px.
+//     slug     — optional, but needed for a runnable second pass: the grapher slug the first export
+//     params     came from, plus any query params it carried (a country selection, an MDim view).
+//                solve_export.py prints its `curl` only when it gets `--slug`, so without these
+//                `nextPass` solves the numbers and leaves you to rebuild the request by hand — which
+//                is where a selection or a view param gets dropped and the re-export quietly comes
+//                back with different data.
 //
 // The `nextPass` field in the output is the finished second-pass command — run it as printed. Do
 // NOT hand-build it by feeding the measured aspect back as `--content-aspect`: the solve would then
@@ -36,6 +42,8 @@ const CONFIG = {
   hideIds: [], // e.g. ["I123:4;5:6"] for connectors / year markers
   targetGap: 14, // px per end the fit aims for; 12-16 on 540-wide frames, 30 on the IG portrait
   targetLabel: 13.5, // final label px the first export was solved for; the portrait ladder uses 15
+  slug: "", // grapher slug the first export came from, e.g. "life-expectancy"
+  params: "", // the first export's extra query params, e.g. "country=USA~CHN" or an MDim view
 };
 
 // Normalized CONFIG reads, so deleting a line from the block above degrades to the house default
@@ -43,8 +51,13 @@ const CONFIG = {
 const hideIds = CONFIG.hideIds || [];
 const targetGap = CONFIG.targetGap ?? 14;
 const targetLabel = CONFIG.targetLabel ?? 13.5;
+const slug = CONFIG.slug || "";
+const params = CONFIG.params || "";
 
 const r = (v) => (v === null || v === undefined ? null : Math.round(v * 100) / 100);
+// Aspects and scale factors need more than 2dp: `rescale(1.14)` where 1.1433 was meant lands a
+// 343px band height ~1px short, and the docs and `--content-aspect` both speak in 4dp aspects.
+const r4 = (v) => (v === null || v === undefined ? null : Math.round(v * 10000) / 10000);
 
 // How many lines a TEXT node actually renders on. `lineHeight` may be AUTO or a percentage, so
 // resolve it to px first; fall back to 1.2x the font size, which is Figma's AUTO factor.
@@ -92,8 +105,8 @@ const band = bandTop !== null && footerTop !== null ? { top: bandTop, bottom: r(
 // --- content box: taken from the HEADER, exactly as verify_templates.js does it (`header.x` /
 // `header.width`), because by Step 7 the imported chart is already a child of this frame — the docs
 // require appending it before positioning — and a union over `frame.children` would then include the
-// not-yet-fitted group. That inflates the box to the group's own width and `scaleToContentW` comes
-// out near 1, i.e. "no scaling needed", which is the one answer this script exists to produce.
+// not-yet-fitted group. That inflates the box to the group's own width, so `xMapShortfall` comes out
+// near 0, i.e. "nothing left to close", which is the one answer this script exists to produce.
 const contentX = header ? r(header.x) : null;
 const contentW = header ? r(header.width) : null;
 
@@ -223,36 +236,56 @@ if (groupNode) {
   const raw = g.absoluteBoundingBox;
   const w = x1 - x0,
     h = y1 - y0;
+
+  // What Step 7 actually asks for is the HEIGHT-first factor. reference/FITTING.md: "Fit to the
+  // band's height, then map x to fill the width — not the other way round", and again in Step 8's
+  // recipe, `chart.rescale(TARGET_H / chart.height)  // height-first; never resize()`. The
+  // width-first `contentW / w` is the move those lines open by rejecting — it locks the width and
+  // leaves the height wherever the export's aspect fell — so this reports TARGET_H / h instead. On
+  // the docs' own near-miss (measured 1.4342 against a 1.4810 target) width-first comes out 3.3%
+  // large, which would also land in every fontSizes.afterScale below: about 0.5px at 15px, enough
+  // to pick the wrong rung off Step 8c's ladder.
+  //
+  // rescale(), never resize() — resize stretches children through their constraints and silently
+  // rewraps every text box in the chart.
+  const targetH = band ? band.height - 2 * targetGap : null;
+  const fitScale = targetH !== null && targetH > 0 ? targetH / h : null;
+
   group = {
     id: g.id,
     name: g.name,
-    declared: raw ? { w: r(raw.width), h: r(raw.height), aspect: r(raw.width / raw.height) } : null,
-    measured: { w: r(w), h: r(h), aspect: r(w / h) },
+    declared: raw ? { w: r(raw.width), h: r(raw.height), aspect: r4(raw.width / raw.height) } : null,
+    measured: { w: r(w), h: r(h), aspect: r4(w / h) },
     excluded: { requested: hideIds.length, matched: hideIds.length - unmatched.length, unmatched },
-    // What Step 7 actually asks for: the uniform factor that makes the group span the content
-    // width. rescale(), never resize() — resize stretches children through their constraints and
-    // silently rewraps every text box in the chart.
-    scaleToContentW: contentW ? r(contentW / w) : null,
-    heightAtThatScale: contentW ? r((h * contentW) / w) : null,
-    gapPerEnd: contentW && band ? r((band.height - (h * contentW) / w) / 2) : null,
+    fitScaleToBandH: r4(fitScale),
+    // The height fit lands the targetGap per end BY CONSTRUCTION, so the gap is no longer the
+    // diagnostic — the leftover width is. `xMapShortfall` is what the closed-form x-map has to
+    // close, and it IS the aspect miss expressed in px; a value far from 0 means re-export.
+    widthAtFitScale: fitScale === null ? null : r(w * fitScale),
+    xMapShortfall: fitScale === null || !contentW ? null : r(contentW - w * fitScale),
   };
 
   // The second pass, solved rather than guessed. `target` is the aspect the group has to have for
   // the gap to come out at targetGap; `measured` is what it actually came back as; the export to
   // request next is the one solved for the reflection of the measured aspect about the target.
   const gap = targetGap;
-  const usable = band ? band.height - 2 * gap : null;
+  const usable = targetH;
   if (contentW && usable > 0) {
     const target = contentW / usable;
     const measured = w / h;
     // --target-label has to travel with the correction: solve_export.py defaults to 13.5, so a
     // portrait solved at 15 would come back with smaller text purely from re-solving the aspect.
+    // --slug/--params travel for the same reason one step further out: solve_export.py emits its
+    // curl only with --slug, and rebuilding the URL by hand is where a country selection or an MDim
+    // view param gets dropped and the re-export silently returns different data.
     // Runnable as printed, from the repo root: these scripts are committed non-executable like every
     // other script in this directory, and the repo rule is that Python goes through the venv.
     const cmd =
       ".venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py" +
-      ` --band ${contentW}x${r(band.height)} --gap ${gap} --target-label ${targetLabel}`;
-    group.target = { aspect: r(target), gap, usableHeight: r(usable) };
+      ` --band ${contentW}x${r(band.height)} --gap ${gap} --target-label ${targetLabel}` +
+      (slug ? ` --slug ${slug}` : "") +
+      (params ? ` --params '${params}'` : "");
+    group.target = { aspect: r4(target), gap, usableHeight: r(usable) };
     // The reflection only cancels a small model error. A group that is far off the target is not a
     // near-miss to correct but something else — the wrong export, or furniture still in the bbox —
     // and reflecting it would ask for an absurd aspect, so fall back to a plain first-pass solve.
@@ -278,7 +311,8 @@ if (groupNode) {
     .map(([size, n]) => ({
       size: size === "mixed" ? "mixed" : Number(size),
       count: n,
-      afterScale: size === "mixed" || !group.scaleToContentW ? null : r(Number(size) * group.scaleToContentW),
+      // the height-first fit factor, so these are the sizes Step 8c actually picks its rung from
+      afterScale: size === "mixed" || fitScale === null ? null : r(Number(size) * fitScale),
     }));
 }
 
@@ -305,8 +339,14 @@ return {
     group && group.excluded.unmatched.length
       ? `hideIds NOT FOUND under the group: ${group.excluded.unmatched.join(", ")}. Nothing was excluded for them, so the measured aspect still contains whatever they were meant to remove. Re-read the ids off this group — an id from another page or another chart looks identical and excludes nothing.`
       : null,
-    group && group.gapPerEnd !== null && Math.abs(group.gapPerEnd - targetGap) > 2
-      ? `gapPerEnd ${group.gapPerEnd} is more than 2px off the ${targetGap}px target — re-export with the \`nextPass\` command above (read \`nextPassNote\` first if it is set).`
+    // 6px of leftover width is the old "2px off the target gap" threshold re-expressed for the
+    // height-first fit: |gap error| = |xMapShortfall| / (2 x measured aspect), so at the aspects
+    // these templates run (~1.4-1.6) the two trip at very nearly the same aspect miss.
+    group && group.xMapShortfall !== null && Math.abs(group.xMapShortfall) > 6
+      ? `the height-fitted group lands ${group.xMapShortfall}px off the ${contentW}px content width — that leftover IS the aspect miss in px, and it is more than the x-map should be asked to close. Re-export with the \`nextPass\` command above (read \`nextPassNote\` first if it is set). The ${targetGap}px gap per end is already correct by construction, so do not judge this fit by the gap.`
+      : null,
+    group && group.nextPass && !slug
+      ? "CONFIG.slug is empty, so `nextPass` solves the numbers but prints no curl — solve_export.py emits the re-export command only with `--slug`. Set `slug` (and `params`, for a country selection or an MDim view) to what the first export used, so the second pass runs as printed instead of being rebuilt by hand."
       : null,
   ].filter(Boolean),
 };

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Solve a grapher embed export so the imported chart fills a template band on the first try.
+
+Requesting the aspect you *want* is the mistake: grapher insets the drawing inside the SVG it hands
+back, so the group Figma imports is smaller than the declared size — and it is the group that has to
+fill the band. Ask for the aspect that *yields* the one you want instead.
+
+The model, from `reference/FITTING.md` and Step 3:
+
+    inset       ~= 1.4 * imFontSize on each axis
+    canvas       : W * H ~= 510000 px^2   (the server renormalizes to this)
+    content      : (W - 1.4F) x (H - 1.4F)
+    label size   ~= 0.75 * F, then scaled by (placed width / content width)
+
+Substituting W = 510000/H into (W - 1.4F)/(H - 1.4F) = A gives a quadratic in H:
+
+    A*H^2 + 1.4*F*(1 - A)*H - 510000 = 0
+
+which this solves in closed form. F is then found by bisection, because the content width that sets
+the final label size itself depends on F.
+
+Accurate to a few px, which is what the docs claim ("expect at most one correction"). Passing a
+--content-aspect measured off a real import removes even that.
+
+Usage:
+    solve_export.py --band 508x371 --slug life-expectancy
+    solve_export.py --band 508x371 --target-label 15 --params "country=USA~CHN&tab=chart"
+    solve_export.py --band 302x220 --thumbnail --slug life-expectancy
+
+Self-test (validates the model against the two worked examples in the docs):
+    solve_export.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+
+CANVAS_AREA = 510_000.0  # px^2 the server renormalizes an uncaptioned/default export to
+INSET_PER_FONT = 1.4  # inset on each axis, as a multiple of imFontSize
+LABEL_RATIO = 0.75  # segment values / entity names, as a multiple of the base font
+MIN_LABEL = 12.0  # the floor the guidelines set for a full-size chart
+
+
+def solve_canvas(content_aspect: float, font: float) -> tuple[float, float]:
+    """Return the (W, H) to request so the *content* comes back at content_aspect."""
+    a = content_aspect
+    b = INSET_PER_FONT * font * (1.0 - a)
+    disc = b * b + 4.0 * a * CANVAS_AREA
+    h = (-b + math.sqrt(disc)) / (2.0 * a)
+    return CANVAS_AREA / h, h
+
+
+def content_box(w: float, h: float, font: float) -> tuple[float, float]:
+    return w - INSET_PER_FONT * font, h - INSET_PER_FONT * font
+
+
+def label_at(font: float, content_w: float, placed_w: float) -> float:
+    """Final on-page label size once the export is scaled to placed_w."""
+    return LABEL_RATIO * font * (placed_w / content_w)
+
+
+def solve_font(content_aspect: float, placed_w: float, target_label: float) -> float:
+    """Bisect for the imFontSize whose labels land on target_label at placed_w."""
+    lo, hi = 8.0, 200.0
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        w, h = solve_canvas(content_aspect, mid)
+        cw, _ = content_box(w, h, mid)
+        if label_at(mid, cw, placed_w) < target_label:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2.0
+
+
+def self_test() -> int:
+    """The two exports recorded in the docs, reproduced from the model."""
+    cases = [
+        # font, declared WxH, content WxH  (reference/FITTING.md / Step 3)
+        (32.0, 901.0, 566.0, 857.0, 520.0),
+        (30.0, 862.0, 591.0, 818.9, 550.0),
+    ]
+    worst = 0.0
+    print(f"{'F':>5} {'aspect':>8} {'W pred':>8} {'W obs':>7} {'H pred':>8} {'H obs':>7} {'err px':>7}")
+    for font, dw, dh, cw, ch in cases:
+        w, h = solve_canvas(cw / ch, font)
+        err = max(abs(w - dw), abs(h - dh))
+        worst = max(worst, err)
+        print(f"{font:5.0f} {cw / ch:8.4f} {w:8.1f} {dw:7.0f} {h:8.1f} {dh:7.0f} {err:7.1f}")
+        # and the inset model itself
+        pcw, pch = content_box(dw, dh, font)
+        print(f"      inset check: content {pcw:.1f}x{pch:.1f} vs observed {cw:.1f}x{ch:.1f}")
+    print(f"\nworst canvas error: {worst:.1f}px — docs state the model is approximate (+-3px)")
+    ok = worst <= 3.0
+    print("PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--band", help="the band to fill, in template px, e.g. 508x371")
+    ap.add_argument(
+        "--content-aspect",
+        type=float,
+        help="measured content aspect of a real import — overrides the band's own aspect. "
+        "Use this for the one correction: hide connectors and year markers first, then re-read it.",
+    )
+    ap.add_argument("--target-label", type=float, default=13.5, help="desired final label px (default 13.5)")
+    ap.add_argument("--placed-width", type=float, help="width the export is placed at (default: band width)")
+    ap.add_argument("--slug", help="grapher slug, to emit a ready curl")
+    ap.add_argument("--params", default="", help="extra grapher query params, e.g. 'country=USA~CHN'")
+    ap.add_argument(
+        "--thumbnail",
+        action="store_true",
+        help="302-wide route: imType=thumbnail takes the size outright (staticBounds = imWidth/4 x "
+        "imHeight/4), so no aspect solve and no rescale. See SMALL-CHARTS.md.",
+    )
+    ap.add_argument("--self-test", action="store_true", help="validate the model against the docs")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.band:
+        ap.error("--band is required (or use --self-test)")
+
+    try:
+        bw, bh = (float(x) for x in args.band.lower().split("x"))
+    except ValueError:
+        ap.error("--band must look like 508x371")
+
+    placed_w = args.placed_width or bw
+
+    if args.thumbnail:
+        print("thumbnail route — request the pixel size directly, no solve needed:")
+        print(f"  imWidth={int(round(bw * 4))}&imHeight={int(round(bh * 4))}   (staticBounds = imWidth/4 x imHeight/4)")
+        print(f"  imFontSize: aim for {args.target_label:.0f} at 0.75x base -> ~{args.target_label / LABEL_RATIO:.0f}")
+        if args.slug:
+            p = f"{args.params}&" if args.params else ""
+            print(
+                f'\ncurl -sL "https://ourworldindata.org/grapher/{args.slug}.svg'
+                f"?{p}imType=thumbnail&imWidth={int(round(bw * 4))}&imHeight={int(round(bh * 4))}"
+                f'&imFontSize={args.target_label / LABEL_RATIO:.0f}&nocache" -o thumb.svg'
+            )
+        return 0
+
+    aspect = args.content_aspect if args.content_aspect else bw / bh
+    font = solve_font(aspect, placed_w, args.target_label)
+    w, h = solve_canvas(aspect, font)
+    cw, ch = content_box(w, h, font)
+    label = label_at(font, cw, placed_w)
+    im_w = int(round(w / h * 1000))
+
+    src = "measured content aspect" if args.content_aspect else "band aspect"
+    print(f"band            {bw:g} x {bh:g}   (aspect {bw / bh:.4f})")
+    print(f"solving for     {aspect:.4f}  [{src}]")
+    print(f"placed at       {placed_w:g}px wide")
+    print()
+    print(f"imFontSize      {font:.0f}")
+    print(f"imWidth/Height  {im_w}/1000        (aspect ratio only — the server renormalizes)")
+    print(f"declared        {w:.0f} x {h:.0f}   ({w * h:,.0f} px^2)")
+    print(f"content         {cw:.1f} x {ch:.1f}   (aspect {cw / ch:.4f})")
+    print(f"scale into band {placed_w / cw:.4f}")
+    print(f"final labels    {label:.1f}px", end="")
+    if label < MIN_LABEL:
+        print(f"   *** under the {MIN_LABEL:g}px floor — raise --target-label or cut entities")
+    else:
+        print()
+
+    if args.slug:
+        p = f"{args.params}&" if args.params else ""
+        print(
+            f'\ncurl -sL "https://ourworldindata.org/grapher/{args.slug}.svg'
+            f"?{p}imType=uncaptioned&imWidth={im_w}&imHeight=1000&imFontSize={font:.0f}"
+            f'&nocache" -o embed.svg'
+        )
+        print("\nthen check what came back, and correct once if the group's aspect moved:")
+        print("  head -c 300 embed.svg")
+        print("  grep -oE 'font-size=\"[0-9.]+\"' embed.svg | sort | uniq -c | sort -rn | head -3")
+    print(
+        "\nHide connectors and year markers BEFORE measuring the group — they extend past the plot,"
+        "\nso hiding them narrows it and makes it relatively taller. Re-run with --content-aspect"
+        "\nfrom the group you are actually going to fit."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -25,17 +25,23 @@ edge to edge with a zero-pixel gap, which `measure_fit.js` then flags and you re
 14 by default with 12-16 the comfortable range on the 540-wide frames, but it is a flag because the
 Instagram portrait runs at 30 (reference/FITTING.md).
 
-Accurate to a few px, which is what the docs claim ("expect at most one correction"). Passing a
---content-aspect measured off a real import removes even that.
+Accurate to a few px, which is what the docs claim ("expect at most one correction"). To spend that
+correction, take the `nextPass` command `measure_fit.js` prints — do NOT pass the aspect you measured
+off the import back in as --content-aspect. Solving for the aspect you already got aims at the miss
+instead of at the target and roughly doubles it; the correction has to be the reflection of the
+measured aspect about the target, `2*target - measured`, which is what `nextPass` carries.
 
-Usage:
-    solve_export.py --band 508x371 --slug life-expectancy
-    solve_export.py --band 508x371 --gap 30 --target-label 15 --params "country=USA~CHN"
-    solve_export.py --band 302x220 --thumbnail --slug life-expectancy
+Usage — from the repo root, through the venv (this file is committed non-executable, like every
+other script in this directory):
+
+    S=.claude/skills/create-figma-chart/scripts/solve_export.py
+    .venv/bin/python $S --band 508x371 --slug life-expectancy
+    .venv/bin/python $S --band 508x371 --gap 30 --target-label 15 --params "country=USA~CHN"
+    .venv/bin/python $S --band 302x220 --thumbnail --slug life-expectancy
 
 Self-test (validates the model against the worked examples in the docs, and round-trips the band
 arithmetic — the solved content, scaled into the band, must leave exactly --gap at each end):
-    solve_export.py --self-test
+    .venv/bin/python $S --self-test
 """
 
 from __future__ import annotations
@@ -143,8 +149,10 @@ def main() -> int:
     ap.add_argument(
         "--content-aspect",
         type=float,
-        help="measured content aspect of a real import — overrides the band's own aspect. "
-        "Use this for the one correction: hide connectors and year markers first, then re-read it.",
+        help="the content aspect to solve for, bypassing the band/gap derivation. This is the "
+        "TARGET, not the measurement: pass the reflected value from measure_fit.js's `nextPass` "
+        "(2*target - measured), never the aspect you just measured off the import, which aims the "
+        "solve at the miss and doubles it.",
     )
     ap.add_argument(
         "--gap",
@@ -245,7 +253,7 @@ def main() -> int:
     scale = placed_w / cw
     gap_each_end = (bh - ch * scale) / 2.0
 
-    src = "measured content aspect" if args.content_aspect else "band minus gaps"
+    src = "explicit target aspect" if args.content_aspect else "band minus gaps"
     print(f"band            {bw:g} x {bh:g}   (aspect {bw / bh:.4f})")
     print(f"usable          {bw:g} x {usable_h:g}   (aspect {bw / usable_h:.4f}, {args.gap:g}px gap per end)")
     print(f"solving for     {aspect:.4f}  [{src}]")
@@ -279,8 +287,10 @@ def main() -> int:
         print("  grep -oE 'font-size=\"[0-9.]+\"' embed.svg | sort | uniq -c | sort -rn | head -3")
     print(
         "\nHide connectors and year markers BEFORE measuring the group — they extend past the plot,"
-        "\nso hiding them narrows it and makes it relatively taller. Re-run with --content-aspect"
-        "\nfrom the group you are actually going to fit."
+        "\nso hiding them narrows it and makes it relatively taller. Then measure with"
+        "\nscripts/measure_fit.js and run the `nextPass` command it prints: it reflects the measured"
+        "\naspect about the target for you. Passing the measured aspect straight back to"
+        "\n--content-aspect solves for the miss and doubles it."
     )
     return 0
 

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -49,6 +49,7 @@ INSET_PER_FONT = 1.4  # inset on each axis, as a multiple of imFontSize
 LABEL_RATIO = 0.75  # segment values / entity names, as a multiple of the base font
 MIN_LABEL = 12.0  # the floor the guidelines set for a full-size chart
 DEFAULT_GAP = 14.0  # px at each end of the band; 12-16 is the house range on 540-wide frames
+DEFAULT_TARGET_LABEL = 13.5  # final label px on a 540-wide frame; the portrait ladder uses 15
 
 # 302-wide thumbnail route (SMALL-CHARTS.md). imType=thumbnail returns early from extractOptions, so
 # imWidth/imHeight are the canvas outright — but grapher still insets the ink inside that canvas, so
@@ -155,7 +156,7 @@ def main() -> int:
     ap.add_argument(
         "--target-label",
         type=float,
-        help=f"desired final label px (default 13.5, or {THUMB_TARGET_LABEL:g} on --thumbnail)",
+        help=f"desired final label px (default {DEFAULT_TARGET_LABEL:g}, or {THUMB_TARGET_LABEL:g} on --thumbnail)",
     )
     ap.add_argument("--placed-width", type=float, help="width the export is placed at (default: band width)")
     ap.add_argument("--slug", help="grapher slug, to emit a ready curl")
@@ -199,7 +200,8 @@ def main() -> int:
         ap.error(f"--content-aspect must be positive, got {args.content_aspect:g}")
 
     placed_w = args.placed_width or bw
-    target_label = args.target_label if args.target_label is not None else (THUMB_TARGET_LABEL if args.thumbnail else 13.5)
+    default_label = THUMB_TARGET_LABEL if args.thumbnail else DEFAULT_TARGET_LABEL
+    target_label = args.target_label if args.target_label is not None else default_label
 
     if args.thumbnail:
         # Target the ink, not the frame: a 302-wide canvas puts its ink at 7.2 ... 294.2, which

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -24,8 +24,13 @@ Substituting W = 510000/H into (W - 1.4F)/(H - 1.4F) = A gives a quadratic in H:
 
     A*H^2 + 1.4*F*(1 - A)*H - 510000 = 0
 
-which this solves in closed form. F is then found by bisection, because the content width that sets
-the final label size itself depends on F.
+which this solves in closed form. F is then found by bisection, because the content height that
+sets the final label size itself depends on F -- and is then ROUNDED, because `imFontSize` travels in
+the URL as an integer. Every number reported is recomputed from that integer, so the predicted label
+size is the one the emitted `curl` will actually produce rather than the one the ideal font would
+have: at 508x371 with the reflected aspect 1.5279 the ideal font is 28.6 and the request carries 29,
+which lands labels at 13.7px, not the 13.5px asked for. The aspect is unaffected -- the canvas solve
+enforces it at any font -- so the gap and the x-map leftover stay exact.
 
 The band is not the target. Step 7 fits the chart to `band - 2*gap`, not to the band itself, so the
 aspect to solve for is `bandW / (bandH - 2*gap)`. Solving for the band's own aspect lands the chart
@@ -65,6 +70,9 @@ LABEL_RATIO = 0.75  # segment values / entity names, as a multiple of the base f
 MIN_LABEL = 12.0  # the floor the guidelines set for a full-size chart
 DEFAULT_GAP = 14.0  # px at each end of the band; 12-16 is the house range on 540-wide frames
 DEFAULT_TARGET_LABEL = 13.5  # final label px on a 540-wide frame; the portrait ladder uses 15
+# How far an INTEGER imFontSize can leave the final label from --target-label: half a font step,
+# 0.5 * target / F, which is ~0.25px at the 13.5px/F=29 and 15px/F=27 the templates run.
+ROUNDING_TOLERANCE = 0.25
 
 # 302-wide thumbnail route (SMALL-CHARTS.md). imType=thumbnail returns early from extractOptions, so
 # imWidth/imHeight are the canvas outright — but grapher still insets the ink inside that canvas, so
@@ -138,57 +146,78 @@ def self_test() -> int:
     # at each end, land the full band width (nothing for the x-map to close) and hit target_label.
     # A zero-gap solve here is one regression this covers — it is what a chart crowding the header
     # and footer looks like.
+    # `F` is the ideal bisection result and `emit` the integer the URL carries; `label` is measured
+    # against `emit`, because that is the export you actually get. ROUNDING_TOLERANCE bounds how far
+    # an integer imFontSize can leave the label from its target (half a font step, ~0.5*target/F).
     bands = [(508.0, 371.0, 14.0, 13.5), (508.0, 371.0, 12.0, 13.5), (508.0, 552.0, 30.0, 15.0)]
-    print(f"\n{'band':>12} {'gap':>5} {'F':>4} {'content':>15} {'gap/end':>8} {'x-map':>7} {'label':>7}")
+    print(
+        f"\n{'band':>12} {'gap':>5} {'F':>7} {'emit':>5} {'content':>15} "
+        f"{'gap/end':>8} {'x-map':>7} {'label':>7} {'err':>6}"
+    )
     worst_gap = 0.0
     worst_xmap = 0.0
+    worst_ideal = 0.0
     worst_label = 0.0
     for bw, bh, gap, target in bands:
         usable = bh - 2.0 * gap
-        font = solve_font(bw / usable, usable, target)
+        font_exact = solve_font(bw / usable, usable, target)
+        font = float(round(font_exact))
         w, h = solve_canvas(bw / usable, font)
         cw, ch = content_box(w, h, font)
         scale = usable / ch
         got_gap = (bh - ch * scale) / 2.0
         xmap = bw - cw * scale
         label = label_at(font, ch, usable)
+        _, ch_exact = content_box(*solve_canvas(bw / usable, font_exact), font_exact)
         worst_gap = max(worst_gap, abs(got_gap - gap))
         worst_xmap = max(worst_xmap, abs(xmap))
+        worst_ideal = max(worst_ideal, abs(label_at(font_exact, ch_exact, usable) - target))
         worst_label = max(worst_label, abs(label - target))
         print(
-            f"{f'{bw:g}x{bh:g}':>12} {gap:5.0f} {font:4.0f} {f'{cw:.1f}x{ch:.1f}':>15} "
-            f"{got_gap:8.2f} {xmap:7.3f} {label:7.2f}"
+            f"{f'{bw:g}x{bh:g}':>12} {gap:5.0f} {font_exact:7.3f} {font:5.0f} "
+            f"{f'{cw:.1f}x{ch:.1f}':>15} {got_gap:8.2f} {xmap:7.3f} {label:7.2f} {label - target:+6.3f}"
         )
     print(
-        f"\nworst gap error {worst_gap:.3f}px, worst x-map leftover {worst_xmap:.3f}px, "
-        f"worst label error {worst_label:.3f}px — all exact arithmetic (<0.01px)"
+        f"\nworst gap error {worst_gap:.3f}px and x-map leftover {worst_xmap:.3f}px — exact (<0.01px), "
+        f"rounding does not touch the aspect.\nideal-font label error {worst_ideal:.3f}px (<0.01px); "
+        f"emitted-font label error {worst_label:.3f}px (<{ROUNDING_TOLERANCE:g}px, the integer bound)"
     )
-    ok = ok and worst_gap < 0.01 and worst_xmap < 0.01 and worst_label < 0.01
+    ok = ok and worst_gap < 0.01 and worst_xmap < 0.01
+    ok = ok and worst_ideal < 0.01 and worst_label < ROUNDING_TOLERANCE
 
     # A reflected SECOND pass must still land its --target-label. The reflection is deliberately off
     # the band's own aspect, which is exactly where a width-first label scale stops agreeing with the
     # height-first fit: on the docs' 508x371 case measured at 1.4342 it asked for imFontSize 29 and
     # promised 13.5px labels the height fit renders at 13.93px, and across the miss range it picked a
     # font up to 4px off. Reflections come from measure_fit.js's `nextPass`.
-    print(f"\n{'band':>12} {'measured':>9} {'reflected':>10} {'F':>4} {'label':>7} {'want':>6} {'err':>6}")
+    print(
+        f"\n{'band':>12} {'measured':>9} {'reflected':>10} {'F':>7} {'emit':>5} "
+        f"{'ideal':>7} {'emitted':>8} {'want':>6}"
+    )
     worst_refl = 0.0
+    worst_refl_emit = 0.0
     for (bw, bh, gap, target), measured_frac in zip(bands, [-0.0316, 0.05, -0.10]):
         usable = bh - 2.0 * gap
         band_aspect = bw / usable
         measured = band_aspect * (1.0 + measured_frac)
         reflected = 2.0 * band_aspect - measured
-        font = solve_font(reflected, usable, target)
-        w, h = solve_canvas(reflected, font)
-        _, ch = content_box(w, h, font)
-        label = label_at(font, ch, usable)
-        err = abs(label - target)
-        worst_refl = max(worst_refl, err)
+        font_exact = solve_font(reflected, usable, target)
+        font = float(round(font_exact))
+        _, ch_exact = content_box(*solve_canvas(reflected, font_exact), font_exact)
+        _, ch = content_box(*solve_canvas(reflected, font), font)
+        ideal = label_at(font_exact, ch_exact, usable)
+        emitted = label_at(font, ch, usable)
+        worst_refl = max(worst_refl, abs(ideal - target))
+        worst_refl_emit = max(worst_refl_emit, abs(emitted - target))
         print(
-            f"{f'{bw:g}x{bh:g}':>12} {measured:9.4f} {reflected:10.4f} {font:4.0f} "
-            f"{label:7.2f} {target:6.1f} {err:6.3f}"
+            f"{f'{bw:g}x{bh:g}':>12} {measured:9.4f} {reflected:10.4f} {font_exact:7.3f} "
+            f"{font:5.0f} {ideal:7.2f} {emitted:8.2f} {target:6.1f}"
         )
-    print(f"\nworst reflected-pass label error: {worst_refl:.3f}px — the second pass keeps --target-label")
-    ok = ok and worst_refl < 0.01
+    print(
+        f"\nreflected pass: ideal-font label error {worst_refl:.3f}px (<0.01px), emitted-font "
+        f"{worst_refl_emit:.3f}px (<{ROUNDING_TOLERANCE:g}px) — the second pass keeps --target-label"
+    )
+    ok = ok and worst_refl < 0.01 and worst_refl_emit < ROUNDING_TOLERANCE
 
     print("PASS" if ok else "FAIL")
     return 0 if ok else 1
@@ -276,15 +305,22 @@ def main() -> int:
             ap.error(f"--margin {args.margin:g} leaves no content width in a {bw:g}px frame")
         canvas_w = content_w + 2.0 * args.ink_inset
         im_w, im_h = int(round(canvas_w * 4)), int(round(bh * 4))
-        font = target_label / LABEL_RATIO
+        # Rounded for the same reason as the main route: imFontSize is an integer in the URL, so the
+        # label size to report is the one that integer yields, not the one the target asked for.
+        font = float(round(target_label / LABEL_RATIO))
+        label = LABEL_RATIO * font
         print("thumbnail route — the canvas is taken outright, so no aspect solve and no rescale:")
         print(f"  frame           {bw:g} x {bh:g}")
         print(f"  content box     {content_w:g} wide  (margin {args.margin:g} per side)")
         print(f"  canvas          {canvas_w:.1f} wide  (+{args.ink_inset:g} ink inset per side) -> ink ~{content_w:g}")
         print(f"  imWidth/Height  {im_w}/{im_h}   (staticBounds = imWidth/4 x imHeight/4)")
-        print(f"  imFontSize      {font:.0f}   ({target_label:g}px labels at {LABEL_RATIO}x base)")
-        if target_label < THUMB_MIN_LABEL:
-            print(f"  *** {target_label:g}px is under this format's {THUMB_MIN_LABEL:g}px floor")
+        print(f"  imFontSize      {font:.0f}   ({label:g}px labels at {LABEL_RATIO}x base)", end="")
+        if abs(label - target_label) > 0.05:
+            print(f"   (asked for {target_label:g}; imFontSize is an integer)")
+        else:
+            print()
+        if label < THUMB_MIN_LABEL:
+            print(f"  *** {label:g}px is under this format's {THUMB_MIN_LABEL:g}px floor")
         if args.slug:
             p = f"{args.params}&" if args.params else ""
             print(
@@ -301,7 +337,13 @@ def main() -> int:
         ap.error(f"--gap {args.gap:g} leaves no height in a {bh:g}px band (2*gap >= band height)")
 
     aspect = args.content_aspect if args.content_aspect is not None else placed_w / usable_h
-    font = solve_font(aspect, usable_h, target_label)
+    # Solve, then round: imFontSize goes into the URL as an integer, so the integer is what the
+    # export will actually use. Recompute the canvas, the content box and the label from it —
+    # reporting the ideal font's label beside an `imFontSize` one step away promises a size the
+    # request cannot deliver. The aspect survives rounding untouched, because solve_canvas enforces
+    # it at whatever font it is given, so the gap and the x-map leftover below are still exact.
+    font_exact = solve_font(aspect, usable_h, target_label)
+    font = float(round(font_exact))
     w, h = solve_canvas(aspect, font)
     cw, ch = content_box(w, h, font)
     label = label_at(font, ch, usable_h)
@@ -323,7 +365,11 @@ def main() -> int:
     print(f"solving for     {aspect:.4f}  [{src}]")
     print(f"fitting to      {placed_w:g}px wide, height-first")
     print()
-    print(f"imFontSize      {font:.0f}")
+    print(f"imFontSize      {font:.0f}", end="")
+    if abs(font - font_exact) > 0.05:
+        print(f"   (ideal {font_exact:.1f}, rounded — the URL carries an integer)")
+    else:
+        print()
     print(f"imWidth/Height  {im_w}/1000        (aspect ratio only — the server renormalizes)")
     print(f"declared        {w:.0f} x {h:.0f}   ({w * h:,.0f} px^2)")
     print(f"content         {cw:.1f} x {ch:.1f}   (aspect {cw / ch:.4f})")
@@ -339,6 +385,8 @@ def main() -> int:
     print(f"final labels    {label:.1f}px", end="")
     if label < MIN_LABEL:
         print(f"   *** under the {MIN_LABEL:g}px floor — raise --target-label or cut entities")
+    elif abs(label - target_label) > 0.05:
+        print(f"   (asked for {target_label:g}; imFontSize {font:.0f} is the closest integer)")
     else:
         print()
 

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -19,15 +19,22 @@ Substituting W = 510000/H into (W - 1.4F)/(H - 1.4F) = A gives a quadratic in H:
 which this solves in closed form. F is then found by bisection, because the content width that sets
 the final label size itself depends on F.
 
+The band is not the target. Step 7 fits the chart to `band - 2*gap`, not to the band itself, so the
+aspect to solve for is `bandW / (bandH - 2*gap)`. Solving for the band's own aspect lands the chart
+edge to edge with a zero-pixel gap, which `measure_fit.js` then flags and you re-export. The gap is
+14 by default with 12-16 the comfortable range on the 540-wide frames, but it is a flag because the
+Instagram portrait runs at 30 (reference/FITTING.md).
+
 Accurate to a few px, which is what the docs claim ("expect at most one correction"). Passing a
 --content-aspect measured off a real import removes even that.
 
 Usage:
     solve_export.py --band 508x371 --slug life-expectancy
-    solve_export.py --band 508x371 --target-label 15 --params "country=USA~CHN&tab=chart"
+    solve_export.py --band 508x371 --gap 30 --target-label 15 --params "country=USA~CHN"
     solve_export.py --band 302x220 --thumbnail --slug life-expectancy
 
-Self-test (validates the model against the two worked examples in the docs):
+Self-test (validates the model against the worked examples in the docs, and round-trips the band
+arithmetic — the solved content, scaled into the band, must leave exactly --gap at each end):
     solve_export.py --self-test
 """
 
@@ -41,6 +48,15 @@ CANVAS_AREA = 510_000.0  # px^2 the server renormalizes an uncaptioned/default e
 INSET_PER_FONT = 1.4  # inset on each axis, as a multiple of imFontSize
 LABEL_RATIO = 0.75  # segment values / entity names, as a multiple of the base font
 MIN_LABEL = 12.0  # the floor the guidelines set for a full-size chart
+DEFAULT_GAP = 14.0  # px at each end of the band; 12-16 is the house range on 540-wide frames
+
+# 302-wide thumbnail route (SMALL-CHARTS.md). imType=thumbnail returns early from extractOptions, so
+# imWidth/imHeight are the canvas outright — but grapher still insets the ink inside that canvas, so
+# the canvas has to be solved from the *content* width, not the frame width.
+THUMB_MARGIN = 12.0  # side margin of the 302-wide templates: content box is 12 ... 290
+THUMB_INK_INSET = 7.2  # measured ink padding per side at imFontSize=16
+THUMB_TARGET_LABEL = 12.0  # top of the format's range; imFontSize=16 lands here on both types
+THUMB_MIN_LABEL = 11.0  # the format's floor — the templates' own labels are 11px by design
 
 
 def solve_canvas(content_aspect: float, font: float) -> tuple[float, float]:
@@ -94,6 +110,28 @@ def self_test() -> int:
         print(f"      inset check: content {pcw:.1f}x{pch:.1f} vs observed {cw:.1f}x{ch:.1f}")
     print(f"\nworst canvas error: {worst:.1f}px — docs state the model is approximate (+-3px)")
     ok = worst <= 3.0
+
+    # The band arithmetic, round-tripped: solve for band - 2*gap, scale the solved content to the
+    # band width, and the leftover must be exactly gap at each end. A zero-gap solve here is the
+    # regression this covers — it is what a chart crowding the header and footer looks like.
+    print(f"\n{'band':>12} {'gap':>5} {'F':>4} {'content':>15} {'scaled h':>9} {'gap/end':>8} {'err':>6}")
+    worst_gap = 0.0
+    for bw, bh, gap, target in [(508.0, 371.0, 14.0, 13.5), (508.0, 371.0, 12.0, 13.5), (508.0, 552.0, 30.0, 15.0)]:
+        usable = bh - 2.0 * gap
+        font = solve_font(bw / usable, bw, target)
+        w, h = solve_canvas(bw / usable, font)
+        cw, ch = content_box(w, h, font)
+        scaled_h = ch * (bw / cw)
+        got = (bh - scaled_h) / 2.0
+        err = abs(got - gap)
+        worst_gap = max(worst_gap, err)
+        print(
+            f"{f'{bw:g}x{bh:g}':>12} {gap:5.0f} {font:4.0f} {f'{cw:.1f}x{ch:.1f}':>15} "
+            f"{scaled_h:9.1f} {got:8.2f} {err:6.3f}"
+        )
+    print(f"\nworst gap error: {worst_gap:.3f}px — the band round-trip is exact arithmetic (<0.01px)")
+    ok = ok and worst_gap < 0.01
+
     print("PASS" if ok else "FAIL")
     return 0 if ok else 1
 
@@ -107,7 +145,18 @@ def main() -> int:
         help="measured content aspect of a real import — overrides the band's own aspect. "
         "Use this for the one correction: hide connectors and year markers first, then re-read it.",
     )
-    ap.add_argument("--target-label", type=float, default=13.5, help="desired final label px (default 13.5)")
+    ap.add_argument(
+        "--gap",
+        type=float,
+        default=DEFAULT_GAP,
+        help=f"px to leave at each end of the band (default {DEFAULT_GAP:g}; 12-16 on the 540-wide "
+        "frames, 30 on the Instagram portrait). The solve targets band height - 2*gap.",
+    )
+    ap.add_argument(
+        "--target-label",
+        type=float,
+        help=f"desired final label px (default 13.5, or {THUMB_TARGET_LABEL:g} on --thumbnail)",
+    )
     ap.add_argument("--placed-width", type=float, help="width the export is placed at (default: band width)")
     ap.add_argument("--slug", help="grapher slug, to emit a ready curl")
     ap.add_argument("--params", default="", help="extra grapher query params, e.g. 'country=USA~CHN'")
@@ -115,7 +164,22 @@ def main() -> int:
         "--thumbnail",
         action="store_true",
         help="302-wide route: imType=thumbnail takes the size outright (staticBounds = imWidth/4 x "
-        "imHeight/4), so no aspect solve and no rescale. See SMALL-CHARTS.md.",
+        "imHeight/4), so no aspect solve and no rescale. Solves the canvas from the content width "
+        "and the ink inset, so the group lands on the template's content box. See SMALL-CHARTS.md.",
+    )
+    ap.add_argument(
+        "--margin",
+        type=float,
+        default=THUMB_MARGIN,
+        help=f"--thumbnail only: side margin of the template (default {THUMB_MARGIN:g}, giving a "
+        "278px content box on a 302-wide frame)",
+    )
+    ap.add_argument(
+        "--ink-inset",
+        type=float,
+        default=THUMB_INK_INSET,
+        help=f"--thumbnail only: ink padding per side inside the canvas (default {THUMB_INK_INSET:g}, "
+        "measured at imFontSize=16 — measure the import and expect one correction)",
     )
     ap.add_argument("--self-test", action="store_true", help="validate the model against the docs")
     args = ap.parse_args()
@@ -129,31 +193,59 @@ def main() -> int:
         bw, bh = (float(x) for x in args.band.lower().split("x"))
     except ValueError:
         ap.error("--band must look like 508x371")
+    if bw <= 0 or bh <= 0:
+        ap.error(f"--band must be positive on both axes, got {bw:g}x{bh:g}")
+    if args.content_aspect is not None and args.content_aspect <= 0:
+        ap.error(f"--content-aspect must be positive, got {args.content_aspect:g}")
 
     placed_w = args.placed_width or bw
+    target_label = args.target_label if args.target_label is not None else (THUMB_TARGET_LABEL if args.thumbnail else 13.5)
 
     if args.thumbnail:
-        print("thumbnail route — request the pixel size directly, no solve needed:")
-        print(f"  imWidth={int(round(bw * 4))}&imHeight={int(round(bh * 4))}   (staticBounds = imWidth/4 x imHeight/4)")
-        print(f"  imFontSize: aim for {args.target_label:.0f} at 0.75x base -> ~{args.target_label / LABEL_RATIO:.0f}")
+        # Target the ink, not the frame: a 302-wide canvas puts its ink at 7.2 ... 294.2, which
+        # overflows the template's 12 ... 290 content box at both ends (SMALL-CHARTS.md).
+        content_w = bw - 2.0 * args.margin
+        if content_w <= 0:
+            ap.error(f"--margin {args.margin:g} leaves no content width in a {bw:g}px frame")
+        canvas_w = content_w + 2.0 * args.ink_inset
+        im_w, im_h = int(round(canvas_w * 4)), int(round(bh * 4))
+        font = target_label / LABEL_RATIO
+        print("thumbnail route — the canvas is taken outright, so no aspect solve and no rescale:")
+        print(f"  frame           {bw:g} x {bh:g}")
+        print(f"  content box     {content_w:g} wide  (margin {args.margin:g} per side)")
+        print(f"  canvas          {canvas_w:.1f} wide  (+{args.ink_inset:g} ink inset per side) -> ink ~{content_w:g}")
+        print(f"  imWidth/Height  {im_w}/{im_h}   (staticBounds = imWidth/4 x imHeight/4)")
+        print(f"  imFontSize      {font:.0f}   ({target_label:g}px labels at {LABEL_RATIO}x base)")
+        if target_label < THUMB_MIN_LABEL:
+            print(f"  *** {target_label:g}px is under this format's {THUMB_MIN_LABEL:g}px floor")
         if args.slug:
             p = f"{args.params}&" if args.params else ""
             print(
                 f'\ncurl -sL "https://ourworldindata.org/grapher/{args.slug}.svg'
-                f"?{p}imType=thumbnail&imWidth={int(round(bw * 4))}&imHeight={int(round(bh * 4))}"
-                f'&imFontSize={args.target_label / LABEL_RATIO:.0f}&nocache" -o thumb.svg'
+                f"?{p}imType=thumbnail&imWidth={im_w}&imHeight={im_h}"
+                f'&imFontSize={font:.0f}&nocache" -o thumb.svg'
             )
+        print(f"\nThe group is its own ink, so set chart.x = {args.margin:g} after import — no rescale.")
+        print("The ink inset was measured at one font size: measure the import and expect one correction.")
         return 0
 
-    aspect = args.content_aspect if args.content_aspect else bw / bh
-    font = solve_font(aspect, placed_w, args.target_label)
+    usable_h = bh - 2.0 * args.gap
+    if usable_h <= 0:
+        ap.error(f"--gap {args.gap:g} leaves no height in a {bh:g}px band (2*gap >= band height)")
+
+    aspect = args.content_aspect if args.content_aspect else bw / usable_h
+    font = solve_font(aspect, placed_w, target_label)
     w, h = solve_canvas(aspect, font)
     cw, ch = content_box(w, h, font)
     label = label_at(font, cw, placed_w)
     im_w = int(round(w / h * 1000))
 
-    src = "measured content aspect" if args.content_aspect else "band aspect"
+    scale = placed_w / cw
+    gap_each_end = (bh - ch * scale) / 2.0
+
+    src = "measured content aspect" if args.content_aspect else "band minus gaps"
     print(f"band            {bw:g} x {bh:g}   (aspect {bw / bh:.4f})")
+    print(f"usable          {bw:g} x {usable_h:g}   (aspect {bw / usable_h:.4f}, {args.gap:g}px gap per end)")
     print(f"solving for     {aspect:.4f}  [{src}]")
     print(f"placed at       {placed_w:g}px wide")
     print()
@@ -161,7 +253,12 @@ def main() -> int:
     print(f"imWidth/Height  {im_w}/1000        (aspect ratio only — the server renormalizes)")
     print(f"declared        {w:.0f} x {h:.0f}   ({w * h:,.0f} px^2)")
     print(f"content         {cw:.1f} x {ch:.1f}   (aspect {cw / ch:.4f})")
-    print(f"scale into band {placed_w / cw:.4f}")
+    print(f"scale into band {scale:.4f}")
+    print(f"predicted gap   {gap_each_end:.1f}px per end", end="")
+    if gap_each_end < 0:
+        print("   *** the chart overflows the band — raise --gap or re-check --content-aspect")
+    else:
+        print()
     print(f"final labels    {label:.1f}px", end="")
     if label < MIN_LABEL:
         print(f"   *** under the {MIN_LABEL:g}px floor — raise --target-label or cut entities")

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -10,7 +10,15 @@ The model, from `reference/FITTING.md` and Step 3:
     inset       ~= 1.4 * imFontSize on each axis
     canvas       : W * H ~= 510000 px^2   (the server renormalizes to this)
     content      : (W - 1.4F) x (H - 1.4F)
-    label size   ~= 0.75 * F, then scaled by (placed width / content width)
+    label size   ~= 0.75 * F, then scaled by (usable band height / content height)
+
+The label scale is the HEIGHT-first factor, because that is the only rescale Step 7 spends. From
+`reference/FITTING.md`: "Fit to the band's height, then map x to fill the width", and the x-map that
+follows "takes the plot out to the full content width without touching a single font size" (L243,
+L450, L456). The width-first `placed width / content width` agrees with it exactly whenever the
+solved aspect IS the band's usable aspect, so it reads as equivalent on a first pass -- and stops
+being equivalent the moment --content-aspect carries the reflected aspect of a second pass, which is
+deliberately off the band's own. There it asked for a font up to 4px away from the right one.
 
 Substituting W = 510000/H into (W - 1.4F)/(H - 1.4F) = A gives a quadratic in H:
 
@@ -39,8 +47,9 @@ other script in this directory):
     .venv/bin/python $S --band 508x371 --gap 30 --target-label 15 --params "country=USA~CHN"
     .venv/bin/python $S --band 302x220 --thumbnail --slug life-expectancy
 
-Self-test (validates the model against the worked examples in the docs, and round-trips the band
-arithmetic — the solved content, scaled into the band, must leave exactly --gap at each end):
+Self-test (validates the model against the worked examples in the docs, round-trips the band
+arithmetic — the height-fitted content must leave exactly --gap at each end and no width for the
+x-map to close — and checks that a reflected second pass still lands its --target-label):
     .venv/bin/python $S --self-test
 """
 
@@ -79,19 +88,25 @@ def content_box(w: float, h: float, font: float) -> tuple[float, float]:
     return w - INSET_PER_FONT * font, h - INSET_PER_FONT * font
 
 
-def label_at(font: float, content_w: float, placed_w: float) -> float:
-    """Final on-page label size once the export is scaled to placed_w."""
-    return LABEL_RATIO * font * (placed_w / content_w)
+def label_at(font: float, content_h: float, fitted_h: float) -> float:
+    """Final on-page label size once the export is HEIGHT-fitted to fitted_h.
+
+    Height-first because that is the only rescale Step 7 spends: the x-map that follows closes the
+    width without touching a font size (reference/FITTING.md L243/L450/L456). Identical to the
+    width-first factor when the solved aspect is the band's usable aspect; not identical, and not
+    interchangeable, once --content-aspect carries a second pass's reflected aspect.
+    """
+    return LABEL_RATIO * font * (fitted_h / content_h)
 
 
-def solve_font(content_aspect: float, placed_w: float, target_label: float) -> float:
-    """Bisect for the imFontSize whose labels land on target_label at placed_w."""
+def solve_font(content_aspect: float, usable_h: float, target_label: float) -> float:
+    """Bisect for the imFontSize whose labels land on target_label after the height fit."""
     lo, hi = 8.0, 200.0
     for _ in range(200):
         mid = (lo + hi) / 2.0
         w, h = solve_canvas(content_aspect, mid)
-        cw, _ = content_box(w, h, mid)
-        if label_at(mid, cw, placed_w) < target_label:
+        _, ch = content_box(w, h, mid)
+        if label_at(mid, ch, usable_h) < target_label:
             lo = mid
         else:
             hi = mid
@@ -118,26 +133,62 @@ def self_test() -> int:
     print(f"\nworst canvas error: {worst:.1f}px — docs state the model is approximate (+-3px)")
     ok = worst <= 3.0
 
-    # The band arithmetic, round-tripped: solve for band - 2*gap, scale the solved content to the
-    # band width, and the leftover must be exactly gap at each end. A zero-gap solve here is the
-    # regression this covers — it is what a chart crowding the header and footer looks like.
-    print(f"\n{'band':>12} {'gap':>5} {'F':>4} {'content':>15} {'scaled h':>9} {'gap/end':>8} {'err':>6}")
+    # The band arithmetic, round-tripped through the HEIGHT-first fit Step 7 actually performs:
+    # solve for band - 2*gap, rescale by usable_h / content_h, and the result must leave exactly gap
+    # at each end, land the full band width (nothing for the x-map to close) and hit target_label.
+    # A zero-gap solve here is one regression this covers — it is what a chart crowding the header
+    # and footer looks like.
+    bands = [(508.0, 371.0, 14.0, 13.5), (508.0, 371.0, 12.0, 13.5), (508.0, 552.0, 30.0, 15.0)]
+    print(f"\n{'band':>12} {'gap':>5} {'F':>4} {'content':>15} {'gap/end':>8} {'x-map':>7} {'label':>7}")
     worst_gap = 0.0
-    for bw, bh, gap, target in [(508.0, 371.0, 14.0, 13.5), (508.0, 371.0, 12.0, 13.5), (508.0, 552.0, 30.0, 15.0)]:
+    worst_xmap = 0.0
+    worst_label = 0.0
+    for bw, bh, gap, target in bands:
         usable = bh - 2.0 * gap
-        font = solve_font(bw / usable, bw, target)
+        font = solve_font(bw / usable, usable, target)
         w, h = solve_canvas(bw / usable, font)
         cw, ch = content_box(w, h, font)
-        scaled_h = ch * (bw / cw)
-        got = (bh - scaled_h) / 2.0
-        err = abs(got - gap)
-        worst_gap = max(worst_gap, err)
+        scale = usable / ch
+        got_gap = (bh - ch * scale) / 2.0
+        xmap = bw - cw * scale
+        label = label_at(font, ch, usable)
+        worst_gap = max(worst_gap, abs(got_gap - gap))
+        worst_xmap = max(worst_xmap, abs(xmap))
+        worst_label = max(worst_label, abs(label - target))
         print(
             f"{f'{bw:g}x{bh:g}':>12} {gap:5.0f} {font:4.0f} {f'{cw:.1f}x{ch:.1f}':>15} "
-            f"{scaled_h:9.1f} {got:8.2f} {err:6.3f}"
+            f"{got_gap:8.2f} {xmap:7.3f} {label:7.2f}"
         )
-    print(f"\nworst gap error: {worst_gap:.3f}px — the band round-trip is exact arithmetic (<0.01px)")
-    ok = ok and worst_gap < 0.01
+    print(
+        f"\nworst gap error {worst_gap:.3f}px, worst x-map leftover {worst_xmap:.3f}px, "
+        f"worst label error {worst_label:.3f}px — all exact arithmetic (<0.01px)"
+    )
+    ok = ok and worst_gap < 0.01 and worst_xmap < 0.01 and worst_label < 0.01
+
+    # A reflected SECOND pass must still land its --target-label. The reflection is deliberately off
+    # the band's own aspect, which is exactly where a width-first label scale stops agreeing with the
+    # height-first fit: on the docs' 508x371 case measured at 1.4342 it asked for imFontSize 29 and
+    # promised 13.5px labels the height fit renders at 13.93px, and across the miss range it picked a
+    # font up to 4px off. Reflections come from measure_fit.js's `nextPass`.
+    print(f"\n{'band':>12} {'measured':>9} {'reflected':>10} {'F':>4} {'label':>7} {'want':>6} {'err':>6}")
+    worst_refl = 0.0
+    for (bw, bh, gap, target), measured_frac in zip(bands, [-0.0316, 0.05, -0.10]):
+        usable = bh - 2.0 * gap
+        band_aspect = bw / usable
+        measured = band_aspect * (1.0 + measured_frac)
+        reflected = 2.0 * band_aspect - measured
+        font = solve_font(reflected, usable, target)
+        w, h = solve_canvas(reflected, font)
+        _, ch = content_box(w, h, font)
+        label = label_at(font, ch, usable)
+        err = abs(label - target)
+        worst_refl = max(worst_refl, err)
+        print(
+            f"{f'{bw:g}x{bh:g}':>12} {measured:9.4f} {reflected:10.4f} {font:4.0f} "
+            f"{label:7.2f} {target:6.1f} {err:6.3f}"
+        )
+    print(f"\nworst reflected-pass label error: {worst_refl:.3f}px — the second pass keeps --target-label")
+    ok = ok and worst_refl < 0.01
 
     print("PASS" if ok else "FAIL")
     return 0 if ok else 1
@@ -166,7 +217,13 @@ def main() -> int:
         type=float,
         help=f"desired final label px (default {DEFAULT_TARGET_LABEL:g}, or {THUMB_TARGET_LABEL:g} on --thumbnail)",
     )
-    ap.add_argument("--placed-width", type=float, help="width the export is placed at (default: band width)")
+    ap.add_argument(
+        "--placed-width",
+        type=float,
+        help="width the height-fitted group is placed at (default: band width). Sets the aspect to "
+        "solve for and the width the x-map has to reach — NOT the label scale, which follows the "
+        "height fit.",
+    )
     ap.add_argument("--slug", help="grapher slug, to emit a ready curl")
     ap.add_argument("--params", default="", help="extra grapher query params, e.g. 'country=USA~CHN'")
     ap.add_argument(
@@ -243,30 +300,40 @@ def main() -> int:
     if usable_h <= 0:
         ap.error(f"--gap {args.gap:g} leaves no height in a {bh:g}px band (2*gap >= band height)")
 
-    aspect = args.content_aspect if args.content_aspect else bw / usable_h
-    font = solve_font(aspect, placed_w, target_label)
+    aspect = args.content_aspect if args.content_aspect is not None else placed_w / usable_h
+    font = solve_font(aspect, usable_h, target_label)
     w, h = solve_canvas(aspect, font)
     cw, ch = content_box(w, h, font)
-    label = label_at(font, cw, placed_w)
+    label = label_at(font, ch, usable_h)
     im_w = int(round(w / h * 1000))
 
-    scale = placed_w / cw
-    gap_each_end = (bh - ch * scale) / 2.0
+    # Height-first, exactly as Step 7 fits: `chart.rescale(TARGET_H / chart.height)`. The gap is then
+    # --gap at each end by construction, so it is no longer the diagnostic — the leftover width the
+    # x-map has to close is, and it IS the aspect miss expressed in px (measure_fit.js reports the
+    # same quantity as `xMapShortfall`).
+    scale = usable_h / ch
+    fitted_w = cw * scale
+    shortfall = placed_w - fitted_w
+    if abs(shortfall) < 0.05:
+        shortfall = 0.0  # so an exact band solve prints 0.0 rather than float noise's -0.0
 
-    src = "explicit target aspect" if args.content_aspect else "band minus gaps"
+    src = "explicit target aspect" if args.content_aspect is not None else "band minus gaps"
     print(f"band            {bw:g} x {bh:g}   (aspect {bw / bh:.4f})")
     print(f"usable          {bw:g} x {usable_h:g}   (aspect {bw / usable_h:.4f}, {args.gap:g}px gap per end)")
     print(f"solving for     {aspect:.4f}  [{src}]")
-    print(f"placed at       {placed_w:g}px wide")
+    print(f"fitting to      {placed_w:g}px wide, height-first")
     print()
     print(f"imFontSize      {font:.0f}")
     print(f"imWidth/Height  {im_w}/1000        (aspect ratio only — the server renormalizes)")
     print(f"declared        {w:.0f} x {h:.0f}   ({w * h:,.0f} px^2)")
     print(f"content         {cw:.1f} x {ch:.1f}   (aspect {cw / ch:.4f})")
-    print(f"scale into band {scale:.4f}")
-    print(f"predicted gap   {gap_each_end:.1f}px per end", end="")
-    if gap_each_end < 0:
-        print("   *** the chart overflows the band — raise --gap or re-check --content-aspect")
+    print(f"scale into band {scale:.4f}   (height-first: usable height / content height)")
+    print(f"gap per end     {args.gap:g}px   (exact — the height fit sets it by construction)")
+    print(f"x-map closes    {shortfall:.1f}px of the {placed_w:g}px width", end="")
+    if args.content_aspect is not None:
+        print("   (a reflected second pass over-corrects on purpose, so expect this to be non-zero)")
+    elif abs(shortfall) > 1.0:
+        print("   *** should be ~0 on a band solve — re-check --band and --gap")
     else:
         print()
     print(f"final labels    {label:.1f}px", end="")
@@ -286,6 +353,7 @@ def main() -> int:
         print("  head -c 300 embed.svg")
         print("  grep -oE 'font-size=\"[0-9.]+\"' embed.svg | sort | uniq -c | sort -rn | head -3")
     print(
+        "\nFit the height, then x-map the width — never a second rescale (reference/FITTING.md)."
         "\nHide connectors and year markers BEFORE measuring the group — they extend past the plot,"
         "\nso hiding them narrows it and makes it relatively taller. Then measure with"
         "\nscripts/measure_fit.js and run the `nextPass` command it prints: it reflects the measured"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Third in the series, after #6720 and #6721. **Stacked on #6721** — review that first; this base retargets to `master` once the chain merges.

Two scripts that replace hand arithmetic and repeated Figma probes. Both are verified against live data, not asserted — `verify_templates.js` shipped with a silently-skipped footer check and took five review rounds to settle, so an untested Figma script is not worth shipping.

## `solve_export.py` — the aspect solve, in closed form

The docs' own model: inset ≈ `1.4 × imFontSize` per axis, the canvas renormalized to ~510,000 px², labels ≈ `0.75 × imFontSize`. Substituting `W = 510000/H` into the aspect equation gives a quadratic in `H`, solved in closed form; `imFontSize` is then bisected, because the content width that sets the final label size itself depends on it.

- `--self-test` reproduces **both** worked examples in the docs to within **1.4px** (the docs state ±3px).
- **End to end:** at `--gap 0` — i.e. filling the band, which is what this script did before the review — a 508×371 band solved `imFontSize=28, imWidth=1346` and predicted 828×616. Grapher returned **829×616** with `font-size="21"` — exactly `0.75 × 28` — landing labels at **13.5px**, as modeled. The canvas model is therefore confirmed against the real renderer; what the review changed is the target fed into it (see below).
- `--thumbnail` covers the 302-wide route, where `imWidth/4 × imHeight/4` sets the size outright. Requesting 1208×880 does return exactly **302×220**, confirming that claim about the canvas — but the canvas is not the target: grapher insets the ink ~7.2px per side, so the frame width overflows the template's 278px content box. It now solves the canvas from the content width and emits the `imWidth=1170` `SMALL-CHARTS.md` derives.

This is the arithmetic `SKILL.md` says costs "one re-export *per page*" when done naively.

## `measure_fit.js` — one read-only call for all of Step 7

Returns the band off the *filled* clone, the content box, header sizing (including whether it actually `reflows`), and — given the imported group — its bbox, content aspect, the uniform scale to the content width, and the resulting gap per end. Read-only: it sets no property and creates no node, so it needs no approval against the shared Charts file.

- Resolves header and footer with the **same structural rule** as `verify_templates.js` — topmost/bottommost auto-layout child, any direction. The live templates are named `Frame 20` / `Frame 22`, which is exactly the case a name-based lookup loses silently.
- Reports **rendered** line counts (`height / lineHeight`), not a count of `\n`. My first version counted newlines and called the two-line placeholder title one line — a *wrapped* title contains no newline. Caught by running it, which is the argument for running it.
- `hideIds` computes the group's bbox **as if** `connectors` and the year markers were hidden, *without* hiding them — so the aspect returned is the one you will actually fit, and the file stays untouched. It feeds a finished `nextPass` command, not a raw aspect — see below for why the raw aspect was the wrong thing to feed back.

**Cross-checked read-only against three live templates.** Every field matched `verify_templates.js`'s expected geometry — sizes, `contentX`/`contentW`, band top 118, footer y/height/mode/rows, `reflows` — including Static Vertical's `1015.81` footer:

| Template | size | contentW | band | footer |
|---|---|---|---|---|
| Static Chart Template_Horizontal | 850×638 | 818 | 118 → 559 | y 559, h 63, VERTICAL, 3 rows |
| Static Chart Template_Vertical | 850×1095 | 818 | 118 → 1015.81 | y 1015.81, h 63, VERTICAL, 3 rows |
| Static Chart Template_Mobile (ex. 2) | 540×824 | 508 | 118 → 770 | y 770, h 38, VERTICAL, 2 rows |

That agreement also independently confirms the docs' reflowed band figure: the placeholder subtitle renders on two lines at 19px, so `118 − 19 = ` **99** for a one-line subtitle — the number `FITTING.md` states.

Both templates were measured in **one** `use_figma` call rather than three, which is the batching rule from #6720 applied to its own tooling.

Spine is 56,765 bytes, inside the 60 KB budget #6721 set.

## Not done here — two of the four planned scripts

The plan approved four scripts. I am shipping two, because the other two cannot be verified the same way:

- **`verify_page.js`** (mechanising the Step 8c table) is read-only and therefore *allowed*, but validating it means running it against a real finished chart page — and, more importantly, against one **known to have a defect**. A checker validated only on a clean page is how `verify_templates.js`'s `layoutMode === "VERTICAL"` footer filter passed review while skipping every footer check for the DI template. **Point me at a page with a known problem and I'll build and validate it against that.**
- **`replay_chart_edits.js`** (replaying chart-local edits after a re-import) is inherently a *write* script. Testing it needs a scratch page in the shared `Charts (2026)` file, and this skill's own checkpoint rule says nothing is written there without explicit approval. **It needs your go-ahead, not just a review.**

Nothing here has been measured against a whole real run either. `solve_export.py` removing a re-export and `measure_fit.js` collapsing several probes are both worth a few round trips each on paper; the honest test is the next chart build.


## Review round 1 — four findings, all valid, all fixed in 7b3b8c3

CI green throughout. Every thread replied to and resolved.

1. **The solve ignored the band's gaps** (P1). It targeted the band's own aspect, so the chart landed edge to edge — for a 508×371 band the solved content scaled to 508×371.0, a 0px gap, where the fit wants 12–16. `--gap` now carries it (default 14, and it is a flag because the Instagram portrait runs at 30), the solve targets `bandH - 2*gap`, and `--self-test` round-trips three band/gap combinations to 0.000px. `2*gap >= bandH`, a non-positive band axis and a non-positive `--content-aspect` are now rejected rather than solved.
2. **`measure_fit.js` measured the content box over `frame.children`** (P1), which by this step includes the not-yet-fitted chart group — the docs require appending it before positioning. On a mock Static Vertical clone the union read `0/1200` where the box is `16/818`, making `scaleToContentW` 1.05 ("nothing to scale") instead of 0.72. It now reads the header, as `verify_templates.js` does, and keeps the union as a `contentBoxFromRows` cross-check with the group excluded.
3. **The thumbnail route requested the frame width** (P2) — 1208 rather than the 1170 the small-chart reference derives — overflowing the content box at both ends. Fixed via `--margin` and `--ink-inset`. Its label default was wrong too: it inherited the full-size 13.5px target, giving `imFontSize=18`, which that reference's measured table puts at 13px, above the format's range. It now defaults to 12px labels (`imFontSize=16`) against the format's 11px floor.
4. **The `reflows` predicate ignored the properties it was already collecting** (P2), so a clone whose title had regressed to a fixed height still reported `reflows: true` — silence in exactly the case the warning exists for. There is now a `blocksReflow(child)` check covering `layoutGrow`, `layoutSizingVertical`, `textAutoResize` and `ABSOLUTE` positioning, and it reports *which* property pins the header.

**One further defect found while fixing those, not raised in the review.** The second pass fed the *measured* aspect back as the aspect to solve for — aiming at what the import already was. Under any monotone model of the inset that moves the next export away from the target by about the same margin again: on a 508×371 band, a group measured at 1.4342 against a 1.4810 target predicts a 2.4px gap on the re-export, where the reflection `2*target - measured` predicts 14.0. `measure_fit.js` now emits that corrected command as `nextPass`, and drops the correction with a note when the measurement is more than 15% off the target, since that far out is a wrong export or leftover furniture rather than a near-miss.

**How the JS was verified, and what that does not cover.** `measure_fit.js` only runs inside Figma, so it was exercised under a mock `figma` document shaped like Static Vertical — group inside the frame, group absent, a title flipped to fixed height, and a near-miss second pass. That covers the arithmetic and the predicates; it does not cover the real API surface, so the property *set* in `blocksReflow` remains a judgement, deliberately biased toward false alarms. The next real chart build is still the honest test, as the section above says.

## Review round 2 — three findings, all valid, all fixed in 60146aa

All three landed on the correction path added in round 1, which is the fair place for them.

1. **`nextPass` dropped `--target-label`** (P2), so a portrait solved for 15px labels would re-solve at `solve_export.py`'s 13.5 default — correcting the aspect would have silently shrunk the text. `targetGap` and `targetLabel` are now `CONFIG` keys and both travel with the command; at `targetGap: 30, targetLabel: 15` it emits `--band 818x897.81 --gap 30 --target-label 15 --content-aspect 1.0438`.
2. **`excluded` reported the requested `hideIds` count, not the matched one** (P2). An id mistyped or copied from another page excluded nothing while still reporting as a success — the measured aspect would keep the connectors with no clue anywhere. It now reports `{requested, matched, unmatched}` and names the ids that matched nothing.
3. **An `ABSOLUTE` title was treated as reflow-safe** (P2) — my round-1 reasoning, and wrong. It cannot pin the parent's height, but it is out of the auto-layout flow entirely, so editing that text cannot grow the header either: the band stops tracking the copy, which is worse than a pinned height. `ABSOLUTE` now blocks for TEXT and is skipped for anything else.

Both `CONFIG` reads are normalized, so deleting a line degrades to the house default instead of printing `undefined` into the command the next step runs.

The mock-`figma` harness now covers eight cases: group inside the frame, group absent, `hideIds` present and absent, an unmatched `hideId`, a fixed-height title, an absolute title, a near-miss second pass, and a non-default gap/label pair. It is a scratch harness, not committed — the argument for committing something like it is real, but it would need to be a proper fixture rather than a throwaway.

## Review round 3 — two findings, both valid, both fixed in 55e0059

1. **`nextPass` printed a command that could not run** (P2). It emitted `scripts/solve_export.py …`, but the file is committed `100644` — as is every other script in that directory — and the path was relative to the skill rather than the repo root. It now emits `.venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py …`, which runs from the repo root through the venv the repo requires. Checked by running an emitted command verbatim, which also confirmed the propagated label target: `final labels 15.0px`. The usage block and the `SKILL.md` pointer now show the same form, since a caller reading either would otherwise hand-reproduce the broken one.
2. **`solve_export.py` still advised the correction that round 1 discarded** (P2) — my own incomplete fix. The reflection went into `measure_fit.js` and the fitting reference, but this script's docstring, `--content-aspect` help, closing instructions and even its printed status line still told a direct caller to pass the measured aspect back. All four now agree with `nextPass` and say why the raw measurement is wrong.

**Round 3's fixes are themselves unreviewed.** Rounds 2 and 3 both found real defects in the preceding round's fixes, so 55e0059 deserves one more `@codex review` before this merges — I stopped at the three-round cap rather than because the file went quiet.
