### PR TITLE
✨ Let the topic vocabulary target a custom R2 key, and regenerate it with gemini-3.7-flash

### DIFF
--- a/scripts/vocabulary/README.md
+++ b/scripts/vocabulary/README.md
@@ -41,7 +41,40 @@ This tool uses a direct LLM approach to extract searchable, domain-specific keyw
 
 - `--topic SLUG` - Topic slug(s) to extract (can be specified multiple times). If not provided, extracts for all topics.
 - `--output PATH` - Output JSON file path (optional, prints to console if not provided)
-- `--model MODEL` - Gemini model to use: `gemini-3-flash-preview` (default) or `gemini-2.5-flash-lite`
+- `--model MODEL` - Gemini model to use (default: `gemini-3.7-flash`). Any model id the API accepts works; models missing from `PRICING` just report their cost as unknown.
+- `--upload-path KEY` - Key to write inside the `owid-public` bucket (default: `topic_vocabulary.json`)
+- `--no-upload` - Generate without writing to R2
+
+## Where the vocabulary goes, and how to try one out
+
+The result is uploaded to the `owid-public` R2 bucket and served through
+`files.ourworldindata.org`, whose worker adds CORS and a 5-minute edge cache.
+The site reads the default key directly from the browser:
+
+    https://files.ourworldindata.org/topic_vocabulary.json
+
+**A plain run overwrites the vocabulary the live site uses.** To try a new one
+without doing that, upload it under a different key — the worker serves the
+whole bucket, so any key works:
+
+```bash
+python scripts/vocabulary/vocabulary.py \
+    --upload-path topic_vocabulary/my-branch.json
+```
+
+then point a staging server at it (see `TOPIC_VOCABULARY_URL` in owid-grapher's
+`settings/clientSettings.ts`):
+
+```
+TOPIC_VOCABULARY_URL=https://files.ourworldindata.org/topic_vocabulary/my-branch.json
+```
+
+Suggestions fall back to the production vocabulary if that key isn't there, so
+a half-finished experiment leaves the page looking normal.
+
+Keywords are consumed by the all-charts block's "Suggested:" line on topic
+pages. It shows the leading few terms per topic, so ordering within a topic
+matters: the terms it lists first are the ones most likely to be shown.
 
 ## How It Works
 

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -42,9 +42,14 @@ from owid.catalog import s3_utils  # ty: ignore
 from etl.config import OWID_ENV  # ty: ignore
 
 S3_BUCKET_NAME = "owid-public"
-S3_VOCABULARY_PATH = "topic_vocabulary.json"
+DEFAULT_S3_VOCABULARY_PATH = "topic_vocabulary.json"
 
