### PR TITLE
🔨🤖 Fold the first real run's lessons into the Figma chart skill

### DIFF
--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -11,6 +11,11 @@ This skill takes any OWID grapher chart and produces a designed static version i
 
 **The defining principle:** the template is law. You adapt the chart's content *into* the template — you never restyle what the template provides (fonts, colors, spacing, logo, footer layout). Anything you add on top (annotations, direct labels, arrows) uses the file's shared text styles and the Chart colors library, nothing else.
 
+**Model check, before anything else:** the session context names the running model. On **Fable**,
+stop before the first Figma call and recommend re-running on **Opus** (or **Sonnet** for a
+mechanical re-export or a single text fix); continue only on the user's say-so — this skill is long
+chains of design judgment, and a build on the wrong model wastes the shared file's review cycle.
+
 **The single checkpoint rule:** the Charts file is a shared design file other people work in. Nothing is written to it before the user has seen the full proposal (page name, template choice, texts, planned label/annotation edits) and explicitly approved. Reading the file to check conventions needs no permission.
 
 Read [GUIDELINES.md](GUIDELINES.md) (sibling file) before editing any chart — it distills the DI Charts Guidelines per chart type and the Good Data Viz Checklist.
@@ -76,7 +81,7 @@ Three sibling skills do the text work this one depends on, and Step 8c calls the
 
 ## Round-trip budget
 
-Every Figma MCP call is a network hop to Figma's hosted connector: **7–10 s for `use_figma`, ~10 s for `get_screenshot`**, flat regardless of how big the script is. A run makes 120–190 of them. So the round trips are where the wall-clock goes — not the SVG exports (0.24 s each, under 2 s for a whole run) and not the response payloads (~1.5 KB per `use_figma`). Measured across five sessions: **16–28 minutes of pure MCP latency per chart**, with every single call issued on its own.
+Every Figma MCP call is a network hop to Figma's hosted connector: **7–10 s for `use_figma`, ~10 s for `get_screenshot`**, flat regardless of how big the script is. A run makes 120–190 of them. So the round trips are where the wall-clock goes — not the SVG exports (0.24 s each, under 2 s for a whole run) and not the response payloads (~1.5 KB per `use_figma`). Measured across five sessions by sweeping each one's call intervals for peak simultaneous in-flight calls: **two sessions never batched at all** (peak 1, nothing overlapping) and two more barely did (peak 2 and 5, 1–9% of calls overlapping), which is **16–28 minutes of pure serial round trips per chart**. One batched heavily — and paid for it; see the ceiling below.
 
 **Fan out independent calls — one message, 4–6 at a time.** The connector serves them concurrently: eight screenshots issued together came back **4.1× faster** than serially (79.7 s of work in 19.4 s of wall clock). It admits about four or five at once, and per-call latency inflates past that — 8.2 s for the first of eight, 13.2 s for the last — so **4–6 per message is the sweet spot and more just queues.** This is the `figma-use` skill's own instruction too: issue the N calls in one message, and don't await one before issuing the next.
 
@@ -87,9 +92,10 @@ What is independent, and today is not batched:
 - **The palette harvest.** `search_design_system` caps at ~14 results against a 24-fill palette, so it takes one group query plus ~11 by-name queries. Every one of them is independent.
 - **Screenshots of different frames or pages.** Issue them together, then `curl` all the returned URLs in one bash call, then Read each. A screenshot is otherwise three tool calls, and a run takes 14–70 of them.
 - **Every format in a multi-format run**, and every frame of a `chart-rows` set — separate pages and frames, so the writes fan out as well as the reads.
-- **Any survey of N nodes.** The pass that wrote GUIDELINES.md screenshotted 272 chart-library nodes one at a time: 2.7 hours, every call an independent read.
+- **Any survey of N nodes** — but at 4–6, not more. The pass that wrote GUIDELINES.md screenshotted 272 chart-library nodes at **peak 14 in flight**, and its calls averaged **35.5 s** against ~10 s everywhere else. That is the ceiling being exceeded, not the connector being slow: 8.2 s at one in flight, 13.2 s at eight queued, 35.5 s at fourteen.
+- **`upload_assets` takes a `count`.** One call returns N single-use `submitUrl`s and the POSTs parallelize, so a two-format run uploads both originals in one call rather than two — and both embeds in one more.
 - **The Step 8c property sweeps** — font sizes, stroke weights, dash patterns, fills, polylines. Those are reads of a single page, so they collapse into *one* `use_figma` returning one JSON. `scripts/verify_templates.js` already does exactly this for ten templates.
-- **The arrow probe's baseline render.** The both-hidden picture is the same for every arrow on the frame: take it once, then one hide-render per shape. N arrows costs `N + 2` screenshots instead of `4N`.
+- **The arrow probe's baseline render.** Only the FULL render is shared across arrows: the other three states of the four-render protocol (no-arrow, no-target, both-hidden) each hide *that pair's* nodes, so they are pair-specific and cannot be reused. N arrows cost `3N + 1` screenshots, not `4N` — and not `N + 2`, which under-collects and produces masks containing another pair's target.
 
 **What is serial for a reason — don't collapse these:**
 
@@ -100,6 +106,8 @@ What is independent, and today is not batched:
 | one page per `use_figma` call | `page.children` on a page you have not switched to returns a short list *without erroring* (Gotchas) |
 
 And a bigger batch is a bigger loss: `use_figma` is atomic, so a script that throws on its last line reverts the whole pass. Stay inside the plugin's ~10-logical-operations-per-call guidance.
+
+**Measuring whether any of this happened: use interval overlap, never a calls-per-message count.** The transcript writes one entry per tool call whether or not the calls were batched, so a calls-per-assistant-message histogram reports `{1: N}` for a provably concurrent run — checked against an 8-call probe that measured 4.12×, which the histogram scored as eight singletons. Sweep `tool_use` → `tool_result` timestamps for peak simultaneous in-flight calls instead, and count how many calls start before the previous one finished.
 
 ## Inputs
 