-# Gemini pricing (as of Feb 2025)
+DEFAULT_MODEL = "gemini-3.7-flash"
+
+# Gemini pricing per million tokens, for the cost estimate the CLI prints.
+# Models absent from here still run; their cost is simply reported as unknown,
+# so this list going out of date can't stop a regeneration (the whole run costs
+# a couple of cents either way).
 PRICING = {
     "gemini-2.5-flash-lite": {"input": 0.015, "output": 0.06},
     "gemini-3-flash-preview": {"input": 0.0375, "output": 0.15},
@@ -116,7 +121,7 @@ def extract_chart_texts(topic_slug: str) -> tuple[str, list[str]]:
 
 
 async def extract_keywords_with_llm(
-    topic_slug: str, topic_name: str, texts: list[str], api_key: str, model_id: str = "gemini-3-flash-preview"
+    topic_slug: str, topic_name: str, texts: list[str], api_key: str, model_id: str = DEFAULT_MODEL
 ) -> dict:
     """Use Gemini to extract good keywords/phrases from chart texts.
 
@@ -239,12 +244,20 @@ async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> li
 @click.option("--output", help="Output JSON file path (optional, prints to console if not provided)")
 @click.option(
     "--model",
-    default="gemini-3-flash-preview",
-    type=click.Choice(["gemini-2.5-flash-lite", "gemini-3-flash-preview"], case_sensitive=False),
-    help="Gemini model to use (default: gemini-3-flash-preview)",
+    default=DEFAULT_MODEL,
+    help=f"Gemini model to use (default: {DEFAULT_MODEL}). Any model id the API accepts works.",
+)
+@click.option(
+    "--upload-path",
+    default=DEFAULT_S3_VOCABULARY_PATH,
+    help=(
+        f"Key to upload to inside the {S3_BUCKET_NAME} bucket (default: {DEFAULT_S3_VOCABULARY_PATH}, "
+        "the one the site reads). Use another key to try a vocabulary on a staging server without "
+        "overwriting production, e.g. --upload-path topic_vocabulary/my-branch.json"
+    ),
 )
 @click.option("--no-upload", is_flag=True, help="Skip uploading to R2 (useful for testing)")
-def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool):
+def main(topic: tuple[str, ...], output: str | None, model: str, upload_path: str, no_upload: bool):
     """Extract vocabulary for topics using LLM (simple approach).
 
     Takes all chart titles and subtitles for topics and asks an LLM to extract
@@ -273,6 +286,8 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
     click.echo("SIMPLE LLM-BASED VOCABULARY EXTRACTION")
     click.echo(f"Topics: {len(topic_slugs)}")
     click.echo(f"Model: {model}")
+    upload_target = "skipped" if no_upload else f"s3://{S3_BUCKET_NAME}/{upload_path}"
+    click.echo(f"Upload: {upload_target}")
     click.echo("=" * 80)
     click.echo()
 
@@ -285,19 +300,20 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
         sys.exit(1)
 
     # Calculate total costs
-    pricing = PRICING[model]
+    pricing = PRICING.get(model)
     total_input_tokens = sum(r["stats"]["input_tokens"] for r in results)
     total_output_tokens = sum(r["stats"]["output_tokens"] for r in results)
-    total_input_cost = (total_input_tokens / 1_000_000) * pricing["input"]
-    total_output_cost = (total_output_tokens / 1_000_000) * pricing["output"]
-    total_cost = total_input_cost + total_output_cost
+    if pricing:
+        total_input_cost = (total_input_tokens / 1_000_000) * pricing["input"]
+        total_output_cost = (total_output_tokens / 1_000_000) * pricing["output"]
+        total_cost = total_input_cost + total_output_cost
 
-    # Add cost to each result
-    for result in results:
-        stats = result["stats"]
-        input_cost = (stats["input_tokens"] / 1_000_000) * pricing["input"]
-        output_cost = (stats["output_tokens"] / 1_000_000) * pricing["output"]
-        stats["total_cost_usd"] = round(input_cost + output_cost, 6)
+        # Add cost to each result
+        for result in results:
+            stats = result["stats"]
+            input_cost = (stats["input_tokens"] / 1_000_000) * pricing["input"]
+            output_cost = (stats["output_tokens"] / 1_000_000) * pricing["output"]
+            stats["total_cost_usd"] = round(input_cost + output_cost, 6)
 
     # Output results
     click.echo()
@@ -326,9 +342,12 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
     click.echo(f"Output tokens: {total_output_tokens:,}")
     click.echo(f"Total tokens:  {total_input_tokens + total_output_tokens:,}")
     click.echo()
-    click.echo(f"Input cost:  ${total_input_cost:.6f}")
-    click.echo(f"Output cost: ${total_output_cost:.6f}")
-    click.echo(f"Total cost:  ${total_cost:.6f}")
+    if pricing:
+        click.echo(f"Input cost:  ${total_input_cost:.6f}")
+        click.echo(f"Output cost: ${total_output_cost:.6f}")
+        click.echo(f"Total cost:  ${total_cost:.6f}")
+    else:
+        click.secho(f"Cost: unknown — no pricing recorded for {model} (add it to PRICING)", fg="yellow")
 
     # Build output data
     if len(results) == 1:
@@ -343,10 +362,17 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
             tmp_path = f.name
 
         try:
-            s3_url = f"s3://{S3_BUCKET_NAME}/{S3_VOCABULARY_PATH}"
+            s3_url = f"s3://{S3_BUCKET_NAME}/{upload_path}"
             s3_utils.upload(s3_url, tmp_path, public=True)
             click.echo()
-            click.secho(f"✓ Uploaded to: https://{S3_BUCKET_NAME}.owid.io/{S3_VOCABULARY_PATH}", fg="green")
+            # files.ourworldindata.org is the worker in front of this bucket; it
+            # is what the site reads, because it adds CORS and an edge cache.
+            click.secho(f"✓ Uploaded to: https://files.ourworldindata.org/{upload_path}", fg="green")
+            if upload_path != DEFAULT_S3_VOCABULARY_PATH:
+                click.secho(
+                    "  (not the key the site reads by default — point TOPIC_VOCABULARY_URL at it to try it out)",
+                    fg="yellow",
+                )
         finally:
             os.unlink(tmp_path)
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

Companion to owid/owid-grapher#7016, which makes the all-charts block's "Suggested:" line read the OWID vocabulary instead of counting word frequencies in chart titles.

Two problems in the way of that:

1. **A plain run of the vocabulary CLI overwrote the vocabulary the live site reads** (`topic_vocabulary.json` in the `owid-public` bucket), so there was no way to try a regenerated one without replacing production.
2. **The published vocabulary was from 3 March 2026 and showed it** — Artificial Intelligence offered `NVIDIA`, `petaFLOP` and `Dataset size`, and Gender Ratio offered `Men`, `Women`, `Males`, `Females`, `Boys`, `Girls`.

So: `--upload-path` takes any key in that bucket, and I regenerated with `gemini-3.7-flash` (the previous default, `gemini-3-flash-preview`, was four Gemini releases behind).

## The regenerated vocabulary

Uploaded to a **non-default key**, so production is untouched (still 3 March, byte-identical):

```
https://files.ourworldindata.org/topic_vocabulary/gemini-3.7-flash.json
```

Try it on a staging server with `TOPIC_VOCABULARY_URL` pointed at that URL.

All 125 topics, 265,891 input / 16,500 output tokens — comparable to the March run, which cost $0.013.

### How it differs

| | March (`gemini-3-flash-preview`) | New (`gemini-3.7-flash`) |
| --- | --- | --- |
| Topics | 125 | 125 |
| Terms, median per topic | 28 | 18 |
| Multi-word terms | 54% | **73%** |
| Bare generic terms (`men`, `women`, `children`, …) | **23** | **0** |
| Terms literally present in a chart title/subtitle | 91% | 89% |
| Topics with an unchanged list | — | 0 / 125 (median overlap 36%) |

This is a different vocabulary, not a touch-up. What that does to the line the block would actually render:

| Topic | March | New |
| --- | --- | --- |
| Gender Ratio | Sex ratio, Missing women, Sex discrimination, Sex-selective abortion, Life expectancy | sex ratio, sex ratio at birth, missing women, sex-selective abortion, excess female mortality |
| Artificial Intelligence | Parameters, petaFLOP, Dataset size, FrontierMath, NVIDIA | generative AI, artificial neural network, data centers, machine learning, computer vision |
| Child Labor | children, economic activity, employment, school attendance, boys | child employment, working children, labor rights, ILO-IPEC, out-of-school children |
| Causes of Death | respiratory infections, cardiovascular disease, diabetes, drug use, meningitis | diabetes, cancer, cardiovascular diseases, tuberculosis, COVID-19 |
| Agricultural Production | Cropland, Cereals, Animal feed, Arable land, Grazing land | agricultural land, cropland, cereals, arable land, animal feed |
| Poverty | poverty line, extreme poverty, multidimensional poverty, lower-middle-income countries, basic needs | poverty line, extreme poverty, International Poverty Line, multidimensional poverty, Multidimensional Poverty Index |
| Energy | Electricity, Solar, Wind, Coal, Oil | coal, hydropower, fossil fuels, plug-in hybrids, wind energy |
| Population Growth | projections, births, deaths, children, age group | migration, world population, fertility, population projections, population density |

The clear win is that **the generic-word failure mode is gone entirely** — 23 bare generic terms became 0. That was the thing the grapher PR had to defend against with a candidate cap, so this vocabulary needs that defence much less.

**Three things that got worse or need a decision:**

- **Energy now leads with "plug-in hybrids"** in fifth place and drops Electricity/Solar; **Population Growth opens on "migration"**, which reads off-topic for it. A handful of topics are arguably worse.
- **Lists are shorter** — median 28 → 18 terms, and 28 topics now have fewer than 12 (was 16). The block ranks within the leading 12, so those topics lose slack. Not obviously bad, since what got cut was mostly the generic tail, but it's a real reduction in candidates.
- **Casing is now 90% lowercase** (was 72%). Chips render the term verbatim, so the line will read mostly lowercase. That matches the design mockup, but it is a visible change and Marwa's call.

Nothing about the prompt changed, so all of the above is the model difference alone. The prompt is still where quality comes from and is worth a separate pass — it currently tells the model to skip any term containing "emissions", "consumption", "production" and a dozen other words, which is why CO₂ & Greenhouse Gas Emissions can't suggest anything containing "emissions".

<details><summary>Details</summary>

### What changed in the code

- **`--upload-path KEY`** (new, defaults to `topic_vocabulary.json`) — the key to write inside `owid-public`. The worker in front of that bucket serves it wholesale, so any key, nested prefixes included, is immediately readable at `files.ourworldindata.org/<key>` with CORS. The success line now prints that URL rather than the raw `owid-public.owid.io` one the browser can't use, and warns when the key isn't the default.
- **`--model`** defaults to `gemini-3.7-flash` and is no longer a two-value `click.Choice`. That list was stale by four releases, and pinning it meant a newer model couldn't be tried without editing the file. `PRICING` lookups became `.get`, so an unpriced model costs only the cost estimate ("unknown") rather than a `KeyError` after the API spend has already happened.
- **README** — documents both options, where the vocabulary is served from, how to point a staging server at an alternative key, and that ordering within a topic matters because the block only shows the leading few terms.

The regenerated JSON is deliberately **not** committed here: it is data destined for R2, not for the repo.

### Verified

- `make format`, `make lint` pass.
- `--upload-path` exercised end to end against a throwaway key: uploaded, fetched back through `files.ourworldindata.org` (HTTP 200, `access-control-allow-origin: *`), then deleted. The production key was re-checked afterwards and is unchanged (103,538 bytes, 2026-03-03 19:06:02).
- Full 125-topic run completed, uploaded to the staging key, and fetched back through the worker (125 topics, CORS present).
- Comparison numbers computed from the two JSON files plus the published chart titles/subtitles for each topic, using the same ranking the block applies.

</details>