@@ -281,21 +289,21 @@ head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <ht
 > `measure_fit.js` reports as `xMapShortfall`, and it is the aspect miss expressed in px; and every
 > number comes from the **rounded** `imFontSize`, since that is what the URL carries, so the label
 > size quoted is the one the `curl` will actually produce (it prints the ideal font alongside when
-> rounding moves it). It also carries the model's own self-test (`--self-test`, which reproduces
-> both worked examples below to within 1.4px, round-trips the band arithmetic exactly, and checks
-> that a reflected second pass still lands its `--target-label`) and the `--thumbnail` route for a
-> 302-wide chart.
+> rounding moves it). It is a TWO-PASS tool: `--band` alone is pass 1, a probe under the symmetric
+> `1.4 × imFontSize` inset model; pass 2 re-runs with `--declared`/`--ink`/`--im-font-size` measured
+> off the probe's import and is exact, because the real inset is per-axis, not symmetric (see Step 7
+> and reference/FITTING.md). It also carries its own `--self-test` (the worked examples, the band
+> round-trip, and a real run's two measured-inset passes) and the `--thumbnail` route for a 302-wide
+> chart.
 >
 > **It solves for `band − 2×--gap`, not for the band** — the gap below is a requirement of the fit,
 > so a solve that ignores it lands the chart edge to edge and you re-export. `--gap` defaults to 14
-> and takes 30 for the Instagram portrait. For a 508×371 band that makes the target 508×343, and the
-> solve returns `imFontSize=29, imWidth=1448`, predicting an 818.8×552.8 content box that scales to
-> 508×343 — 14px at each end. Verified end to end at `--gap 0` (i.e. filling the band, which is what
-> this script did before the gap was reserved): it solved `imFontSize=28, imWidth=1346` and predicted
-> 828×616, and grapher returned **829×616** with `font-size="21"`, landing labels at exactly 13.5px —
-> so the canvas model is confirmed against the real renderer; it is the target fed into it that the
-> gap changes. After you have measured a real import, run the `nextPass` command that
-> `measure_fit.js` prints rather than passing the measured aspect back yourself — see Step 7.
+> and takes 30 for the Instagram portrait; a 508×371 band makes the target 508×343, 14px at each
+> end. The canvas model is confirmed against the real renderer — a `--gap 0` solve predicted 828×616
+> and grapher returned **829×616**, landing labels at exactly 13.5px — so it is the target fed into
+> it that the gap changes. After you have measured a real import, run the `nextPass` command that
+> `measure_fit.js` prints — with its `CONFIG.declared` and `CONFIG.imFontSize` set from the probe,
+> it is the exact measured-inset second pass rather than another guess — see Step 7.
 
 **The aspect you request is the *canvas*, not the chart — solve for the padding or you will re-export every page.** Grapher insets the drawing inside the SVG it hands back, so the group Figma imports is smaller than the declared size, and it is the *group* that has to fill the template band. Measured on this file's charts, the inset is close to **1.4 × `imFontSize` on each axis** (at `imFontSize=32`: declared 901×566 → content 857×520; at 30: 862×591 → 818.9×550). So don't request the aspect you want — request the aspect that *yields* it, by solving
 
@@ -326,6 +334,11 @@ Caveats: `?tab=table` is silently ignored (renders the default tab); `imSquareSi
 
 ## Step 4 — Propose, then get the go-ahead
 
+> **If the title changes later, rename the page too.** The page name carries the *final* title, and a
+> title that gets corrected mid-run — because it misread the data, or because it wrapped to a line too
+> many — leaves the page still asserting the superseded claim. It is the one place the old wording
+> survives a retitle, since nothing renders it.
+
 Before touching the file, show the user in one message: the page name **`YYYYMMDD <Title> (<Creator>)`** (today's date, the *final* — possibly rewritten — title), the chosen template(s), every text that will go into the template, the labeling changes you propose (Step 8), and the annotations with their content. **Wait for explicit approval.** This is the single checkpoint; after it, iterate freely on the same page without re-asking.
 
 ## Step 5 — Create the page and place the pieces
@@ -348,7 +361,7 @@ await figma.setCurrentPageAsync(page)
 
    For a **302-wide small or pull chart**, clone `25344:1357` (guided) or `25344:1391` (pull) — the choice is the Step 2 answer, not a judgement. Both now carry a real visible white frame fill and no background vector, so there is nothing to repair before you start; check that still holds rather than assuming, since a hidden fill plus a fixed-size backing vector is exactly what a taller frame under-covers. A `chart-rows` block is 3–5 rows, so expect a *set* of frames on one page. SMALL-CHARTS.md → In Figma has the rest.
 
-3. **Import the original SVG with `upload_assets`** — never `createNodeFromSvg` (the `use_figma` code param caps at 50k chars; a grapher SVG is ~165 KB). `upload_assets` returns a single-use `submitUrl`; POST the file to it and keep the returned `placedOnNodeId`. **Only the original at this stage** — the embed has not been exported yet (Step 3), and it arrives in Step 7 once the band is measurable:
+3. **Import the original SVG with `upload_assets`** — never `createNodeFromSvg` (the `use_figma` code param caps at 50k chars; a grapher SVG is ~165 KB). `upload_assets` takes a **`count`** and returns that many single-use `submitUrl`s — pass `count: 2` for a two-format run and POST both in parallel. Keep each returned `placedOnNodeId`. **Only the original at this stage** — the embed has not been exported yet (Step 3), and it arrives in Step 7 once the band is measurable:
 
 ```bash
 curl -s -X POST "<submitUrl>" -F "file=@$DIR/original.svg;type=image/svg+xml"

--- a/.claude/skills/create-figma-chart/SMALL-CHARTS.md
+++ b/.claude/skills/create-figma-chart/SMALL-CHARTS.md
@@ -261,6 +261,30 @@ GUIDELINES.md → Direct labeling has the placement rules, and the per-type conv
 the target. How much of that work there is depends on the chart type, so measure the export before
 estimating.
 
+### The frame height is an output, and the frame must be resized BEFORE the chart goes in
+
+The shipped 302-wide templates measure 302×233, but that height is a placeholder: grapher returns
+whatever ink the chart needs and reserves the rest. Measured on a single-series line chart at
+`imFontSize=16`: **122.7px of ink in a 183.5px canvas** for the guided variant and 110.9 in 166.5 for
+the pull one — roughly 60px and 56px of vertical space grapher asked for and then did not use. Forcing
+that ink to fill a 233px frame would need a rescale, which this route forbids because it moves the
+font sizes off the 11/12px ladder.
+
+So compute the frame height from the ink: `44 + inkHeight + 12` for the guided variant, and
+`44 + inkHeight + 6 + sourceRowHeight + 12` for the pull one, whose source row sits below the chart.
+That gave 179 and 184 against the shipped 233.
+
+**A resize displaces everything already in the frame, so re-pin afterwards.** Two things broke on one
+`clone.resize()`. The chart, placed before it, was squashed 122.7px → 94.26px — non-uniformly, through
+the group's top-and-bottom constraint, and reported as though that were its real height. And the
+**header moved and was clipped**: these templates constrain it `vertical: CENTER` (pull) and `SCALE`
+(guided), so shrinking 233 → 184 put the pull header at **y = −15** and `clipsContent` sliced the title
+off. Placing the chart after the resize fixes the first; only re-pinning fixes the second, because the
+header ships inside the template.
+
+So the order is: **resize → re-pin the header to `y = 10` → place the chart at `y = 44` → place the
+source row** — then assert no child has a negative `y`, because a clipping frame hides exactly this.
+
 ### Request the final pixel size directly
 
 `getThumbnailOptions` sets `staticBounds = Bounds(0, 0, imWidth / 4, imHeight / 4)`, so `imWidth`
@@ -315,6 +339,13 @@ single-entity chart is pure overhead at 302px.
 | One entity, one indicator | nothing | no name at all — first and last **values** only | **`1`** |
 | One entity, several indicators | the indicator | the indicator's **display name**, placed away from the values | **`1`** |
 | Several entities *and* indicators | both | reconsider the chart — it is too much for 302px |
+
+**This is easy to skip, and the default is the wrong one.** Omitting `imMinimal` gives you `0`, which
+on a single-entity line chart puts the country's name inside a 278px plot — measured on Argentina, the
+export's texts were `1950 | 2025 | Argentina | 0.52`, with "Argentina" sitting in the left of the plot
+where the first value should be. Passing `imMinimal=1` returned `1950 | 2025 | 0.19 | 0.52`: name gone,
+first value gained. Pass it explicitly for rows two and three of the table rather than relying on the
+default.
 
 `imMinimal=1` is the mechanism for rows two and three, and it does exactly the right thing: it drops
 the entity name **and** emits the first *and* last value per series. Verified —
@@ -450,7 +481,7 @@ of label → series possible:
 
 Two Figma mechanics that bite here: **`leadingTrim` heights only settle on the next `use_figma` call**,
 so trim in one call and centre in the next; and a text node's **width is stale in the call that set its
-characters**, which silently invalidates any placement search built from it (SKILL.md → Gotchas).
+characters**, which silently invalidates any placement search built from it (reference/GOTCHAS.md).
 
 ### Expand the plot to the content box — the dots belong on the title box's edges
 

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -391,17 +391,18 @@ Verify against the actual clone with `get_metadata` (the templates evolve; the g
 > scale of ≈1 — "nothing to do" — which is the one answer the script exists to produce. The union is
 > still reported as `contentBoxFromRows` for cross-checking, with the group excluded.
 >
-> **Run the `nextPass` command it prints; do not feed the measured aspect back yourself.** The
-> second pass has to aim at the *reflection* of the measured aspect about the target
-> (`2×target − measured`), not at the measured aspect itself — solving for what you already got moves
-> the next export further off, by about the same margin again. On the case recorded above (target
-> 1.4810 on a 508×371 band, group measured 1.4342) passing the measured aspect back lands a 2.4px
-> gap where 14 was wanted, and the reflection lands 14.0. `nextPass` carries the band, the `--gap`,
-> the `--target-label` and the corrected aspect already — set `targetGap` and `targetLabel` in its
-> `CONFIG` to whatever the first export used, or a portrait solved for 15px labels comes back at 13.5
-> purely from re-solving the aspect. When the measurement is more than 15% off the target it drops the
-> correction and tells you to solve fresh, because that far out is a wrong export or leftover
-> furniture, not a near-miss.
+> **Run the `nextPass` command it prints; do not rebuild the second pass yourself.** With
+> `CONFIG.declared` and `CONFIG.imFontSize` set to what the probe export used, `nextPass` is the
+> **measured-inset** pass 2 (`--declared`/`--ink`/`--im-font-size`): the script subtracts the
+> measured ink from the declared size to get the true per-axis inset, and the re-solve with that
+> inset is exact rather than another guess — the `1.4 × imFontSize` model is symmetric and the real
+> inset is not (64.1/29.0 measured at imFontSize 30 against the model's 42/42). The inset is only
+> meaningful on a group still at its natural size, so it bounds the value (≤25% of the declared
+> canvas per axis) and refuses with `inset.unusable` when the group has already been rescaled or
+> `declared` belongs to a different export — falling back to a fresh probe solve with
+> `--target-label` carried, so a portrait solved for 15px labels does not come back at 13.5. Set
+> `targetGap`, `slug` and `params` in its `CONFIG` to whatever the probe used: the command carries
+> them so the re-export keeps the country selection or MDim view instead of being rebuilt by hand.
 >
 > It also reports `excluded` as `{requested, matched, unmatched}` rather than a count, and warns on
 > any `hideIds` entry that names nothing under the group: an id copied from another page excludes
@@ -410,6 +411,55 @@ Verify against the actual clone with `get_metadata` (the templates evolve; the g
 >
 > Cross-checked read-only against three live templates; every field matched `verify_templates.js`'s
 > expected geometry, Static Vertical's `1015.81` footer included.
+
+> **Portrait bands are fine, and `contentX` is not always 16.** One chart taken into all nine
+> in-scope templates spanned target ink aspects from **0.79 to 1.42**, and grapher returned every
+> canvas at exactly the requested size — the `MIN/MAX_ASPECT_RATIO` clamp never fired, so a tall band
+> (mobile 2 at 0.76, Static Vertical at 0.86, IG portrait at 0.97) needs no special handling. What
+> does need handling: **IG portrait insets its content at `contentX` 26, not 16**, and its band top is
+> 135 with a 28px title against everyone else's 25. Read the content box per template; don't carry 16
+> across.
+>
+> **A title rewrite after the fit invalidates it — in BOTH directions.** Rewording moved band tops by
+> **+29px** where the title grew to three lines and **−29 and −32px** where it shrank to one and two,
+> so a *shorter* title breaks the fit just as surely by growing the band. Three of five frames
+> survived a rewrite; two needed a fresh export. Re-measure the band after any text change, and if it
+> moved, re-solve — but re-solve from the **inset you already measured**: it holds across a band
+> change at the same `imFontSize`, so the new export lands first time with no second probe.
+>
+> **The aspect solve is TWO passes, and the second one is exact. Don't try to land it in one.**
+>
+> The `1.4 × imFontSize` inset in Step 3 is **symmetric, and the real inset is not.** Measured on an
+> `imType=uncaptioned` line chart that reserves a right margin for a direct entity label:
+>
+> | `imFontSize` | inset X | inset Y | what `1.4 × F` predicts |
+> |---|---|---|---|
+> | 30 | 64.1 | 29.0 | 42.0 / 42.0 |
+> | 21 | 70.6 | 40.8 | 29.4 / 29.4 |
+>
+> The model is right for the charts it was measured on — the recorded examples come out ~44/46 at
+> `imFontSize` 32 — and wrong by 2× on the horizontal axis for this class. Note also that inset Y got
+> *larger* as the font got *smaller*, so it is not a simple function of `imFontSize`: don't fit one.
+>
+> So treat the first export as a **probe**, not an attempt:
+>
+> 1. `solve_export.py --band WxH --target-label 15` → export, import, hide the furniture, measure.
+> 2. `inset = declared − ink`, per axis. `scripts/measure_fit.js` returns it, and the ready pass-2
+>    command with it, if you give it `CONFIG.declared` and `CONFIG.imFontSize`.
+> 3. `solve_export.py --band WxH --declared … --ink … --im-font-size …` → export, import, fit.
+>
+> The inset is stable to ~2px across an aspect change at the same font, and `insetX − insetY` was
+> *exactly* constant per chart across both passes (35.04 and 29.80), which is what makes pass 2 land
+> rather than being another guess. Measured errors: pass 1 predicted the canvas to 1.2–1.4px, pass 2
+> to **0.4–0.5px**.
+>
+> **And solve for the gap, not for the band.** `--gap` defaults to 14 because the target is 12–16px at
+> *each end*; solving for the band's own aspect asks the chart to fill it edge to edge and leaves
+> nothing. On a 508×409 band that is the difference between a target ink aspect of 1.2421 and 1.3333.
+>
+> **Don't try to measure the ink from the SVG to skip the first import.** Text ink depends on font
+> metrics that are not in the file; parsing every coordinate in one came out 13–33px wide of what
+> Figma measured.
 
 **The header reflows itself — don't reposition it.** Every template's header block is a flat vertical auto-layout of `[title, subtitle]` (the logo is a sibling, not a child — see the node map), so a title that grows from two lines to three pushes the subtitle down and grows the header on its own. Set `characters`, then **read the new `header.y + header.height` back** and measure the band from that; any y you computed before the text went in is stale. Measured on the portrait: a two-line title gives a 135 band bottom, three lines 199.
 

--- a/.claude/skills/create-figma-chart/reference/GOTCHAS.md
+++ b/.claude/skills/create-figma-chart/reference/GOTCHAS.md
@@ -60,6 +60,63 @@
 - **A bespoke component mounted outside a Shadow DOM renders unstyled, silently.** Each bundle injects its own CSS scoped to `:host`, so those rules never match in a plain element — and because the serializer reads `getComputedStyle`, you get a structurally plausible SVG with the wrong paint, weights and geometry. BESPOKE-SVG.md has the correct mount.
 - **New year, new file** — ask for the link and re-verify every node id in the map above before the first run of a new year.
 
+- **Once the chart is fitted it is a frame child, so measuring the content box from "all children" includes it.** The chart lands 508.05px wide against a 508px content box, so a content-box measurement taken after the fit reports 508.05 — it drifts the very number the chart was fitted to, and each re-fit compounds it. Exclude the chart group (and the logo) when reading `contentX`/`contentW`; `scripts/measure_fit.js` does.
+- **An inset computed against an already-rescaled group is garbage that looks plausible.** `declared − ink` is only the inset while the import is at its natural size. Run it after the fit and you subtract a rescaled width from the probe's declared one: measured 282.95 / 264.28 against a true 64.08 / 29.04, which would send the next export badly wrong. A real inset is a small fraction of the canvas — `measure_fit.js` bounds it at 25% and reports `unusable` rather than a number.
+- **Never place a curvy arrow by any bounding box — neither the group's nor the head's.** These arrows
+  are a long curved tail plus a small arrowhead, so the group's box is mostly tail and the head's box
+  has the tip in one corner. Aiming the group's box left the heads **13–21px off their dots**; aiming
+  the head's box centre put one tip *inside* its dot and another 5.3px off-axis. **The full recipe is
+  in [LABELING.md](LABELING.md) → Placing an arrow**; it works from the head's real vertices, picks
+  the arrow whose span fits, and checks both ends.
+- **Resizing a template clone displaces EVERY child it already holds, each by its own constraint —
+  and nothing in the response says so.** Two distinct failures from one `clone.resize()`:
+  - **The chart got squashed non-uniformly**, 122.7px to **94.26px** with its width untouched, through
+    the group's top-and-bottom constraint. A **GROUP has no `constraints` property** (`node.constraints:
+    no such property on GROUP`), so it cannot be pinned — it must be placed *after* the resize.
+  - **The header moved, and the frame clipped it.** The 302-wide headers are constrained
+    `vertical: CENTER` on the pull template and `SCALE` on the guided one — neither is `MIN` — so
+    shrinking the frame 233 → 184 put the pull header at **y = −15**, with its title sliced off by
+    `clipsContent`. Ordering cannot help here: the header is in the template before you touch it.
+
+  So: resize first, then **re-pin every child** to its designed position (the 302-wide header belongs
+  at `y = 10`, bottom flush with the 44px band top), and assert nothing has a negative `y` — a
+  clipping frame hides the evidence.
+- **`curl -F "file=@..."` fails with exit 26 on a path containing spaces or non-ASCII** — and since
+  the upload filename becomes the Figma layer name, the temptation is to name the file exactly what
+  you want the layer called. Don't: use a plain ASCII filename and rename the node in Figma.
+- **Route parallel uploads by declared size, never by response order.** Two POSTs fired concurrently
+  come back in arbitrary order, so pairing the *n*th response with the *n*th target silently swaps
+  them. Match each import to its target by dimensions and assert no two route to the same
+  destination — the sizes differ per template, so it is exact.
+- **`resize()` resets a text node's sizing to FIXED, so `textAutoResize` must come AFTER it — and
+  getting that backwards makes the node lie about its height while rendering perfectly.** Setting
+  `textAutoResize = "HEIGHT"` and *then* `resize(w, 10)` left four annotations with **10px-tall boxes
+  around 38–76px of ink**. Figma text overflows rather than clipping, so the render was correct and
+  nothing errored — but every gap, centring and overlap test computed against those boxes was
+  meaningless and each one silently "passed". The tell is a text node whose `height` is far smaller
+  than its line count justifies. Order it `resize()` → `textAutoResize`, and read the height back on
+  the *next* call before positioning anything against it.
+- **Figma's `rotation` is counter-clockwise, while screen angles from `atan2(dy, dx)` are y-down.** So
+  for a node you are rotating to a computed heading, `achieved = natural − rotation`, and the value to
+  set is `natural − required`. Getting the sign wrong put an arrow at 29° when 173° was wanted, with
+  no error and a plausible-looking number in the response. Always set, re-measure, and correct by
+  `(achieved − required)` — one iteration converges exactly.
+- **A chart's node id does not survive a re-import — resolve it by NAME.** Every corrected export
+  replaces the group, so an id captured earlier goes stale and `getNodeByIdAsync` returns `null`; the
+  next `.findAll` throws `cannot read property 'findAll' of null`. On a run with two refitted frames
+  out of five, three ids were still good and two were dead, which is the worst version of this. Use
+  `clone.children.find((c) => c.name === "chart")`.
+- **A PAGE does not resolve through `getNodeByIdAsync` — use `figma.root.children`.** It returns
+  `null`, and passing that to `setCurrentPageAsync` throws `cannot read property 'id' of null` rather
+  than anything mentioning pages. Find pages with
+  `figma.root.children.find((p) => p.id === "…")`, and search by name when an id may be stale — a page
+  someone has deleted looks identical to a page id you got wrong.
+- **One `setCurrentPageAsync` per call, including in read-only loops.** Iterating two pages to compare
+  them throws on the second switch. Split it into one call per page — and since these are reads, emit
+  them in the same message so they run concurrently.
+- **`x`/`y` on a frame child are PARENT-relative, while `absoluteBoundingBox` is not.** After `clone.appendChild(chart)`, setting `chart.x = clone.x + contentX` sends the chart off-canvas by exactly the frame's own page offset — 1590px on a real run, which reads as the import having vanished. Read absolute geometry from `absoluteBoundingBox`, but *write* `x`/`y` in the parent's coordinates: `chart.x = contentX`. The tell is a reported right edge far outside the content box.
+- **Removing a footer row leaves the footer stranded, because every footer but one is constrained `MIN`.** MIN keeps the *top* edge, so deleting the `Note:` row from a Static Horizontal clone collapsed the footer 63 → 31 but left `y` at 559: its bottom rose from 622 to 590 and the frame gained 48px of dead space against its own 16px margin. Nothing errors and the band bottom does not move, so it survives a band measurement. Re-pin with `footer.y = frame.height − bottomMargin − footer.height`, and do it **before** measuring the band.
+
 **Four mechanics below were each found on one chart type and bite on all of them.** They are here,
 not in the type file, for that reason — the worked examples stay in `reference/per-chart-type/`.
 
@@ -67,6 +124,24 @@ not in the type file, for that reason — the worked examples stay in `reference
   a 1px annotation stroke becomes 4px — so **set every stroke after the final scale, never before**.
   Found on maps (`reference/per-chart-type/maps.md`, where the whole treatment is hairlines), but it
   applies to any chart whose group is scaled into a band, which is all of them in Step 7.
+  - **It also thins the data line, which is the case you will actually ship.** Fitting a square DI
+    chart scaled by 0.657 left `line__Chile` at **1.32px** and its white halo at 1.98. Nothing looks
+    broken — it reads as a weaker chart than grapher's own, and a designer spots it before you do.
+    `scripts/measure_fit.js` detects it when given `CONFIG.originalGroupId`, comparing the fitted
+    strokes against the untouched reference import of the same format.
+  - **It goes the other way too, on any template whose band is WIDER than the export.** Static
+    Vertical fits at **1.30x**, an upscale, so the same multiplier *thickens*: its line arrived at 2.61
+    and its halo at 3.91 and both had to come **down** to 2/3. So the rule is not "restore what the
+    rescale thinned" but "set every stroke after the scale, whichever way the scale went".
+  - **The reference tells you the rescale changed it. It does not tell you the target.** `imType=square`
+    ships 4/5 and `uncaptioned` ships 2/3 — and the house weight is **3 with a 4px halo**, i.e. neither
+    of them. Use the comparison to *notice*, then set the house value, keeping the halo one px above
+    the line.
+  - **3/4 holds across the static and IG templates regardless of frame width.** I set the 850-wide
+    Static Vertical to 2/3 on a rule I invented — "a wider plot wants a relatively thinner line" — and
+    on a 1095-tall frame it read thin. Don't derive a weight from the frame size; 3/4 is the value.
+  - This entry existed before the run that hit it. Documenting a multiplier is not enough; the check is
+    what catches it — and a check that asserts the wrong target is its own bug.
 - **Text widths only settle on the next `use_figma` call.** Same class as the `leadingTrim` rule in
   the Round-trip budget: bolding a label, changing its font, or editing its characters does not
   update `width` within the call that does it. Any placement search that runs in the same call is

--- a/.claude/skills/create-figma-chart/reference/LABELING.md
+++ b/.claude/skills/create-figma-chart/reference/LABELING.md
@@ -1,5 +1,153 @@
 # Step 8 — Improve the labeling and annotate
 
+## Before placing an arrow: does the note point at a POINT?
+
+An arrow aimed at one dot asserts "this value, here". If the sentence is about a **span of time or
+several events**, that is the wrong device, and the recipe below will happily execute it anyway —
+which is the trap. "Four military coups between 1955 and 1976 cut short democratic rule" was given a
+single arrow to the deepest trough: the note describes 21 years and four events, the arrow claimed one
+year and one value.
+
+`reference/per-chart-type/line.md` already carries the devices for this. Pick by what the note is
+about:
+
+| The note is about | Device | Archive |
+|---|---|---|
+| A period | a **pale tinted vertical band** across it, annotation set inside the band | `349:167` ("Global financial crisis", "COVID pandemic"), `541:217` ("Great Leap Forward"), `222:504` (annotation inside, in the band's colour) |
+| A period, told through the line itself | **recolour the stretch** the story is about | `202:831` (red where democracy eroded, navy elsewhere), `1:4716`, `1:1465`; `678:490` labels the phases in-plot |
+| Several discrete events | a **milestone ladder** — a dot per event, each with its value and short sentence | `222:133`, `366:245`, `228:63`, `359:111`, `241:131` |
+| A moment | a **thin vertical event rule** labelled at the top of the plot | `347:69` (three of them), `486:51`, `589:211` |
+| One value | an arrow, per the recipe below | — |
+| A gap between two lines | a **double-headed arrow labelled with the ratio** | `250:120` ("six times") |
+
+Read that table before the recipe, not after. The arrow mechanics are long and specific, and the
+detail is exactly what makes "point at the nearest dot" feel like the answer.
+
+### Building the period band
+
+There is **no library style for it** — `search_design_system` for a pale tint returns nothing — so take
+it from the archive. Read off `349:167` and `541:217` (the Great Leap Forward band), which agree:
+
+- a **RECTANGLE**, fill **`#dddddd` at 50% fill opacity** (`fills[0].opacity`, not the node's)
+- spanning the **plot**, not the frame: use the `horizontal-grid-lines` group's bbox, which is the
+  drawing area without the axis-label rows
+- inserted at **`clone.insertChild(0, band)`** so the line, dots and labels all draw over it
+- and **no arrow**. The band is the pointer; adding one re-asserts the single point the band exists to
+  avoid.
+
+Set the band's own x from the line's vertices at the first and last year of the period, the same way
+dots are placed — not from the axis ticks, which are sampled and may not include your years.
+
+**The annotation goes inside the band** (`222:504`), padded ~10px from its top-left, with its width set
+to the band's width less that padding on both sides. If the text does not fit the band's width at a
+readable size, the band is too narrow for an in-band label — put the note beside it instead of
+shrinking the type.
+
+## Placing an arrow
+
+An arrow has two ends and both are load-bearing: the tip has to point at the thing it names, and the
+tail has to read as leaving the annotation. Bounding boxes get neither right — the group's box is
+mostly tail, and the head's box has the tip in a corner.
+
+**Measure the library once.** Every arrow on the `↪️ Curvy Arrows` page has a natural tail→tip
+**span** — a length and an angle. Measured 2026-08-20:
+
+| Arrow | box | span | angle |
+|---|---|---|---|
+| `Group 18` `6086:565` | 14.6×43 | 41.5 | −87.9° |
+| `Group 3` `4937:94` | 56.3×43.9 | 63.4 | 135.1° |
+| `Group 5` `4937:96` | 56.3×43.9 | 63.4 | −142.1° |
+| `Group 19` `6086:568` | 70.4×25.7 | 72.6 | −8.1° |
+| `Group 4` `4937:95` | 68.8×51.8 | 74.7 | 148.5° |
+| `Group 1` `4937:92` | 68.8×51.8 | 74.7 | −148.5° |
+| `Group 8` `6373:161` | 29.8×76.1 | 81.4 | 110.6° |
+| `Group 7` `4941:61` | 95.4×69.4 | 117.6 | 144.1° |
+| `Group 6` `4941:42` | 162.9×42.4 | 165.2 | −170.5° |
+
+To get a span: the **head** is the smallest-area vector child and the **tail** the largest; read each
+one's real vertices by parsing `vectorPaths` and pushing every pair through its `absoluteTransform`
+(`x' = a·x + c·y + e`, `y' = b·x + d·y + f` for `[[a,c,e],[b,d,f]]`). The head's **apex** is its vertex
+farthest from its own centroid; the tail point is the tail vector's vertex farthest from that apex.
+
+**Then, per arrow:**
+
+1. **Place the annotation first**, at the position the design wants.
+2. **Anchor** = where the arrow should leave it — the bottom edge for a downward arrow, the left edge
+   at first-line height (`+ lineHeight/2`) for a sideways one.
+3. **Target** = `dotCentre − unit(dotCentre − anchor) × (radius + gap)`. This is what makes the arrow
+   point *through* the dot's centre along its own angle, so a diagonal arrow arrives diagonally —
+   which aligning the tip on one axis does not achieve. 5px of gap off a 10px dot reads well.
+4. **Pick the arrow whose span length is closest to `|target − anchor|`.** Length is what decides
+   whether the tail reaches the block; the library spans 41–165px, so something usually fits. Do not
+   scale one to fit — that distorts the head.
+5. **Rotate**: `rotation = natural − required`, because Figma's rotation is counter-clockwise against
+   y-down angles. Then re-measure and correct by `(achieved − required)`; one iteration is exact.
+6. **Translate** so the apex lands on the target.
+7. **Nudge the annotation** so its anchor edge sits 3–5px off the tail. The arrow is fixed-length, so
+   the block moves, never the arrow — moving the arrow loses the tip.
+
+**Check all four, they are one subtraction each:** the tip is `radius + gap` from the dot centre; the
+cross product of the heading with `(dotCentre − tip)` is **0**; the arrow's box does not overlap the
+annotation's; and the annotation is still inside the content box — pushing a block sideways to meet a
+tail is how it ends up hanging off the frame.
+
+**A tail that stops short of the block reads as two unrelated objects.** Sitting 4px *above* an
+annotation's top edge is not connected; the tail has to be within the block's vertical span, level
+with a line of text.
+
+**The value label and the arrow want the same spot, so place the label opposite the approach.** An
+arrow aimed at a dot arrives along its own heading, and a value centred *above* that dot lands right
+under the tip — measured on all five templates of one chart. Put the value diagonally opposite the
+arrow's approach instead: the restoration arrow came in from the upper right, so its value went
+up-**left** of the dot, bottom-right corner near the dot's top-left.
+
+**Check the label against the line on BOTH axes, not just the one you were thinking about.** The
+trough value was placed above its dot, clear of the flat trough line it sat over — and straight
+across the 1975→1976 **vertical** drop, which the "is it above the line?" check never looked at. It
+moved left of the dot, where the descending line is far above and the plot is empty. A steep segment
+is as much of an obstacle as a flat one and is easier to forget.
+
+**A bbox overlap between a long arrow and a label is usually empty — confirm on the render.** Three
+of five frames reported the arrow's box overlapping the value label after the fix, and all three were
+clear in the render: the long library arrows (117–165px) have large boxes around a thin curve, so most
+of the box is air. Treat the box test as a screen that tells you where to look, never as the verdict.
+
+**Selection across templates is real work, not a formality.** Ten placements of the same two
+annotations across five templates drew **five different library arrows** — `Group 3`, `Group 8`,
+`Group 6`, `Group 19` and `Group 7` — because the required spans ran from 62px to 202px as the band
+changed shape. Picking one arrow and reusing it would have missed by up to 100px.
+
+> **The knockout stroke matches whatever is DIRECTLY BEHIND the text — usually the frame, but not
+> always.** Text sitting inside a period band has the band behind it, so the stroke is the band
+> composited onto the frame: `bandFill × opacity + frameFill × (1 − opacity)`. Measured here that is
+> `#ecebe8` on the beige templates and `#eeece9` on the cream ones, where the frame alone would have
+> given `#fbf9f3` and `#fffbf5` — close enough to look deliberate and wrong enough to see. The rule
+> below is the common case, not the whole rule.
+>
+> **The knockout stroke is the FRAME'S OWN BACKGROUND — read it off the frame, never hardcode white.**
+> Only two of the nine templates are white. Measured: the IG pair is **`#fbf9f3`** (beige), the static
+> trio **`#fffbf5`** (cream), and only DI and the 302-wide pair are `#ffffff`. A white halo on a cream
+> frame draws a visible outline round every line of annotation text — it reads as a deliberate stroke,
+> not as a knockout, and it is the first thing a designer sees. `scripts/verify_templates.js` already
+> reports each frame's `fill` for exactly this reason ("DI white, static cream, IG beige"): take the
+> colour from `frame.fills[0]` and copy its channels into the stroke. It is also assertable —
+> every annotation's stroke should equal its frame's fill, which is one comparison per node.
+>
+> **A value label that lands on the line gets MOVED, not masked.** The white knockout stroke is for
+> an annotation that has to cross chart ink to sit where the reader needs it — not a licence to park
+> a number on a line and mask it. The house preference is that labels stay off the ink. On the Chile
+> chart the trough value sat on the flat `0.03` segment; the fix is 6px above its dot, in the empty
+> plot the drop and the rise leave behind, and no stroke at all. Reach for the knockout only when
+> there is genuinely nowhere clear to go.
+>
+> **A direct end label centred on the last point collides with a dot placed there.** grapher's own
+> layout starts the entity label about 2.6px after the final data point, so the moment you add an
+> endpoint dot the two overlap — measured 3.4px on the square and 2.4px on the desktop, and you
+> cannot fix it by sliding the label right because it is already on its 16px margin. Put the label
+> **below** the dot (6px clear, right edge still on the margin), which is also the single-series move
+> this file recommends further down for reclaiming the right margin.
+
+
 > Read at Step 8. Also covers Step 8b and re-exporting after a change to the chart itself.  Part of [`/create-figma-chart`](../SKILL.md); the spine has the step order.
 
 

--- a/.claude/skills/create-figma-chart/scripts/measure_fit.js
+++ b/.claude/skills/create-figma-chart/scripts/measure_fit.js
@@ -9,45 +9,71 @@
 //
 // USAGE
 //   Fill in CONFIG and paste the whole file as one `use_figma` call.
-//     frameId  — the TEMPLATE CLONE, after Step 6 has filled its texts. Measuring an unfilled
-//                clone gives you the placeholder band, which is the mistake reference/NODE-MAP.md
-//                warns about: the header hugs its text, so the band moves when the real title
-//                lands. A one-line title + one-line subtitle takes Static Vertical's band from
-//                118 to 70.
-//     groupId  — optional; the imported chart group, once it exists. Give it and you also get the
-//                group's bbox, its content aspect, and the scale needed to fit the band.
-//     hideIds  — optional; nodes to EXCLUDE from the group's measured bbox AND from the font-size
-//                histogram (grapher's `connectors` and year markers extend past the plot). This
-//                computes both as if they were hidden, WITHOUT hiding them — so the aspect you get
-//                is the one you will actually fit, the histogram covers only text that survives,
-//                and the file is untouched. reference/FITTING.md: hiding the elbows moved a
-//                measured aspect from 1.6026 to 1.5558, turning a 14px gap into 9.5px.
-//     slug     — optional, but needed for a runnable second pass: the grapher slug the first export
-//     params     came from, plus any query params it carried (a country selection, an MDim view).
-//                solve_export.py prints its `curl` only when it gets `--slug`, so without these
-//                `nextPass` solves the numbers and leaves you to rebuild the request by hand — which
-//                is where a selection or a view param gets dropped and the re-export quietly comes
-//                back with different data.
+//     frameId    — the TEMPLATE CLONE, after Step 6 has filled its texts. Measuring an unfilled
+//                  clone gives you the placeholder band, which is the mistake reference/NODE-MAP.md
+//                  warns about: the header hugs its text, so the band moves when the real title
+//                  lands. A one-line title + one-line subtitle takes Static Vertical's band from
+//                  118 to 70.
+//     groupId    — optional; the imported chart group, once it exists. Give it and you also get the
+//                  group's bbox, its ink aspect, and the scale needed to fit the band.
+//     hideNames  — name patterns to treat as hidden furniture. Prefer this to hideIds: on a fresh
+//                  import you do not have the ids yet, and grapher's names for these are stable
+//                  where its node ids are not. `datapoints__<Entity>` is one marker per year (76 on
+//                  a 1950-2025 line chart) — the pattern hides the container, not each child; the
+//                  story dots are added by hand in Step 8.
+//     hideIds    — extra ids to EXCLUDE from the measured bbox AND the font-size histogram, if
+//                  something needs excluding that the names above don't catch. Both exclusions are
+//                  computed as if the nodes were hidden, WITHOUT hiding them — the aspect you get is
+//                  the one you will actually fit, and the file is untouched. reference/FITTING.md:
+//                  hiding the elbows moved a measured aspect from 1.6026 to 1.5558, turning a 14px
+//                  gap into 9.5px.
+//     declared   — the probe export's declared SVG size, from
+//                    grep -oE 'width="[0-9]+" height="[0-9]+"' embed.svg | head -1
+//                  Give it (with imFontSize) and this returns the per-axis inset and the finished
+//                  `solve_export.py` pass-2 command as `nextPass` — the export that lands exactly.
+//     imFontSize — the imFontSize that probe was requested at, e.g. 30. The inset is only valid at
+//                  that font, so the pass-2 command carries it.
+//     slug       — optional, but needed for a runnable second pass: the slug the probe came from,
+//     params       plus any query params it carried (a country selection, an MDim view). For an
+//                  EXPLORER view pass the site-relative path (e.g. "explorers/natural-disasters"):
+//                  solve_export.py routes a bare slug to /grapher/ and a path-carrying one as-is,
+//                  because explorer views export from /explorers/<slug>.svg, a different endpoint.
+//                  solve_export.py prints its `curl` only when it gets `--slug`, so without these
+//                  `nextPass` solves the numbers and leaves you to rebuild the request by hand —
+//                  which is where a selection or a view param gets dropped and the re-export quietly
+//                  comes back with different data.
+//     originalGroupId — the untouched reference import of the SAME format, left on the page beside
+//                  the frame. Given it, this checks stroke widths: `rescale()` multiplies them, so
+//                  a fitted chart's data line comes out thinner than grapher shipped it (measured
+//                  1.32px against an original 4px) and reads as a weaker chart with nothing visibly
+//                  broken. The reference DETECTS the change; the target is the house 3/4 (line 3,
+//                  halo 4), not the export's own numbers — `imType=square` ships 4/5 where
+//                  `uncaptioned` ships 2/3, and neither is what a finished frame carries.
 //
-// The `nextPass` field in the output is the finished second-pass command — run it as printed. Do
-// NOT hand-build it by feeding the measured aspect back as `--content-aspect`: the solve would then
-// aim at the aspect you already got, which moves the export further from the target rather than onto
-// it. `nextPass` passes the REFLECTION `2*target - measured` instead, so the same model error that
-// put the group off-target cancels. Worked through on the docs' own case (solved 1.6026, measured
-// 1.5558): feeding 1.5558 back doubles the error, the reflection lands on the target.
+// The `nextPass` field in the output is the finished second-pass command — run it as printed. It
+// feeds solve_export.py the MEASURED per-axis inset (`--declared`/`--ink`/`--im-font-size`), which
+// is what makes the second export exact instead of another guess: the `1.4 * imFontSize` model is
+// symmetric and the real inset is not (64.1/29.0 measured at imFontSize 30 against the model's
+// 42/42). Without CONFIG.declared there is nothing to compute the inset from, so `nextPass` falls
+// back to a fresh probe solve and a note tells you what to set.
 
 const CONFIG = {
   frameId: "5332:75", // the template clone
   groupId: null, // the imported chart group, or null
-  hideIds: [], // e.g. ["I123:4;5:6"] for connectors / year markers
+  hideNames: [/^connectors$/, /^datapoints__/], // furniture, matched by stable grapher names
+  hideIds: [], // extra ids, e.g. ["I123:4;5:6"], for what the names above don't catch
+  declared: null, // the probe's declared SVG size, e.g. [791, 645]
+  imFontSize: null, // the imFontSize the probe was requested at, e.g. 30
   targetGap: 14, // px per end the fit aims for; 12-16 on 540-wide frames, 30 on the IG portrait
-  targetLabel: 13.5, // final label px the first export was solved for; the portrait ladder uses 15
-  slug: "", // grapher slug the first export came from, e.g. "life-expectancy"
-  params: "", // the first export's extra query params, e.g. "country=USA~CHN" or an MDim view
+  targetLabel: 13.5, // final label px the probe was solved for; the portrait ladder uses 15
+  slug: "", // slug the probe came from, e.g. "life-expectancy"; an explorer view needs its path, "explorers/<slug>"
+  params: "", // the probe's extra query params, e.g. "country=USA~CHN" or an MDim view
+  originalGroupId: null, // the untouched reference import of the same format, for stroke checks
 };
 
 // Normalized CONFIG reads, so deleting a line from the block above degrades to the house default
 // rather than emitting `undefined` into the command this script prints.
+const hideNames = CONFIG.hideNames || [];
 const hideIds = CONFIG.hideIds || [];
 const targetGap = CONFIG.targetGap ?? 14;
 const targetLabel = CONFIG.targetLabel ?? 13.5;
@@ -56,7 +82,7 @@ const params = CONFIG.params || "";
 
 const r = (v) => (v === null || v === undefined ? null : Math.round(v * 100) / 100);
 // Aspects and scale factors need more than 2dp: `rescale(1.14)` where 1.1433 was meant lands a
-// 343px band height ~1px short, and the docs and `--content-aspect` both speak in 4dp aspects.
+// 343px band height ~1px short, and the docs speak in 4dp aspects.
 const r4 = (v) => (v === null || v === undefined ? null : Math.round(v * 10000) / 10000);
 
 // How many lines a TEXT node actually renders on. `lineHeight` may be AUTO or a percentage, so
@@ -208,25 +234,31 @@ if (groupNode) {
   const g = groupNode;
   const hide = new Set(hideIds);
 
-  // Union the bboxes of visible leaves, skipping the hideIds subtrees. Doing it from leaves is what
+  // Union the bboxes of visible leaves, skipping the excluded subtrees. Doing it from leaves is what
   // lets us answer "what would the aspect be with the connectors hidden" without hiding anything.
   let x0 = Infinity,
     y0 = Infinity,
     x1 = -Infinity,
     y1 = -Infinity;
-  // Which hideIds actually named a node under this group. A mistyped or copied-from-another-page id
-  // excludes nothing, and reporting the requested count as `excluded` would then hide the one clue
-  // that the aspect still contains the connectors — a silent no-op dressed up as a success.
+  // Resolve the name patterns to ids in one walk, and record which hideIds actually named a node
+  // under this group. A mistyped or copied-from-another-page id excludes nothing, and reporting the
+  // requested count as `excluded` would then hide the one clue that the aspect still contains the
+  // connectors — a silent no-op dressed up as a success.
   const seen = new Set();
+  const hiddenByName = [];
   const collect = (n) => {
     seen.add(n.id);
+    if (hideNames.some((re) => re.test(n.name))) {
+      hide.add(n.id);
+      hiddenByName.push(n.name);
+    }
     if ("children" in n) n.children.forEach(collect);
   };
   collect(g);
   const unmatched = hideIds.filter((id) => !seen.has(id));
 
   // The font histogram is collected in THIS traversal, not a second findAllWithCriteria pass. A
-  // separate pass sees neither the hideIds subtrees nor an invisible ancestor — `visible` is a local
+  // separate pass sees neither the excluded subtrees nor an invisible ancestor — `visible` is a local
   // flag, so a text inside a hidden group still reads as visible — and would report label sizes for
   // text the fitted chart will not contain, which is the histogram's whole job to get right.
   const visibleTexts = [];
@@ -272,7 +304,7 @@ if (groupNode) {
     name: g.name,
     declared: raw ? { w: r(raw.width), h: r(raw.height), aspect: r4(raw.width / raw.height) } : null,
     measured: { w: r(w), h: r(h), aspect: r4(w / h) },
-    excluded: { requested: hideIds.length, matched: hideIds.length - unmatched.length, unmatched },
+    excluded: { byName: hiddenByName, requested: hideIds.length, matched: hideIds.length - unmatched.length, unmatched },
     fitScaleToBandH: r4(fitScale),
     // The height fit lands the targetGap per end BY CONSTRUCTION, so the gap is no longer the
     // diagnostic — the leftover width is. `xMapShortfall` is what the closed-form x-map has to
@@ -281,37 +313,105 @@ if (groupNode) {
     xMapShortfall: fitScale === null || !contentW ? null : r(contentW - w * fitScale),
   };
 
-  // The second pass, solved rather than guessed. `target` is the aspect the group has to have for
-  // the gap to come out at targetGap; `measured` is what it actually came back as; the export to
-  // request next is the one solved for the reflection of the measured aspect about the target.
-  const gap = targetGap;
-  const usable = targetH;
-  if (contentW && usable > 0) {
-    const target = contentW / usable;
-    const measured = w / h;
-    // --target-label has to travel with the correction: solve_export.py defaults to 13.5, so a
-    // portrait solved at 15 would come back with smaller text purely from re-solving the aspect.
-    // --slug/--params travel for the same reason one step further out: solve_export.py emits its
-    // curl only with --slug, and rebuilding the URL by hand is where a country selection or an MDim
-    // view param gets dropped and the re-export silently returns different data.
-    // Runnable as printed, from the repo root: these scripts are committed non-executable like every
-    // other script in this directory, and the repo rule is that Python goes through the venv.
+  // The second pass, solved rather than guessed: the per-axis inset, which is what makes the SECOND
+  // export exact instead of another probe. `1.4 * imFontSize` is symmetric and the real inset is not
+  // — 64.1/29.0 measured at imFontSize 30 on an uncaptioned line chart against the model's 42/42.
+  // --slug/--params travel with the command because solve_export.py emits its curl only with --slug,
+  // and rebuilding the URL by hand is where a country selection or an MDim view param gets dropped
+  // and the re-export silently returns different data. Runnable as printed, from the repo root:
+  // these scripts are committed non-executable like every other script in this directory, and the
+  // repo rule is that Python goes through the venv.
+  if (band && contentW) {
+    const carry = (slug ? ` --slug ${slug}` : "") + (params ? ` --params '${params}'` : "");
     const cmd =
       ".venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py" +
-      ` --band ${contentW}x${r(band.height)} --gap ${gap} --target-label ${targetLabel}` +
-      (slug ? ` --slug ${slug}` : "") +
-      (params ? ` --params '${params}'` : "");
-    group.target = { aspect: r4(target), gap, usableHeight: r(usable) };
-    // The reflection only cancels a small model error. A group that is far off the target is not a
-    // near-miss to correct but something else — the wrong export, or furniture still in the bbox —
-    // and reflecting it would ask for an absurd aspect, so fall back to a plain first-pass solve.
-    if (Math.abs(measured - target) / target <= 0.15) {
-      group.nextPass = `${cmd} --content-aspect ${(2 * target - measured).toFixed(4)}`;
+      ` --band ${contentW}x${r(band.height)} --gap ${targetGap}`;
+    if (CONFIG.declared) {
+      const [dw, dh] = CONFIG.declared;
+      const insetX = r(dw - w);
+      const insetY = r(dh - h);
+      // The inset is only meaningful on a group still at its NATURAL size. Run this after the fit
+      // and you are subtracting a rescaled width from the probe's declared one, which yields a large
+      // plausible-looking number (282.95 against a true 64.08, measured) and would send the next
+      // export badly wrong. A real inset is a small fraction of the canvas, so bound it.
+      const rescaled = insetX <= 0 || insetY <= 0 || insetX > 0.25 * dw || insetY > 0.25 * dh;
+      if (rescaled) {
+        group.inset = {
+          unusable:
+            `inset would be ${insetX} / ${insetY} against a declared ${dw}x${dh} — implausible, so this ` +
+            "group is not at its natural size (already rescaled, or CONFIG.declared belongs to a " +
+            "different export). Measure the inset on the freshly-imported probe, before the fit.",
+        };
+        group.nextPass = `${cmd} --target-label ${targetLabel}${carry}`;
+        group.nextPassNote =
+          "the inset was unusable (see group.inset), so this is a fresh PROBE solve, not the exact " +
+          "second pass. Re-import the probe at its natural size and re-run.";
+      } else {
+        group.inset = {
+          x: insetX,
+          y: insetY,
+          modelWouldSay: CONFIG.imFontSize ? r(1.4 * CONFIG.imFontSize) : null,
+        };
+        group.nextPass =
+          `${cmd} --declared ${dw}x${dh} --ink ${r(w)}x${r(h)}` +
+          (CONFIG.imFontSize ? ` --im-font-size ${CONFIG.imFontSize}` : " --im-font-size <the one you exported at>") +
+          carry;
+        if (!CONFIG.imFontSize) {
+          group.nextPassNote =
+            "CONFIG.imFontSize is unset — fill in the imFontSize the probe was requested at before " +
+            "running nextPass; the inset is only valid at that font.";
+        }
+      }
     } else {
-      group.nextPass = cmd;
+      group.nextPass = `${cmd} --target-label ${targetLabel}${carry}`;
       group.nextPassNote =
-        `measured aspect ${r(measured)} is more than 15% off the ${r(target)} target, too far for a ` +
-        "one-step correction — solve it fresh (command above), and check the export and the hideIds first.";
+        "CONFIG.declared is unset, so no inset was computed and this is a fresh PROBE solve. For the " +
+        "exact second pass, read the declared size off the probe SVG " +
+        "(grep -oE 'width=\"[0-9]+\" height=\"[0-9]+\"' embed.svg | head -1) and re-run with " +
+        "CONFIG.declared and CONFIG.imFontSize set.";
+    }
+  }
+
+  // Stroke widths against the untouched reference import: rescale() multiplied them, and the data
+  // line is the one that matters. Compare by node NAME, since the two groups are separate imports.
+  if (CONFIG.originalGroupId) {
+    const orig = await figma.getNodeByIdAsync(CONFIG.originalGroupId);
+    if (!orig) {
+      group.strokes = { error: `originalGroupId ${CONFIG.originalGroupId} not found` };
+    } else {
+      const widths = (node) => {
+        const m = {};
+        for (const n of node.findAll(() => true)) {
+          if (/^(line|outline)__/.test(n.name) && "strokeWeight" in n && typeof n.strokeWeight === "number") {
+            m[n.name] = r(n.strokeWeight);
+          }
+        }
+        return m;
+      };
+      const o = widths(orig);
+      const f = widths(g);
+      // The reference tells you the rescale CHANGED a stroke. It does not tell you the target:
+      // imType=square ships 4/5 and uncaptioned ships 2/3, and the house weight is 3 with a 4px halo
+      // — neither of them (reference/GOTCHAS.md). So the comparison detects, and the HOUSE value is
+      // what the repair sets, after the scale.
+      const house = (k) => (/^outline__/.test(k) ? 4 : 3);
+      const strokeRows = Object.keys(o).map((k) => ({
+        name: k,
+        reference: o[k],
+        fitted: f[k] ?? null,
+        house: house(k),
+        ok: f[k] != null && Math.abs(f[k] - house(k)) < 0.05,
+      }));
+      group.strokes = {
+        rows: strokeRows,
+        verdict: strokeRows.every((x) => x.ok)
+          ? "ok — strokes sit at the house 3/4"
+          : "STROKES ARE OFF THE HOUSE 3/4 — set them after the scale: " +
+            strokeRows.filter((x) => !x.ok).map((x) => `${x.name} ${x.fitted} -> ${x.house}`).join(", ") +
+            ". The reference column only shows what the export shipped (square 4/5, uncaptioned 2/3) " +
+            "— it is the detector, not the target; the house weight is 3 with a 4px halo regardless " +
+            "of frame width (reference/GOTCHAS.md).",
+      };
     }
   }
 
@@ -349,8 +449,8 @@ return {
     contentW !== null && rowsW !== null && Math.abs(contentW - rowsW) > 1
       ? `contentBox from the header (${contentX}/${contentW}) disagrees with the union of the template's other rows (${rowsX}/${rowsW}). The header is the one to trust on any template with a fit step; a difference here means either a header that hugs its text (the 302-wide small templates do, and they have no fit step) or a row that has been moved — look before you scale.`
       : null,
-    CONFIG.groupId && hideIds.length === 0
-      ? "hideIds is empty — if the chart has `connectors` or year markers, the measured aspect includes them and will move once you hide them. Pass their ids."
+    group && group.excluded.byName.length === 0 && group.excluded.matched === 0
+      ? "Nothing was excluded — if this chart has `connectors` or per-year markers, the measured aspect includes them and will move once you hide them. Check the names in the tree against CONFIG.hideNames."
       : null,
     group && group.excluded.unmatched.length
       ? `hideIds NOT FOUND under the group: ${group.excluded.unmatched.join(", ")}. Nothing was excluded for them, so the measured aspect still contains whatever they were meant to remove. Re-read the ids off this group — an id from another page or another chart looks identical and excludes nothing.`
@@ -362,7 +462,13 @@ return {
       ? `the height-fitted group lands ${group.xMapShortfall}px off the ${contentW}px content width — that leftover IS the aspect miss in px, and it is more than the x-map should be asked to close. Re-export with the \`nextPass\` command above (read \`nextPassNote\` first if it is set). The ${targetGap}px gap per end is already correct by construction, so do not judge this fit by the gap.`
       : null,
     group && group.nextPass && !slug
-      ? "CONFIG.slug is empty, so `nextPass` solves the numbers but prints no curl — solve_export.py emits the re-export command only with `--slug`. Set `slug` (and `params`, for a country selection or an MDim view) to what the first export used, so the second pass runs as printed instead of being rebuilt by hand."
+      ? "CONFIG.slug is empty, so `nextPass` solves the numbers but prints no curl — solve_export.py emits the re-export command only with `--slug`. Set `slug` (and `params`, for a country selection or an MDim view) to what the probe used, so the second pass runs as printed instead of being rebuilt by hand."
+      : null,
+    group && !CONFIG.originalGroupId
+      ? "originalGroupId is unset, so stroke widths were not checked against the reference import. The rescale thins them and the render still looks fine — pass it."
+      : null,
+    group && group.strokes && group.strokes.verdict && !group.strokes.verdict.startsWith("ok")
+      ? group.strokes.verdict
       : null,
   ].filter(Boolean),
 };

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -143,7 +143,7 @@ for (const job of CONFIG.jobs) {
   //
   // Three things this has to get right, and each was wrong in an earlier version:
   //   - matplotlib writes a patch as `<g id="patch_1"><path/></g>`, so it imports as a GROUP, which
-  //     has no `fills` of its own (see SKILL.md → Gotchas). The paint is on the descendant vector, so
+  //     has no `fills` of its own (see reference/GOTCHAS.md). The paint is on the descendant vector, so
   //     that is what decides whether the patch covers anything.
   //   - only a *fill* counts. The spine group is a `patch_N` too and is stroke-only, so testing fills
   //     rather than any paint leaves it alone.

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -1,60 +1,80 @@
 #!/usr/bin/env python3
-"""Solve a grapher embed export so the imported chart fills a template band on the first try.
+"""Solve a grapher embed export so the imported chart fills a template band.
 
 Requesting the aspect you *want* is the mistake: grapher insets the drawing inside the SVG it hands
 back, so the group Figma imports is smaller than the declared size — and it is the group that has to
 fill the band. Ask for the aspect that *yields* the one you want instead.
 
-The model, from `reference/FITTING.md` and Step 3:
-
-    inset       ~= 1.4 * imFontSize on each axis
+    inset        = declared - ink, PER AXIS (see below — the axes are not equal)
     canvas       : W * H ~= 510000 px^2   (the server renormalizes to this)
-    content      : (W - 1.4F) x (H - 1.4F)
-    label size   ~= 0.75 * F, then scaled by (usable band height / content height)
+    ink          : (W - insetX) x (H - insetY)
+    label size  ~= 0.75 * imFontSize, then scaled by the HEIGHT-first fit factor
 
 The label scale is the HEIGHT-first factor, because that is the only rescale Step 7 spends. From
 `reference/FITTING.md`: "Fit to the band's height, then map x to fill the width", and the x-map that
-follows "takes the plot out to the full content width without touching a single font size" (L243,
-L450, L456). The width-first `placed width / content width` agrees with it exactly whenever the
-solved aspect IS the band's usable aspect, so it reads as equivalent on a first pass -- and stops
-being equivalent the moment --content-aspect carries the reflected aspect of a second pass, which is
-deliberately off the band's own. There it asked for a font up to 4px away from the right one.
+follows "takes the plot out to the full content width without touching a single font size". The
+width-first `placed width / ink width` agrees with it exactly when the achieved aspect IS the target
+aspect — which pass 2 guarantees and pass 1 does not, and on a pass-1 miss the width-first factor
+asked for an imFontSize up to 4px away from the right one.
 
-Substituting W = 510000/H into (W - 1.4F)/(H - 1.4F) = A gives a quadratic in H:
+Substituting W = 510000/H into (W - insetX)/(H - insetY) = A gives a quadratic in H:
 
-    A*H^2 + 1.4*F*(1 - A)*H - 510000 = 0
+    A*H^2 + (insetX - A*insetY)*H - 510000 = 0
 
-which this solves in closed form. F is then found by bisection, because the content height that
-sets the final label size itself depends on F -- and is then ROUNDED, because `imFontSize` travels in
-the URL as an integer. Every number reported is recomputed from that integer, so the predicted label
-size is the one the emitted `curl` will actually produce rather than the one the ideal font would
-have: at 508x371 with the reflected aspect 1.5279 the ideal font is 28.6 and the request carries 29,
-which lands labels at 13.7px, not the 13.5px asked for. The aspect is unaffected -- the canvas solve
-enforces it at any font -- so the gap and the x-map leftover stay exact.
+solved here in closed form.
+
+TWO PASSES, AND THE SECOND IS EXACT. Do not try to land it in one.
+
+  1. `--band WxH` alone uses the `1.4 * imFontSize` model for the inset and bisects imFontSize for
+     your target label size — then ROUNDS it, because `imFontSize` travels in the URL as an integer,
+     and recomputes every reported number from that integer, so the prediction is what the emitted
+     `curl` actually produces. Treat the result as a probe: export it, import it, hide the furniture,
+     measure the ink (scripts/measure_fit.js does all of it in one call).
+  2. Re-run with `--declared` and `--ink` (or `--inset-x/--inset-y`) from that measurement, plus
+     `--im-font-size` from the probe. The inset is stable to ~2px across an aspect change at the same
+     imFontSize, so this pass lands.
+
+Why the model is only a probe: the `1.4 * imFontSize` figure is symmetric, and the real inset is not.
+Measured on an `imType=uncaptioned` line chart that reserves a right margin for a direct entity
+label:
+
+    imFontSize 30 -> insetX 64.1, insetY 29.0   (model predicts 42.0 / 42.0)
+    imFontSize 21 -> insetX 70.6, insetY 40.8   (model predicts 29.4 / 29.4)
+
+The model is right for the charts it was measured on — the recorded examples come out ~44/46 at
+imFontSize 32 — and wrong by 2x on the horizontal axis for this class. Note also that insetY got
+*larger* as the font got *smaller*: the inset is not a simple function of imFontSize, so don't try to
+fit one from a couple of runs. Measure it. And the measured inset pins the font — pass 2 keeps the
+imFontSize the inset was measured at rather than re-bisecting for a label target, because changing
+the font invalidates the measurement.
+
+And don't try to read the ink out of the SVG to skip the first import: text ink depends on font
+metrics that are not in the file. Parsing every coordinate in one came out 13-33px wide of what
+Figma measured.
 
 The band is not the target. Step 7 fits the chart to `band - 2*gap`, not to the band itself, so the
 aspect to solve for is `bandW / (bandH - 2*gap)`. Solving for the band's own aspect lands the chart
-edge to edge with a zero-pixel gap, which `measure_fit.js` then flags and you re-export. The gap is
-14 by default with 12-16 the comfortable range on the 540-wide frames, but it is a flag because the
-Instagram portrait runs at 30 (reference/FITTING.md).
-
-Accurate to a few px, which is what the docs claim ("expect at most one correction"). To spend that
-correction, take the `nextPass` command `measure_fit.js` prints — do NOT pass the aspect you measured
-off the import back in as --content-aspect. Solving for the aspect you already got aims at the miss
-instead of at the target and roughly doubles it; the correction has to be the reflection of the
-measured aspect about the target, `2*target - measured`, which is what `nextPass` carries.
+edge to edge with a zero-pixel gap. The gap is 14 by default with 12-16 the comfortable range on the
+540-wide frames, but it is a flag because the Instagram portrait runs at 30 (reference/FITTING.md).
 
 Usage — from the repo root, through the venv (this file is committed non-executable, like every
 other script in this directory):
 
     S=.claude/skills/create-figma-chart/scripts/solve_export.py
-    .venv/bin/python $S --band 508x371 --slug life-expectancy
-    .venv/bin/python $S --band 508x371 --gap 30 --target-label 15 --params "country=USA~CHN"
+
+    # pass 1 — the probe
+    .venv/bin/python $S --band 508x409 --target-label 15 --slug liberal-democracy
+
+    # pass 2 — after measuring the import (declared from the SVG, ink from measure_fit.js, which
+    # prints this command for you as `nextPass`)
+    .venv/bin/python $S --band 508x409 --declared 791x645 --ink 726.92x615.96 --im-font-size 30 \\
+        --slug liberal-democracy --params "tab=chart&country=~CHL"
+
     .venv/bin/python $S --band 302x220 --thumbnail --slug life-expectancy
 
 Self-test (validates the model against the worked examples in the docs, round-trips the band
-arithmetic — the height-fitted content must leave exactly --gap at each end and no width for the
-x-map to close — and checks that a reflected second pass still lands its --target-label):
+arithmetic — the height-fitted ink must leave exactly --gap at each end and no width for the x-map
+to close — and reproduces the two measured-inset second passes recorded from a real run):
     .venv/bin/python $S --self-test
 """
 
@@ -65,7 +85,7 @@ import math
 import sys
 
 CANVAS_AREA = 510_000.0  # px^2 the server renormalizes an uncaptioned/default export to
-INSET_PER_FONT = 1.4  # inset on each axis, as a multiple of imFontSize
+INSET_PER_FONT = 1.4  # the SYMMETRIC model inset — pass 1's probe only, see the module docstring
 LABEL_RATIO = 0.75  # segment values / entity names, as a multiple of the base font
 MIN_LABEL = 12.0  # the floor the guidelines set for a full-size chart
 DEFAULT_GAP = 14.0  # px at each end of the band; 12-16 is the house range on 540-wide frames
@@ -83,38 +103,52 @@ THUMB_TARGET_LABEL = 12.0  # top of the format's range; imFontSize=16 lands here
 THUMB_MIN_LABEL = 11.0  # the format's floor — the templates' own labels are 11px by design
 
 
-def solve_canvas(content_aspect: float, font: float) -> tuple[float, float]:
-    """Return the (W, H) to request so the *content* comes back at content_aspect."""
-    a = content_aspect
-    b = INSET_PER_FONT * font * (1.0 - a)
-    disc = b * b + 4.0 * a * CANVAS_AREA
-    h = (-b + math.sqrt(disc)) / (2.0 * a)
+def solve_canvas(ink_aspect: float, inset_x: float, inset_y: float) -> tuple[float, float]:
+    """Return the (W, H) to request so the *ink* comes back at ink_aspect."""
+    a = ink_aspect
+    b = inset_x - a * inset_y
+    h = (-b + math.sqrt(b * b + 4.0 * a * CANVAS_AREA)) / (2.0 * a)
     return CANVAS_AREA / h, h
 
 
-def content_box(w: float, h: float, font: float) -> tuple[float, float]:
-    return w - INSET_PER_FONT * font, h - INSET_PER_FONT * font
+def model_inset(font: float) -> tuple[float, float]:
+    return INSET_PER_FONT * font, INSET_PER_FONT * font
 
 
-def label_at(font: float, content_h: float, fitted_h: float) -> float:
+def label_at(font: float, ink_h: float, fitted_h: float) -> float:
     """Final on-page label size once the export is HEIGHT-fitted to fitted_h.
 
     Height-first because that is the only rescale Step 7 spends: the x-map that follows closes the
-    width without touching a font size (reference/FITTING.md L243/L450/L456). Identical to the
-    width-first factor when the solved aspect is the band's usable aspect; not identical, and not
-    interchangeable, once --content-aspect carries a second pass's reflected aspect.
+    width without touching a font size (reference/FITTING.md). Identical to the width-first factor
+    when the achieved aspect is the target aspect — which pass 2 guarantees — and not interchangeable
+    on a pass-1 miss.
     """
-    return LABEL_RATIO * font * (fitted_h / content_h)
+    return LABEL_RATIO * font * (fitted_h / ink_h)
 
 
-def solve_font(content_aspect: float, usable_h: float, target_label: float) -> float:
-    """Bisect for the imFontSize whose labels land on target_label after the height fit."""
+def target_aspect(band_w: float, band_h: float, gap: float) -> float:
+    """The ink aspect that leaves `gap` at each end of the band once height-fitted.
+
+    Solving for the band's own aspect instead — which is what a gap of 0 means — asks the chart to
+    fill the band edge to edge and leaves nothing for the 12-16px the guidelines want.
+    """
+    usable = band_h - 2.0 * gap
+    if usable <= 0:
+        raise ValueError(f"gap {gap:g} leaves no height in a {band_h:g}px band (2*gap >= band height)")
+    return band_w / usable
+
+
+def solve_font(ink_aspect: float, usable_h: float, target_label: float) -> float:
+    """Bisect for the imFontSize whose labels land on target_label after the height fit.
+
+    Pass 1 only: it runs under the MODEL inset, which is what makes its result a probe.
+    """
     lo, hi = 8.0, 200.0
     for _ in range(200):
         mid = (lo + hi) / 2.0
-        w, h = solve_canvas(content_aspect, mid)
-        _, ch = content_box(w, h, mid)
-        if label_at(mid, ch, usable_h) < target_label:
+        ix, iy = model_inset(mid)
+        w, h = solve_canvas(ink_aspect, ix, iy)
+        if label_at(mid, h - iy, usable_h) < target_label:
             lo = mid
         else:
             hi = mid
@@ -122,60 +156,53 @@ def solve_font(content_aspect: float, usable_h: float, target_label: float) -> f
 
 
 def self_test() -> int:
-    """The two exports recorded in the docs, reproduced from the model."""
-    cases = [
-        # font, declared WxH, content WxH  (reference/FITTING.md / Step 3)
-        (32.0, 901.0, 566.0, 857.0, 520.0),
-        (30.0, 862.0, 591.0, 818.9, 550.0),
-    ]
-    worst = 0.0
-    print(f"{'F':>5} {'aspect':>8} {'W pred':>8} {'W obs':>7} {'H pred':>8} {'H obs':>7} {'err px':>7}")
-    for font, dw, dh, cw, ch in cases:
-        w, h = solve_canvas(cw / ch, font)
-        err = max(abs(w - dw), abs(h - dh))
-        worst = max(worst, err)
-        print(f"{font:5.0f} {cw / ch:8.4f} {w:8.1f} {dw:7.0f} {h:8.1f} {dh:7.0f} {err:7.1f}")
-        # and the inset model itself
-        pcw, pch = content_box(dw, dh, font)
-        print(f"      inset check: content {pcw:.1f}x{pch:.1f} vs observed {cw:.1f}x{ch:.1f}")
-    print(f"\nworst canvas error: {worst:.1f}px — docs state the model is approximate (+-3px)")
-    ok = worst <= 3.0
+    """The docs' recorded exports, the band round-trip, and a real run's measured-inset passes."""
+    ok = True
 
-    # The band arithmetic, round-tripped through the HEIGHT-first fit Step 7 actually performs:
-    # solve for band - 2*gap, rescale by usable_h / content_h, and the result must leave exactly gap
-    # at each end, land the full band width (nothing for the x-map to close) and hit target_label.
-    # A zero-gap solve here is one regression this covers — it is what a chart crowding the header
-    # and footer looks like.
-    # `F` is the ideal bisection result and `emit` the integer the URL carries; `label` is measured
-    # against `emit`, because that is the export you actually get. ROUNDING_TOLERANCE bounds how far
-    # an integer imFontSize can leave the label from its target (half a font step, ~0.5*target/F).
+    # --- the model inset, against the two exports the docs record.
+    print("model inset, against the two exports the docs record:")
+    print(f"{'F':>4} {'aspect':>8} {'W pred':>8} {'W obs':>7} {'H pred':>8} {'H obs':>7} {'err':>6}")
+    for font, dw, dh, cw, ch in [(32.0, 901.0, 566.0, 857.0, 520.0), (30.0, 862.0, 591.0, 818.9, 550.0)]:
+        ix, iy = model_inset(font)
+        w, h = solve_canvas(cw / ch, ix, iy)
+        err = max(abs(w - dw), abs(h - dh))
+        ok &= err <= 3.0
+        print(f"{font:4.0f} {cw / ch:8.4f} {w:8.1f} {dw:7.0f} {h:8.1f} {dh:7.0f} {err:6.1f}")
+    print("(the docs state the model is approximate, +-3px — that is why pass 1 is a probe)")
+
+    # --- the band arithmetic, round-tripped through the HEIGHT-first fit Step 7 actually performs:
+    # solve for band - 2*gap, rescale by usable_h / ink_h, and the result must leave exactly gap at
+    # each end, land the full band width (nothing for the x-map to close) and hit target_label. A
+    # zero-gap solve here is one regression this covers — it is what a chart crowding the header and
+    # footer looks like. `F` is the ideal bisection result and `emit` the integer the URL carries;
+    # `label` is measured against `emit`, because that is the export you actually get.
     bands = [(508.0, 371.0, 14.0, 13.5), (508.0, 371.0, 12.0, 13.5), (508.0, 552.0, 30.0, 15.0)]
     print(
-        f"\n{'band':>12} {'gap':>5} {'F':>7} {'emit':>5} {'content':>15} "
+        f"\n{'band':>12} {'gap':>5} {'F':>7} {'emit':>5} {'ink':>15} "
         f"{'gap/end':>8} {'x-map':>7} {'label':>7} {'err':>6}"
     )
-    worst_gap = 0.0
-    worst_xmap = 0.0
-    worst_ideal = 0.0
-    worst_label = 0.0
+    worst_gap = worst_xmap = worst_ideal = worst_label = 0.0
     for bw, bh, gap, target in bands:
         usable = bh - 2.0 * gap
-        font_exact = solve_font(bw / usable, usable, target)
+        aspect = bw / usable
+        font_exact = solve_font(aspect, usable, target)
         font = float(round(font_exact))
-        w, h = solve_canvas(bw / usable, font)
-        cw, ch = content_box(w, h, font)
-        scale = usable / ch
-        got_gap = (bh - ch * scale) / 2.0
-        xmap = bw - cw * scale
-        label = label_at(font, ch, usable)
-        _, ch_exact = content_box(*solve_canvas(bw / usable, font_exact), font_exact)
+        ix, iy = model_inset(font)
+        w, h = solve_canvas(aspect, ix, iy)
+        iw, ih = w - ix, h - iy
+        scale = usable / ih
+        got_gap = (bh - ih * scale) / 2.0
+        xmap = bw - iw * scale
+        label = label_at(font, ih, usable)
+        ixe, iye = model_inset(font_exact)
+        _, he = solve_canvas(aspect, ixe, iye)
         worst_gap = max(worst_gap, abs(got_gap - gap))
         worst_xmap = max(worst_xmap, abs(xmap))
-        worst_ideal = max(worst_ideal, abs(label_at(font_exact, ch_exact, usable) - target))
+        worst_ideal = max(worst_ideal, abs(label_at(font_exact, he - iye, usable) - target))
         worst_label = max(worst_label, abs(label - target))
         print(
             f"{f'{bw:g}x{bh:g}':>12} {gap:5.0f} {font_exact:7.3f} {font:5.0f} "
-            f"{f'{cw:.1f}x{ch:.1f}':>15} {got_gap:8.2f} {xmap:7.3f} {label:7.2f} {label - target:+6.3f}"
+            f"{f'{iw:.1f}x{ih:.1f}':>15} {got_gap:8.2f} {xmap:7.3f} {label:7.2f} {label - target:+6.3f}"
         )
     print(
         f"\nworst gap error {worst_gap:.3f}px and x-map leftover {worst_xmap:.3f}px — exact (<0.01px), "
@@ -185,55 +212,36 @@ def self_test() -> int:
     ok = ok and worst_gap < 0.01 and worst_xmap < 0.01
     ok = ok and worst_ideal < 0.01 and worst_label < ROUNDING_TOLERANCE
 
-    # A reflected SECOND pass must still land its --target-label. The reflection is deliberately off
-    # the band's own aspect, which is exactly where a width-first label scale stops agreeing with the
-    # height-first fit: on the docs' 508x371 case measured at 1.4342 it asked for imFontSize 29 and
-    # promised 13.5px labels the height fit renders at 13.93px, and across the miss range it picked a
-    # font up to 4px off. Reflections come from measure_fit.js's `nextPass`.
-    print(
-        f"\n{'band':>12} {'measured':>9} {'reflected':>10} {'F':>7} {'emit':>5} "
-        f"{'ideal':>7} {'emitted':>8} {'want':>6}"
-    )
-    worst_refl = 0.0
-    worst_refl_emit = 0.0
-    for (bw, bh, gap, target), measured_frac in zip(bands, [-0.0316, 0.05, -0.10]):
-        usable = bh - 2.0 * gap
-        band_aspect = bw / usable
-        measured = band_aspect * (1.0 + measured_frac)
-        reflected = 2.0 * band_aspect - measured
-        font_exact = solve_font(reflected, usable, target)
-        font = float(round(font_exact))
-        _, ch_exact = content_box(*solve_canvas(reflected, font_exact), font_exact)
-        _, ch = content_box(*solve_canvas(reflected, font), font)
-        ideal = label_at(font_exact, ch_exact, usable)
-        emitted = label_at(font, ch, usable)
-        worst_refl = max(worst_refl, abs(ideal - target))
-        worst_refl_emit = max(worst_refl_emit, abs(emitted - target))
-        print(
-            f"{f'{bw:g}x{bh:g}':>12} {measured:9.4f} {reflected:10.4f} {font_exact:7.3f} "
-            f"{font:5.0f} {ideal:7.2f} {emitted:8.2f} {target:6.1f}"
-        )
-    print(
-        f"\nreflected pass: ideal-font label error {worst_refl:.3f}px (<0.01px), emitted-font "
-        f"{worst_refl_emit:.3f}px (<{ROUNDING_TOLERANCE:g}px) — the second pass keeps --target-label"
-    )
-    ok = ok and worst_refl < 0.01 and worst_refl_emit < ROUNDING_TOLERANCE
+    # --- pass 2, against the two measured-inset exports recorded from a real run. These validate
+    # the per-axis quadratic against reality: the solve, fed the inset measured off the probe, must
+    # predict the declared size the server actually returned.
+    print("\nmeasured inset, against a real run's second passes:")
+    print(f"{'case':10s} {'W pred':>8} {'W obs':>7} {'H pred':>8} {'H obs':>7} {'err':>6}")
+    for label_, bw, bh, ix, iy, dw, dh in [
+        ("square", 508.0, 409.0, 64.08, 29.04, 837.0, 609.0),
+        ("desktop", 818.0, 521.0, 70.60, 40.80, 921.0, 554.0),
+    ]:
+        a = target_aspect(bw, bh, DEFAULT_GAP)
+        w, h = solve_canvas(a, ix, iy)
+        err = max(abs(w - dw), abs(h - dh))
+        ok &= err <= 3.0
+        print(f"{label_:10s} {w:8.1f} {dw:7.0f} {h:8.1f} {dh:7.0f} {err:6.1f}")
+        # and the round-trip: the ink the solve implies must sit at the target aspect exactly, so
+        # the height fit leaves exactly DEFAULT_GAP per end and nothing for the x-map to close.
+        iw2, ih2 = w - ix, h - iy
+        scale = (bh - 2.0 * DEFAULT_GAP) / ih2
+        ok &= abs(iw2 / ih2 - a) < 1e-9
+        ok &= abs((bh - ih2 * scale) / 2.0 - DEFAULT_GAP) < 0.01
+        ok &= abs(bw - iw2 * scale) < 0.01
+    print("(pass-2 ink aspect, gap and x-map leftover round-trip exactly — checked to <0.01px)")
 
-    print("PASS" if ok else "FAIL")
+    print("\nPASS" if ok else "\nFAIL")
     return 0 if ok else 1
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--band", help="the band to fill, in template px, e.g. 508x371")
-    ap.add_argument(
-        "--content-aspect",
-        type=float,
-        help="the content aspect to solve for, bypassing the band/gap derivation. This is the "
-        "TARGET, not the measurement: pass the reflected value from measure_fit.js's `nextPass` "
-        "(2*target - measured), never the aspect you just measured off the import, which aims the "
-        "solve at the miss and doubles it.",
-    )
+    ap.add_argument("--band", help="the band to fill, in template px, e.g. 508x409")
     ap.add_argument(
         "--gap",
         type=float,
@@ -241,10 +249,22 @@ def main() -> int:
         help=f"px to leave at each end of the band (default {DEFAULT_GAP:g}; 12-16 on the 540-wide "
         "frames, 30 on the Instagram portrait). The solve targets band height - 2*gap.",
     )
+    ap.add_argument("--declared", help="pass 2: the probe's declared SVG size, e.g. 791x645")
+    ap.add_argument("--ink", help="pass 2: the ink measured in Figma after hiding furniture, e.g. 726.92x615.96")
+    ap.add_argument("--inset-x", type=float, help="pass 2: measured horizontal inset, if you have it directly")
+    ap.add_argument("--inset-y", type=float, help="pass 2: measured vertical inset")
+    ap.add_argument(
+        "--im-font-size",
+        type=float,
+        help="pass 2: the imFontSize the inset was measured at (required — the inset is only valid "
+        "at that font, so pass 2 keeps it rather than re-solving for --target-label)",
+    )
     ap.add_argument(
         "--target-label",
         type=float,
-        help=f"desired final label px (default {DEFAULT_TARGET_LABEL:g}, or {THUMB_TARGET_LABEL:g} on --thumbnail)",
+        help=f"pass 1 only: desired final label px (default {DEFAULT_TARGET_LABEL:g}, or "
+        f"{THUMB_TARGET_LABEL:g} on --thumbnail). Ignored on pass 2, where the measured inset pins "
+        "the font.",
     )
     ap.add_argument(
         "--placed-width",
@@ -253,8 +273,14 @@ def main() -> int:
         "solve for and the width the x-map has to reach — NOT the label scale, which follows the "
         "height fit.",
     )
-    ap.add_argument("--slug", help="grapher slug, to emit a ready curl")
-    ap.add_argument("--params", default="", help="extra grapher query params, e.g. 'country=USA~CHN'")
+    ap.add_argument(
+        "--slug",
+        help="slug to emit a ready curl for. A bare slug exports from /grapher/<slug>.svg; an "
+        "Explorer view exports from a DIFFERENT route, /explorers/<slug>.svg (SKILL.md, Step 1), "
+        "so pass the site-relative path when the input is not a grapher chart: "
+        "--slug explorers/natural-disasters.",
+    )
+    ap.add_argument("--params", default="", help="extra grapher query params, e.g. 'tab=chart&country=~CHL'")
     ap.add_argument(
         "--thumbnail",
         action="store_true",
@@ -284,15 +310,17 @@ def main() -> int:
     if not args.band:
         ap.error("--band is required (or use --self-test)")
 
-    try:
-        bw, bh = (float(x) for x in args.band.lower().split("x"))
-    except ValueError:
-        ap.error("--band must look like 508x371")
-    if bw <= 0 or bh <= 0:
-        ap.error(f"--band must be positive on both axes, got {bw:g}x{bh:g}")
-    if args.content_aspect is not None and args.content_aspect <= 0:
-        ap.error(f"--content-aspect must be positive, got {args.content_aspect:g}")
+    def pair(s: str, flag: str) -> tuple[float, float]:
+        try:
+            a, b = (float(x) for x in s.lower().split("x"))
+        except ValueError:
+            ap.error(f"{flag} must look like 508x409")
+            raise
+        if a <= 0 or b <= 0:
+            ap.error(f"{flag} must be positive on both axes, got {a:g}x{b:g}")
+        return a, b
 
+    bw, bh = pair(args.band, "--band")
     placed_w = args.placed_width or bw
     default_label = THUMB_TARGET_LABEL if args.thumbnail else DEFAULT_TARGET_LABEL
     target_label = args.target_label if args.target_label is not None else default_label
@@ -323,8 +351,9 @@ def main() -> int:
             print(f"  *** {label:g}px is under this format's {THUMB_MIN_LABEL:g}px floor")
         if args.slug:
             p = f"{args.params}&" if args.params else ""
+            path = args.slug if "/" in args.slug else f"grapher/{args.slug}"
             print(
-                f'\ncurl -sL "https://ourworldindata.org/grapher/{args.slug}.svg'
+                f'\ncurl -sL "https://ourworldindata.org/{path}.svg'
                 f"?{p}imType=thumbnail&imWidth={im_w}&imHeight={im_h}"
                 f'&imFontSize={font:.0f}&nocache" -o thumb.svg'
             )
@@ -335,35 +364,65 @@ def main() -> int:
     usable_h = bh - 2.0 * args.gap
     if usable_h <= 0:
         ap.error(f"--gap {args.gap:g} leaves no height in a {bh:g}px band (2*gap >= band height)")
+    aspect = placed_w / usable_h
 
-    aspect = args.content_aspect if args.content_aspect is not None else placed_w / usable_h
+    # --- which pass?
+    inset_x = inset_y = None
+    if args.declared and args.ink:
+        dw, dh = pair(args.declared, "--declared")
+        iw, ih = pair(args.ink, "--ink")
+        inset_x, inset_y = dw - iw, dh - ih
+        if inset_x <= 0 or inset_y <= 0:
+            ap.error(
+                f"--ink {iw:g}x{ih:g} is not inside --declared {dw:g}x{dh:g} — the inset came out "
+                f"{inset_x:g}/{inset_y:g}. The ink must be measured on the freshly-imported probe, "
+                "before any fit, and belong to the same export as --declared."
+            )
+    elif args.inset_x is not None and args.inset_y is not None:
+        if args.inset_x <= 0 or args.inset_y <= 0:
+            ap.error(f"insets must be positive, got {args.inset_x:g}/{args.inset_y:g}")
+        inset_x, inset_y = args.inset_x, args.inset_y
+    elif args.declared or args.ink or args.inset_x is not None or args.inset_y is not None:
+        ap.error("pass 2 needs BOTH --declared and --ink, or BOTH --inset-x and --inset-y")
+
     # Solve, then round: imFontSize goes into the URL as an integer, so the integer is what the
-    # export will actually use. Recompute the canvas, the content box and the label from it —
-    # reporting the ideal font's label beside an `imFontSize` one step away promises a size the
-    # request cannot deliver. The aspect survives rounding untouched, because solve_canvas enforces
-    # it at whatever font it is given, so the gap and the x-map leftover below are still exact.
-    font_exact = solve_font(aspect, usable_h, target_label)
-    font = float(round(font_exact))
-    w, h = solve_canvas(aspect, font)
-    cw, ch = content_box(w, h, font)
-    label = label_at(font, ch, usable_h)
+    # export will actually use. Recompute the canvas, the ink box and the label from it — reporting
+    # the ideal font's label beside an `imFontSize` one step away promises a size the request cannot
+    # deliver. The aspect survives rounding untouched, because solve_canvas enforces it at whatever
+    # inset it is given, so the gap and the x-map leftover below stay exact.
+    if inset_x is None:
+        # PASS 1 — the probe. Model inset, font bisected for the target label size.
+        font_exact = solve_font(aspect, usable_h, target_label)
+        font = float(round(font_exact))
+        inset_x, inset_y = model_inset(font)
+        pass_label = "1 (PROBE — model inset, expect to re-run)"
+    else:
+        # PASS 2 — measured inset. The font is what the inset was measured at, not re-bisected:
+        # changing it invalidates the measurement.
+        if args.im_font_size is None:
+            ap.error("--im-font-size is required with a measured inset: the inset is only valid at that font")
+        font_exact = args.im_font_size
+        font = float(round(font_exact))
+        pass_label = "2 (measured inset — this one lands)"
+
+    w, h = solve_canvas(aspect, inset_x, inset_y)
+    ink_w, ink_h = w - inset_x, h - inset_y
     im_w = int(round(w / h * 1000))
 
     # Height-first, exactly as Step 7 fits: `chart.rescale(TARGET_H / chart.height)`. The gap is then
     # --gap at each end by construction, so it is no longer the diagnostic — the leftover width the
     # x-map has to close is, and it IS the aspect miss expressed in px (measure_fit.js reports the
     # same quantity as `xMapShortfall`).
-    scale = usable_h / ch
-    fitted_w = cw * scale
-    shortfall = placed_w - fitted_w
+    scale = usable_h / ink_h
+    label = label_at(font, ink_h, usable_h)
+    shortfall = placed_w - ink_w * scale
     if abs(shortfall) < 0.05:
-        shortfall = 0.0  # so an exact band solve prints 0.0 rather than float noise's -0.0
+        shortfall = 0.0  # so an exact solve prints 0.0 rather than float noise's -0.0
 
-    src = "explicit target aspect" if args.content_aspect is not None else "band minus gaps"
+    print(f"pass            {pass_label}")
     print(f"band            {bw:g} x {bh:g}   (aspect {bw / bh:.4f})")
-    print(f"usable          {bw:g} x {usable_h:g}   (aspect {bw / usable_h:.4f}, {args.gap:g}px gap per end)")
-    print(f"solving for     {aspect:.4f}  [{src}]")
-    print(f"fitting to      {placed_w:g}px wide, height-first")
+    print(f"usable          {placed_w:g} x {usable_h:g}   (target ink aspect {aspect:.4f}, {args.gap:g}px gap per end)")
+    print(f"inset           x {inset_x:.2f}   y {inset_y:.2f}")
     print()
     print(f"imFontSize      {font:.0f}", end="")
     if abs(font - font_exact) > 0.05:
@@ -372,41 +431,45 @@ def main() -> int:
         print()
     print(f"imWidth/Height  {im_w}/1000        (aspect ratio only — the server renormalizes)")
     print(f"declared        {w:.0f} x {h:.0f}   ({w * h:,.0f} px^2)")
-    print(f"content         {cw:.1f} x {ch:.1f}   (aspect {cw / ch:.4f})")
-    print(f"scale into band {scale:.4f}   (height-first: usable height / content height)")
+    print(f"ink             {ink_w:.1f} x {ink_h:.1f}   (aspect {ink_w / ink_h:.4f})")
+    print(f"scale into band {scale:.4f}   (height-first: usable height / ink height)")
     print(f"gap per end     {args.gap:g}px   (exact — the height fit sets it by construction)")
     print(f"x-map closes    {shortfall:.1f}px of the {placed_w:g}px width", end="")
-    if args.content_aspect is not None:
-        print("   (a reflected second pass over-corrects on purpose, so expect this to be non-zero)")
-    elif abs(shortfall) > 1.0:
-        print("   *** should be ~0 on a band solve — re-check --band and --gap")
+    if pass_label.startswith("1") and abs(shortfall) > 1.0:
+        print("   *** should be ~0 — re-check --band and --gap")
     else:
         print()
     print(f"final labels    {label:.1f}px", end="")
     if label < MIN_LABEL:
         print(f"   *** under the {MIN_LABEL:g}px floor — raise --target-label or cut entities")
-    elif abs(label - target_label) > 0.05:
+    elif pass_label.startswith("1") and abs(label - target_label) > 0.05:
         print(f"   (asked for {target_label:g}; imFontSize {font:.0f} is the closest integer)")
+    elif pass_label.startswith("2") and args.target_label is not None:
+        print("   (--target-label is ignored on pass 2 — the measured inset pins the font)")
     else:
         print()
 
     if args.slug:
         p = f"{args.params}&" if args.params else ""
+        path = args.slug if "/" in args.slug else f"grapher/{args.slug}"
         print(
-            f'\ncurl -sL "https://ourworldindata.org/grapher/{args.slug}.svg'
+            f'\ncurl -sL "https://ourworldindata.org/{path}.svg'
             f"?{p}imType=uncaptioned&imWidth={im_w}&imHeight=1000&imFontSize={font:.0f}"
             f'&nocache" -o embed.svg'
         )
-        print("\nthen check what came back, and correct once if the group's aspect moved:")
-        print("  head -c 300 embed.svg")
-        print("  grep -oE 'font-size=\"[0-9.]+\"' embed.svg | sort | uniq -c | sort -rn | head -3")
+        if pass_label.startswith("1"):
+            print('  grep -oE \'width="[0-9]+" height="[0-9]+"\' embed.svg | head -1   # the declared size, for pass 2')
+
+    if pass_label.startswith("1"):
+        print(
+            "\nThis is a PROBE. Import it, hide the furniture, measure the ink, then run the pass-2"
+            "\ncommand: scripts/measure_fit.js does all three in one call (set CONFIG.declared and"
+            "\nCONFIG.imFontSize from the export above) and prints the command as `nextPass`."
+        )
     print(
         "\nFit the height, then x-map the width — never a second rescale (reference/FITTING.md)."
-        "\nHide connectors and year markers BEFORE measuring the group — they extend past the plot,"
-        "\nso hiding them narrows it and makes it relatively taller. Then measure with"
-        "\nscripts/measure_fit.js and run the `nextPass` command it prints: it reflects the measured"
-        "\naspect about the target for you. Passing the measured aspect straight back to"
-        "\n--content-aspect solves for the miss and doubles it."
+        "\nHide connectors and year markers BEFORE measuring the ink: they extend past the plot, so"
+        "\nhiding them narrows the group and makes it relatively taller."
     )
     return 0
 

--- a/.claude/skills/create-figma-chart/scripts/verify_docs.py
+++ b/.claude/skills/create-figma-chart/scripts/verify_docs.py
@@ -48,6 +48,9 @@ def normalize(s: str) -> str:
     s = re.sub(r"^#+\s*", "", s)  # heading level: ## X and # X are the same instruction
     s = re.sub(r"\((?:\.\./)+", "(", s)  # link depth: ](../../x) == ](x)
     s = re.sub(r"`(?:\.\./)+", "`", s)  # ditto for backticked path mentions
+    # Inline formatting is not content: promoting a lesson tends to bold its lead or backtick a
+    # value, and every such character breaks the verbatim run the wrapped-rewording fallback needs.
+    s = s.replace("`", "").replace("**", "")
     return s
 
 
@@ -63,21 +66,30 @@ def check_structure(skill_dir: Path) -> list[str]:
             if not (f.parent / clean).resolve().exists():
                 findings.append(f"broken link: {f.relative_to(skill_dir)} -> {target}  [{label}]")
 
-    # Every doc other than the entry points must be reachable by a link from some other doc.
+    # Every doc must be REACHABLE from an entry point by following links — not merely linked from
+    # somewhere. Two reference files that link only to each other both have an incoming link, and an
+    # any-incoming-link check reports no orphan for either; a run starting from SKILL.md still cannot
+    # reach them. Build the link graph and traverse it from the entry points instead.
     entry = {"SKILL.md", "GUIDELINES.md", "SMALL-CHARTS.md", "BESPOKE-SVG.md"}
-    linked: set[Path] = set()
+    graph: dict[Path, set[Path]] = {}
     for f in all_md:
+        targets: set[Path] = set()
         for _, target in LINK.findall(f.read_text()):
             clean = target.split("#")[0]
             if clean.endswith(".md"):
                 p = (f.parent / clean).resolve()
                 if p.exists():
-                    linked.add(p)
+                    targets.add(p)
+        graph[f.resolve()] = targets
+    frontier = [f.resolve() for f in all_md if f.name in entry]
+    reachable = set(frontier)
+    while frontier:
+        new = graph.get(frontier.pop(), set()) - reachable
+        reachable |= new
+        frontier.extend(new)
     for f in all_md:
-        if f.name in entry:
-            continue
-        if f.resolve() not in linked:
-            findings.append(f"orphan: {f.relative_to(skill_dir)} is not linked from any other doc")
+        if f.resolve() not in reachable:
+            findings.append(f"orphan: {f.relative_to(skill_dir)} is not reachable from an entry point")
 
     return findings
 
@@ -95,11 +107,19 @@ def check_against(ref: str, skill_dir: Path, repo_root: Path) -> list[str]:
         return [f"no markdown found under {skill_dir.relative_to(repo_root)} at {ref}"]
 
     haystack: dict[str, str] = {}
+    # A whole-file corpus per doc, of per-line-normalized text joined with single spaces. Line-level
+    # matching alone is defeated by a reflow: a paragraph that wraps differently after a move keeps
+    # every word and loses every line boundary, so each old physical line reports LOST while the
+    # content sits right there. Substring membership in the joined corpus is what "the content
+    # survived" actually means.
+    corpora: list[tuple[str, str]] = []
     for f in docs(skill_dir):
-        for line in f.read_text().split("\n"):
-            n = normalize(line)
+        lines = f.read_text().split("\n")
+        normed = [normalize(line) for line in lines]
+        for n in normed:
             if len(n) >= MIN_LINE:
                 haystack.setdefault(n, str(f.relative_to(skill_dir)))
+        corpora.append((str(f.relative_to(skill_dir)), " ".join(n for n in normed if n)))
 
     findings = []
     keys = list(haystack)
@@ -115,6 +135,8 @@ def check_against(ref: str, skill_dir: Path, repo_root: Path) -> list[str]:
             total += 1
             if n in haystack:
                 continue
+            if any(n in corpus for _, corpus in corpora):
+                continue  # reflowed, not lost — the exact content survives across line boundaries
             close = difflib.get_close_matches(n, keys, n=1, cutoff=0.60)
             if close:
                 # Present but reworded — show what changed so a human can accept or reject it.
@@ -126,6 +148,27 @@ def check_against(ref: str, skill_dir: Path, repo_root: Path) -> list[str]:
                 )
                 findings.append(
                     f"REWORDED  {path}\n    was: {line.strip()[:150]}\n    now: {haystack[close[0]]} ({sm.ratio():.2f})\n    {edits[:300]}"
+                )
+                continue
+            # Reworded ACROSS a wrap or a restructure: the old doc carried the paragraph as one
+            # physical line and its new home hard-wraps or condenses it, so no single new line is
+            # close and the line-level match above misses. Measure what fraction of the old line's
+            # characters survive, in order, as runs of >= 10 chars in some file's corpus — long
+            # enough that common English fragments don't count, short enough that a rewrite's kept
+            # phrases do. Calibrated on this skill's own split: restructured-but-retained lines score
+            # 0.46-0.94, fabricated never-existed lines 0.22-0.33, so 0.40 separates them with margin
+            # on both sides. At or above it the instruction was edited, not dropped — report where,
+            # and let a human judge the edit. Below it, LOST means lost.
+            best_frac, best_file = 0.0, ""
+            for name, corpus in corpora:
+                sm = difflib.SequenceMatcher(None, n, corpus, autojunk=False)
+                kept = sum(b.size for b in sm.get_matching_blocks() if b.size >= 10)
+                if kept / len(n) > best_frac:
+                    best_frac, best_file = kept / len(n), name
+            if best_frac >= 0.40:
+                findings.append(
+                    f"REWORDED  {path}\n    was: {line.strip()[:150]}\n    now: {best_file} "
+                    f"({best_frac:.0%} of the old line survives in >=10-char runs)"
                 )
             else:
                 findings.append(f"LOST      {path}\n    {line.strip()[:200]}")

--- a/.claude/skills/create-static-viz/SKILL.md
+++ b/.claude/skills/create-static-viz/SKILL.md
@@ -11,6 +11,10 @@ Joins the three halves of a static-viz refresh that are otherwise separate: gett
 ETL at a current vintage, drawing it in an `export://static_viz` step whose SVG a designer can
 actually pick up, and getting that SVG into the Charts file.
 
+**Model check:** the session context names the running model. On **Fable**, recommend re-running on
+**Opus** (or **Sonnet** for a mechanical re-render) before starting, and continue only on the user's
+say-so — same rule as `/create-figma-chart`.
+
 > **Paired skill — an update here may oblige an update there, and the reverse.**
 > [`/create-figma-chart`](../create-figma-chart/SKILL.md) owns everything that happens inside Figma,
 > and this skill hands off to it at Step 7. The two share a contract that lives half in each file, so

--- a/.claude/skills/create-static-viz/TEMPLATES.md
+++ b/.claude/skills/create-static-viz/TEMPLATES.md
@@ -204,9 +204,10 @@ figures now fall out of the same formula.
 > The logo constrains **width** instead: the title node is sized narrower than the content box to clear
 > it — 737.84 against 818 on the 850-wide pair, 428 against 508 on mobile.
 >
-> Everything below this note describes the **superseded nested-logo generation** and is kept only so a
-> regression stays recognizable. Its arithmetic no longer applies; the table above is the live one.
-> It has moved to [reference/SUPERSEDED-LOGO-GENERATION.md](reference/SUPERSEDED-LOGO-GENERATION.md) so a run does not load it.
+> The **superseded nested-logo generation** lives in
+> [reference/SUPERSEDED-LOGO-GENERATION.md](reference/SUPERSEDED-LOGO-GENERATION.md), kept only so a
+> regression stays recognizable — its arithmetic no longer applies; the table above is the live one.
+> Everything below THIS note is current guidance.
 
 ## Lay the plot inside the template's band, and draw the slots at the template's own sizes
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Sixth in the series, stacked on #6724. This is the first PR in the chain with evidence from an actual run rather than from measurement alone: I built the Chile liberal-democracy chart into both the DI square and Static Horizontal templates and folded back what broke.

## `solve_export.py` had two defects, and the run found both

**1. It solved for a gap of zero.** It targeted the band's own aspect, which asks the chart to fill the band edge to edge — but the guidelines want 12–16px at *each end*. On a 508×409 band that is a target ink aspect of 1.2421 where 1.3333 was needed. Adds `--gap`, default 14.

**2. The `1.4 × imFontSize` inset is symmetric and the real inset is not.**

| `imFontSize` | inset X | inset Y | what the model says |
|---|---|---|---|
| 30 | 64.1 | 29.0 | 42.0 / 42.0 |
| 21 | 70.6 | 40.8 | 29.4 / 29.4 |

The model is right for the charts it was measured on — the recorded examples come out ~44/46 at `imFontSize` 32 — and wrong by 2× horizontally on an `imType=uncaptioned` line chart that reserves a right margin for a direct entity label. Note `insetY` grew as the font *shrank*, so it isn't a simple function of the font; don't fit one from a handful of runs.

So the solve is now explicitly **two passes**, with `--declared`/`--ink` (or `--inset-x`/`--inset-y`) for the second. The inset is stable to ~2px across an aspect change at the same font, and `insetX − insetY` was **exactly** constant per chart across both passes (35.04 and 29.80) — which is what makes pass 2 land rather than being another guess. The self-test now covers both paths:

```
model inset  (docs' two exports)      err 1.2 – 1.4 px
measured     (this run's second pass) err 0.4 – 0.5 px
```

I also tried to remove the first import entirely by measuring the ink from the SVG. **It doesn't work** — text ink depends on font metrics that aren't in the file, and parsing every coordinate came out 13–33px wide of what Figma measured. Recorded in the script so nobody spends the afternoon retrying it.

## `measure_fit.js` returns the inset — and running it found two more defects

It now reports the per-axis inset and the ready pass-2 command, so the number comes out of the same call that measured it. Testing it against the page from the run caught both of these, which is the argument for testing it:

- It computed a **plausible-looking 282.95 / 264.28** inset for an already-rescaled group, against a true 64.08 / 29.04. `declared − ink` is only the inset while the import is at natural size. Now bounded at 25% of the canvas and reported as `unusable`.
- `contentW` read **508.05** against a 508px content box, because the fitted chart is itself a frame child — the measurement was drifting the very number the chart had been fitted to, and each re-fit would compound it. The chart is now excluded.

It also takes `hideNames` (regex) rather than only `hideIds`: on a fresh import you don't have the ids yet, and grapher's names for `connectors` and `datapoints__*` are stable where its node ids are not.

## Two new gotchas

- **`x`/`y` on a frame child are parent-relative while `absoluteBoundingBox` is not.** `chart.x = clone.x + contentX` sent both charts off-canvas by exactly the frame's page offset — 1590px — which reads as the import having vanished.
- **Removing a footer row leaves the footer stranded**, because every footer but one is constrained `MIN`. Deleting the `Note:` row collapsed the footer 63 → 31 but left `y` at 559, so the frame gained 48px of dead space against its own 16px margin. Nothing errors and the band bottom doesn't move, so it survives a band measurement. Re-pin *before* measuring the band.

## It corrects #6720's evidence

**The calls-per-assistant-message histogram does not measure batching.** The transcript writes one entry per tool call either way, so it reports `{1: N}` for a provably concurrent run — confirmed against the 8-call probe that measured 4.12× and scored as eight singletons. #6720 used that metric and drew the wrong conclusion; its body is already corrected, and this changes the text in `SKILL.md`.

Re-measured on interval overlap instead: two of five sessions never batched (peak 1, nothing overlapping), two barely did, and one ran at **peak 14** — where its calls averaged 35.5 s against ~10 s elsewhere. That session is now cited as evidence **for** the 4–6 ceiling rather than as evidence of never batching, which is the opposite of what the section claimed.

Also corrects "`upload_assets` returns a single-use `submitUrl`": it takes a `count` and returns that many, and the POSTs parallelize. A two-format run uploads both originals in one call.

## Not done here

- **The chart itself is only through Step 7.** The page (`20260820 Chile's democracy collapsed…`) has both formats structurally complete — texts filled, charts fitted at 14.1px and 14.2px gaps — but no labeling, palette or annotation pass yet. That's next, separately.
- **The 4–6 cadence still hasn't been measured across a whole run**, because this run stopped at Step 7 and Step 8 is where the call volume actually is.
- `SKILL.md` is 58,039 bytes, still inside the 60 KB budget, but this PR spent 1.2 KB of the remaining 2 KB. The budget will need revisiting or the Round-trip budget section will need to move to `reference/`.
