### PR TITLE
✨ Choose topic-vocabulary terms by how much of a topic they reveal

### DIFF
--- a/scripts/vocabulary/README.md
+++ b/scripts/vocabulary/README.md
@@ -41,7 +41,40 @@ This tool uses a direct LLM approach to extract searchable, domain-specific keyw
 
 - `--topic SLUG` - Topic slug(s) to extract (can be specified multiple times). If not provided, extracts for all topics.
 - `--output PATH` - Output JSON file path (optional, prints to console if not provided)
-- `--model MODEL` - Gemini model to use: `gemini-3-flash-preview` (default) or `gemini-2.5-flash-lite`
+- `--model MODEL` - Gemini model to use (default: `gemini-3.7-flash`). Any model id the API accepts works; models missing from `PRICING` just report their cost as unknown.
+- `--upload-path KEY` - Key to write inside the `owid-public` bucket (default: `topic_vocabulary.json`)
+- `--no-upload` - Generate without writing to R2
+
+## Where the vocabulary goes, and how to try one out
+
+The result is uploaded to the `owid-public` R2 bucket and served through
+`files.ourworldindata.org`, whose worker adds CORS and a 5-minute edge cache.
+The site reads the default key directly from the browser:
+
+    https://files.ourworldindata.org/topic_vocabulary.json
+
+**A plain run overwrites the vocabulary the live site uses.** To try a new one
+without doing that, upload it under a different key — the worker serves the
+whole bucket, so any key works:
+
+```bash
+python scripts/vocabulary/vocabulary.py \
+    --upload-path topic_vocabulary/my-branch.json
+```
+
+then point a staging server at it (see `TOPIC_VOCABULARY_URL` in owid-grapher's
+`settings/clientSettings.ts`):
+
+```
+TOPIC_VOCABULARY_URL=https://files.ourworldindata.org/topic_vocabulary/my-branch.json
+```
+
+Suggestions fall back to the production vocabulary if that key isn't there, so
+a half-finished experiment leaves the page looking normal.
+
+Keywords are consumed by the all-charts block's "Suggested:" line on topic
+pages. It shows the leading few terms per topic, so ordering within a topic
+matters: the terms it lists first are the ones most likely to be shown.
 
 ## How It Works
 

--- a/scripts/vocabulary/README.md
+++ b/scripts/vocabulary/README.md
@@ -34,27 +34,32 @@ would show nothing for covers nothing and cannot be chosen at all.
 ```
 
 ### Extract for specific topics
-```bash
-# Single topic
-.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy
 
-# Multiple topics (run in parallel)
-.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --topic climate-change
+The uploaded file *replaces* the vocabulary rather than merging into it, so a
+`--topic` run can't go to the key the site reads — every topic it skipped would
+lose its suggestions. Such a run therefore has to say where its result should go
+instead: `--no-upload` to keep it local, or `--upload-path` to try it on a
+staging server.
+
+```bash
+# Single topic, kept out of production
+.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --no-upload
+
+# Multiple topics (run in parallel), published to a staging key
+.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --topic climate-change \
+    --upload-path topic_vocabulary/my-branch.json
 ```
 
 ### Save to file
 ```bash
-# Single topic - saves as single object
-.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --output vocab.json
-
-# Multiple topics - saves as dict keyed by slug
-.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --topic climate-change --output vocab.json
+# A dict keyed by topic slug, whatever the topic count
+.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --no-upload --output vocab.json
 ```
 
 ### Choose model
 ```bash
 # Use faster/cheaper model (default: gemini-3-flash-preview)
-.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --model gemini-2.5-flash-lite
+.venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --no-upload --model gemini-2.5-flash-lite
 ```
 
 ## CLI Options

--- a/scripts/vocabulary/README.md
+++ b/scripts/vocabulary/README.md
@@ -4,7 +4,27 @@ Simple LLM-based CLI to extract characteristic keywords from OWID chart titles a
 
 ## Overview
 
-This tool uses a direct LLM approach to extract searchable, domain-specific keywords from chart text. It bypasses traditional NLP processing and asks an LLM to identify terms users would actually search for.
+For each OWID topic, this builds the short line of suggested search terms shown
+under the all-charts block's search box.
+
+Selection is an optimisation, not a judgement call: **cover as much of the
+topic's chart list as a few terms can, weighting charts by how much they are
+viewed**, first term revealing the most, each next one adding the most that is
+still uncovered. The LLM only proposes candidates; arithmetic picks them.
+
+Four phases:
+
+1. Load, once: topic names, chart view counts (`analytics_chart_views`), and the
+   multi-dim view → config id map that lets a single view's popularity be found.
+2. Per topic, fetch the record set the all-charts block actually lists — plain
+   charts, multi-dim views and explorer views alike — and weight each record by
+   its views.
+3. Ask the model for candidate terms, having shown it that record set.
+4. Choose the terms covering the most of it, by greedy weighted maximum coverage.
+
+Two things follow from (4) rather than needing a second LLM pass: a term whose
+rows are already covered adds nothing and is not chosen, and a term the block
+would show nothing for covers nothing and cannot be chosen at all.
 
 ## Quick Start
 
@@ -44,6 +64,27 @@ This tool uses a direct LLM approach to extract searchable, domain-specific keyw
 - `--model MODEL` - Gemini model to use (default: `gemini-3.7-flash`). Any model id the API accepts works; models missing from `PRICING` just report their cost as unknown.
 - `--upload-path KEY` - Key to write inside the `owid-public` bucket (default: `topic_vocabulary.json`)
 - `--no-upload` - Generate without writing to R2
+- `--report PATH` - Write an HTML coverage report: per term, what it reveals and what it adds, plus the most-viewed charts nothing covers
+- `--weighting {views,uniform}` - Weight charts by views (default) or count them equally
+- `--views-column {views_7d,views_14d,views_365d}` - Which window to weight by (default `views_365d`; a vocabulary is read for weeks, so the year is steadier than the week)
+- `--max-terms N` - Most terms to publish per topic (default 8; the site shows five and drops some, so a couple of spares keep the line full)
+- `--min-marginal-share F` - Stop once the next term would reveal less than this share of a topic's views (default 0.01)
+
+## Chart view data
+
+Weighting reads `analytics_chart_views` from grapher MySQL — the only table with
+per-view granularity, which matters because multi-dim and explorer pages
+contribute one record per view and dominate some topics. It ships only in the
+private data dump, so a local database has it **empty**: either run
+`make refresh.private` in owid-grapher, or point `OWID_ENV` at a staging or
+production database (with `STAGING=1` in `.env`, it already is). A run with no
+view data **aborts** rather than silently weighting everything zero; pass
+`--weighting uniform` to generate without popularity.
+
+Plain charts and multi-dim views are weighted by their own view counts. Explorer
+views can't be: their index records carry no config id, so each is weighted by
+the average views per view of its explorer. The report says how many records fell
+back that way.
 
 ## Where the vocabulary goes, and how to try one out
 
@@ -78,9 +119,13 @@ matters: the terms it lists first are the ones most likely to be shown.
 
 ## How It Works
 
-1. **Extract chart text**: Queries database for all published charts tagged with requested topic(s)
+1. **Extract chart text**: takes the titles and subtitles of every record the
+   topic's all-charts block lists, via the search index — not from the `charts`
+   table, which omits multi-dim and explorer views entirely
 2. **Deduplication**: Removes duplicate titles/subtitles (many charts share text)
-3. **Sampling**: If >200 unique texts, randomly samples 200 for token efficiency
+3. **Sampling**: the 200 most-viewed distinct texts (not a random sample — the
+   terms proposed should describe what people actually look at, and two runs
+   should see the same input)
 4. **LLM extraction**: Feeds all text to Gemini with instructions to extract modern, searchable keywords
 5. **Parallel processing**: When multiple topics requested, processes all in parallel using asyncio
 

--- a/scripts/vocabulary/coverage_model.py
+++ b/scripts/vocabulary/coverage_model.py
@@ -392,10 +392,53 @@ class TopicSelection:
     total_weight: float = 0.0
     total_count: int = 0
     uncovered: list[tuple[str, float]] = field(default_factory=list)
+    # What the topic's own name alone would reach. A reader on the page has
+    # already applied it, so it is the share of the topic that no suggestion can
+    # narrow — and the reason a topic like Life Expectancy, half of whose traffic
+    # is one chart called "Life expectancy", cannot score highly however good its
+    # terms are. Reported rather than subtracted: the coverage number stays a
+    # plain share of the topic, and this says how much of it was reachable.
+    topic_name_share: float = 0.0
 
     @property
     def covered_weight(self) -> float:
         return self.selected[-1].cumulative_weight if self.selected else 0.0
+
+
+def offerable_candidates(candidates: list[str], topic_name: str) -> list[str]:
+    """Drop the candidates the site would refuse to show anyway.
+
+    Two rules, both copied from rankSuggestedKeywords in owid-grapher: a term the
+    topic's own name already contains narrows nothing for a reader already on
+    that page, and places are never suggested. Applying them here rather than
+    only there matters because the site drops them *after* truncating to five, so
+    a term it will discard otherwise costs a slot and shortens the line.
+
+    Deliberately no rule against a term merely resembling the topic name.
+    "Child mortality" on "Child & Infant Mortality" is that topic's single most
+    important term — it names the charts holding half its traffic — and only the
+    exact-containment test above can be trusted to remove a term that truly
+    narrows nothing.
+    """
+    lower_topic = topic_name.lower()
+    return [
+        candidate
+        for candidate in candidates
+        if candidate.lower() not in lower_topic and not _is_place_name(candidate)
+    ]
+
+
+# Region names are the site's business, and it filters them itself; here we only
+# need the obvious ones out of the way so they don't win a slot on coverage. The
+# site's check (getRegionByNameOrVariantName) knows every variant name, so this is
+# a cheap first pass rather than a replacement for it.
+_COMMON_PLACE_WORDS = frozenset(
+    {"world", "africa", "asia", "europe", "america", "oceania", "antarctica"}
+)
+
+
+def _is_place_name(term: str) -> bool:
+    return term.strip().lower() in _COMMON_PLACE_WORDS
 
 
 def select_terms_by_coverage(
@@ -421,6 +464,7 @@ def select_terms_by_coverage(
     charts. And a term the block would show nothing for covers nothing, so it
     can't be taken at all.
     """
+    candidates = offerable_candidates(candidates, universe.topic_name)
     matches = {term: match_identities(universe, term) for term in candidates}
     total_weight = universe.total_weight
     total_count = len(universe.records)
@@ -429,10 +473,12 @@ def select_terms_by_coverage(
     def weight(identities: frozenset[str]) -> float:
         return sum(weight_of.get(identity, 0.0) for identity in identities)
 
+    self_named = match_identities(universe, universe.topic_name)
     selection = TopicSelection(
         topic_name=universe.topic_name,
         total_weight=total_weight,
         total_count=total_count,
+        topic_name_share=(weight(self_named) / total_weight if total_weight else 0.0),
     )
     covered: set[str] = set()
     remaining = list(candidates)

--- a/scripts/vocabulary/coverage_model.py
+++ b/scripts/vocabulary/coverage_model.py
@@ -433,8 +433,16 @@ def _is_place_name(term: str) -> bool:
     return term.strip().lower() in _COMMON_PLACE_WORDS
 
 
-# When one term covers more than this share of a topic, it is a blunt
-# instrument: a reader clicking it is shown most of the page they are already on.
+# When one term covers more than this share of a topic — of its views *or* of its
+# charts — it is a blunt instrument: a reader clicking it is shown most of the
+# page they are already on.
+#
+# Both measures are needed. On Tuberculosis the term "tuberculosis" reaches 50 of
+# the topic's 52 charts but only 47% of its views, because the two most-viewed are
+# about causes of death generally. Judged on views alone it looked specific enough
+# to keep, and taking it made every real term — drug resistance, treatment, BCG —
+# a subset of it that added nothing, so coverage hit 100% with three blunt terms
+# and stopped.
 # Such a term is held back and used only when the sharper terms together cannot
 # reach this same share — the case for a topic whose charts are all named after
 # it, where nothing else reaches them at all.
@@ -488,7 +496,8 @@ def select_terms_by_coverage(
     blunt = {
         term
         for term, identities in matches.items()
-        if total_weight and weight(identities) / total_weight > BROAD_TERM_SHARE
+        if (total_weight and weight(identities) / total_weight > BROAD_TERM_SHARE)
+        or (total_count and len(identities) / total_count > BROAD_TERM_SHARE)
     }
     sharp = [term for term in candidates if term not in blunt]
 

--- a/scripts/vocabulary/coverage_model.py
+++ b/scripts/vocabulary/coverage_model.py
@@ -1,0 +1,520 @@
+"""What the all-charts block shows for a topic, and how terms are chosen to cover it.
+
+The suggestion line under a topic's search box should reveal as much of that
+topic's chart list as a few terms can, most-revealing first, with charts counted
+by how much they are actually viewed. That makes term selection a weighted
+maximum-coverage problem, and this module holds the three pieces it needs: the
+topic's records ("the universe"), a weight per record, and which records each
+candidate term would actually put on screen.
+
+Everything here models the *rendered* list rather than Algolia's matching, which
+is looser in every direction that matters (synonyms, typo tolerance, and `tags` /
+`availableEntities` / `slug` all being searchable). The block intersects Algolia's
+hits with its own per-row test, so that test is the binding constraint and the
+one worth reproducing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from urllib.parse import parse_qsl
+
+import httpx
+
+from etl.config import OWID_ENV  # ty: ignore
+
+# The charts index the block searches, and the public search-only credentials the
+# site ships in its own client bundle (owid-grapher commits the same pair in
+# functions/api/search/searchApi.integration.test.ts). Override to measure
+# against a staging index.
+ALGOLIA_INDEX = "explorer-views-and-charts"
+ALGOLIA_APP_ID = os.getenv("ALGOLIA_ID") or "ASCB5XMYF2"
+ALGOLIA_SEARCH_KEY = os.getenv("ALGOLIA_SEARCH_KEY") or "bafe9c4659e5657bf750a38fbee5c269"
+# Algolia's per-request maximum. Every topic fits in one request — the largest
+# (Climate Change) has ~714 records.
+ALGOLIA_HITS_PER_PAGE = 1000
+ALGOLIA_TIMEOUT_SECONDS = 30
+
+# What the block retrieves and renders. `datasetProducers` is the row's
+# "Source:" line and is matchable, which is why the universe comes from Algolia
+# directly: /api/search does not return it.
+UNIVERSE_ATTRIBUTES = [
+    "title",
+    "subtitle",
+    "datasetProducers",
+    "slug",
+    "queryParams",
+    "type",
+    "chartConfigId",
+]
+
+DEFAULT_VIEWS_COLUMN = "views_365d"
+
+
+class EmptyAnalyticsError(Exception):
+    """Raised when there is no view data to weight charts by."""
+
+
+# ---------------------------------------------------------------- text matching
+
+# Digits written as sub/superscripts in chart titles ("CO₂"), which the site
+# folds to plain digits so that typing "co2" finds them.
+_DIGIT_VARIANTS = str.maketrans("₀₁₂₃₄₅₆₇₈₉⁰¹²³⁴⁵⁶⁷⁸⁹", "01234567890123456789")
+
+
+def split_into_match_words(text: str) -> list[str]:
+    """Split text into the same words the site matches on.
+
+    A transcription of `slugify` + `splitIntoMatchWords` in owid-grapher
+    (packages/@ourworldindata/utils Util.ts, site/search/searchUtils.tsx) rather
+    than a nicer slugifier: that one strips anything outside ASCII
+    `[A-Za-z0-9_]`, so "Côte" becomes "cte", and a Python-idiomatic
+    unicode-aware version would disagree with the site on exactly the rows this
+    is meant to predict.
+    """
+    slug = re.sub(r"\s+", " ", text.translate(_DIGIT_VARIANTS).lower()).strip()
+    slug = re.sub(r"\s*\*.+\*", "", slug)
+    slug = re.sub(r"[^\w\- /]+", "", slug, flags=re.ASCII)
+    slug = re.sub(r" +", "-", slug).replace("/", "")
+    return [word for word in slug.split("-") if word]
+
+
+def record_row_texts(record: dict) -> list[str]:
+    """The texts a row actually displays: its title, subtitle and each producer.
+
+    Kept as separate strings rather than joined, because the site never satisfies
+    a query from words gathered across two of them.
+    """
+    texts = [record.get("title") or "", record.get("subtitle") or ""]
+    texts.extend(record.get("datasetProducers") or [])
+    return [text for text in texts if text]
+
+
+def record_matches_term(record: dict, term: str) -> bool:
+    """Whether the block would show this row for this term.
+
+    Every word of the term must appear in one of the row's own texts, in any
+    order, with the last word allowed to match a prefix — see
+    `textContainsAllQueryWords` in site/search/searchUtils.tsx.
+    """
+    term_words = split_into_match_words(term)
+    if not term_words:
+        return True
+    leading, last = term_words[:-1], term_words[-1]
+    for text in record_row_texts(record):
+        text_words = split_into_match_words(text)
+        if all(word in text_words for word in leading) and any(
+            word.startswith(last) for word in text_words
+        ):
+            return True
+    return False
+
+
+def record_identity(record: dict) -> str:
+    """The key the site uses to tell two rows apart: slug plus query params.
+
+    Mirrors `getChartHitIdentity`. Multi-dim and explorer views share a slug with
+    their siblings and differ only in `queryParams`, and a Featured Metric record
+    shares both with the plain record it was copied from.
+    """
+    return f"{record.get('slug') or ''}{record.get('queryParams') or ''}"
+
+
+# -------------------------------------------------------------------- universe
+
+
+async def fetch_topic_universe(
+    client: httpx.AsyncClient, topic_name: str, semaphore: asyncio.Semaphore
+) -> list[dict]:
+    """Every record the all-charts block lists for a topic.
+
+    The same facets the block's baseline query uses (see `buildChartsFacetFilters`
+    and `baseSearchState` in site/AllChartsBlock.tsx): the topic tag, and the
+    income-group exclusion that applies while no country is selected. The
+    Featured Metric exclusion is deliberately *not* applied, because the block's
+    own default list doesn't apply it either — the FM flavour of a row carries
+    the same title, subtitle and producers as its plain twin, so it matches
+    identically and keys identically.
+    """
+    async def fetch_page(page: int) -> dict:
+        async with semaphore:
+            response = await client.post(
+                f"https://{ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/{ALGOLIA_INDEX}/query",
+                headers={
+                    "X-Algolia-Application-Id": ALGOLIA_APP_ID,
+                    "X-Algolia-API-Key": ALGOLIA_SEARCH_KEY,
+                },
+                json={
+                    "query": "",
+                    "facetFilters": [
+                        [f"tags:{topic_name}"],
+                        "isIncomeGroupSpecificFM:false",
+                    ],
+                    "hitsPerPage": ALGOLIA_HITS_PER_PAGE,
+                    "page": page,
+                    "attributesToRetrieve": UNIVERSE_ATTRIBUTES,
+                },
+                timeout=ALGOLIA_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    first = await fetch_page(0)
+    hits = list(first.get("hits") or [])
+    # Most topics fit in one request; the largest (Food Supply, ~2,000 views of
+    # its explorers) need two or three.
+    pages = first.get("nbPages") or 1
+    if pages > 1:
+        for payload in await asyncio.gather(
+            *(fetch_page(page) for page in range(1, pages))
+        ):
+            hits.extend(payload.get("hits") or [])
+
+    if first.get("nbHits", 0) > len(hits):
+        raise RuntimeError(
+            f"{topic_name}: {first['nbHits']} records but only {len(hits)} fetched"
+        )
+
+    # One record per identity. Where an FM copy and its plain twin both appear,
+    # either will do: they render the same text.
+    return list({record_identity(hit): hit for hit in hits}.values())
+
+
+# --------------------------------------------------------------------- weights
+
+
+@dataclass
+class ViewAnalytics:
+    """Chart view counts, keyed the two ways records can be resolved."""
+
+    by_config_id: dict[str, int]
+    # Average views per view of an explorer or multi-dim, for records whose own
+    # view can't be identified.
+    average_by_slug: dict[str, int]
+    by_slug: dict[str, int]
+
+
+def load_view_analytics(views_column: str = DEFAULT_VIEWS_COLUMN) -> ViewAnalytics:
+    """Load chart view counts from grapher MySQL.
+
+    `analytics_chart_views` is the only table with per-view granularity:
+    `analytics_pageviews` strips query strings entirely, and
+    `analytics_popularity` has one row per chart. Restricted to the latest
+    snapshot day — the primary key allows several, and summing across them would
+    silently multiply every weight.
+    """
+    rows = OWID_ENV.read_sql(
+        f"""
+        SELECT chart_slug, view_config_id, type, {views_column} AS views
+        FROM analytics_chart_views
+        WHERE day = (SELECT MAX(day) FROM analytics_chart_views)
+        """
+    )
+    if rows.empty:
+        raise EmptyAnalyticsError(
+            "analytics_chart_views is empty, so charts cannot be weighted by how much "
+            "they are viewed.\n"
+            "  It ships only in the private data dump: run `make refresh.private` in "
+            "owid-grapher, or point OWID_ENV at a staging/production database.\n"
+            "  To generate without popularity weighting, pass --weighting uniform."
+        )
+
+    by_config_id: dict[str, int] = {}
+    by_slug: dict[str, int] = {}
+    slug_totals: dict[str, list[int]] = {}
+    for row in rows.itertuples(index=False):
+        views = int(row.views or 0)
+        if row.view_config_id:
+            by_config_id[row.view_config_id] = views
+            slug_totals.setdefault(row.chart_slug, []).append(views)
+        elif row.chart_slug:
+            by_slug[row.chart_slug] = views
+
+    average_by_slug = {
+        slug: round(sum(counts) / len(counts)) for slug, counts in slug_totals.items()
+    }
+    return ViewAnalytics(
+        by_config_id=by_config_id, average_by_slug=average_by_slug, by_slug=by_slug
+    )
+
+
+def load_mdim_view_config_ids() -> dict[tuple[str, frozenset], str]:
+    """Map a multi-dim view's (slug, dimension choices) to its chart config id.
+
+    The record's `queryParams` is those same choices, sorted and url-encoded
+    (`dimensionsToSortedQueryStr`), and analytics are keyed by the config id — so
+    this table is what connects the two. Keyed on the parsed choices rather than
+    the encoded string, which sidesteps every encoding discrepancy between
+    Python's urlencode and the browser's URLSearchParams.
+    """
+    rows = OWID_ENV.read_sql(
+        "SELECT slug, config FROM multi_dim_data_pages WHERE published = 1"
+    )
+    mapping: dict[tuple[str, frozenset], str] = {}
+    for row in rows.itertuples(index=False):
+        config = json.loads(row.config) if isinstance(row.config, str) else row.config
+        for view in config.get("views") or []:
+            dimensions = view.get("dimensions") or {}
+            config_id = view.get("fullConfigId")
+            if not config_id:
+                continue
+            mapping[(row.slug, frozenset(dimensions.items()))] = config_id
+    return mapping
+
+
+@dataclass
+class WeightedUniverse:
+    """A topic's records, each with a weight and a note on how it was resolved."""
+
+    topic_name: str
+    records: dict[str, dict]
+    weights: dict[str, float]
+    resolution: dict[str, str]  # identity -> "per-view" | "averaged" | "unmatched"
+
+    @property
+    def total_weight(self) -> float:
+        return sum(self.weights.values())
+
+    def resolution_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for how in self.resolution.values():
+            counts[how] = counts.get(how, 0) + 1
+        return counts
+
+
+def weigh_universe(
+    topic_name: str,
+    records: list[dict],
+    analytics: ViewAnalytics | None,
+    mdim_config_ids: dict[tuple[str, frozenset], str],
+) -> WeightedUniverse:
+    """Attach a view count to every record in a topic's universe.
+
+    Three resolutions, in order of preference:
+
+    - *per-view* — the record's own view count. Plain charts join on their slug;
+      multi-dim views join through their config id.
+    - *averaged* — the average views per view of that explorer or multi-dim, used
+      where a record's own view can't be identified. Explorer views always land
+      here: their records carry no config id, and `explorer_views` is keyed by a
+      slugified view id that can't be reconstructed from `queryParams`. Within
+      one explorer every view therefore weighs the same, which understates its
+      popular views and overstates its ignored ones.
+    - *unmatched* — no analytics row at all, weight zero. Usually a record
+      indexed since the last analytics snapshot.
+
+    With `analytics` omitted every record weighs 1, so coverage degrades to a
+    plain count of charts.
+    """
+    weights: dict[str, float] = {}
+    resolution: dict[str, str] = {}
+    by_identity = {record_identity(record): record for record in records}
+
+    for identity, record in by_identity.items():
+        if analytics is None:
+            weights[identity] = 1.0
+            resolution[identity] = "uniform"
+            continue
+
+        slug = record.get("slug") or ""
+        config_id = record.get("chartConfigId")
+        if not config_id and record.get("queryParams"):
+            choices = frozenset(parse_qsl(record["queryParams"].lstrip("?")))
+            config_id = mdim_config_ids.get((slug, choices))
+
+        views = analytics.by_config_id.get(config_id) if config_id else None
+        if views is None and not record.get("queryParams"):
+            views = analytics.by_slug.get(slug)
+
+        if views is not None:
+            weights[identity] = float(views)
+            resolution[identity] = "per-view"
+            continue
+
+        averaged = analytics.average_by_slug.get(slug)
+        if averaged is not None:
+            weights[identity] = float(averaged)
+            resolution[identity] = "averaged"
+        else:
+            weights[identity] = 0.0
+            resolution[identity] = "unmatched"
+
+    return WeightedUniverse(
+        topic_name=topic_name,
+        records=by_identity,
+        weights=weights,
+        resolution=resolution,
+    )
+
+
+def match_identities(universe: WeightedUniverse, term: str) -> frozenset[str]:
+    """The records the block would show for a term, within this topic."""
+    return frozenset(
+        identity
+        for identity, record in universe.records.items()
+        if record_matches_term(record, term)
+    )
+
+
+# ------------------------------------------------------------------- selection
+
+
+@dataclass
+class TermCoverage:
+    """One selected term and what it reveals."""
+
+    term: str
+    own_weight: float
+    own_count: int
+    marginal_weight: float
+    marginal_count: int
+    cumulative_weight: float
+
+    def own_share(self, total: float) -> float:
+        return self.own_weight / total if total else 0.0
+
+    def marginal_share(self, total: float) -> float:
+        return self.marginal_weight / total if total else 0.0
+
+    def cumulative_share(self, total: float) -> float:
+        return self.cumulative_weight / total if total else 0.0
+
+
+@dataclass
+class TopicSelection:
+    topic_name: str
+    selected: list[TermCoverage] = field(default_factory=list)
+    near_misses: list[TermCoverage] = field(default_factory=list)
+    total_weight: float = 0.0
+    total_count: int = 0
+    uncovered: list[tuple[str, float]] = field(default_factory=list)
+
+    @property
+    def covered_weight(self) -> float:
+        return self.selected[-1].cumulative_weight if self.selected else 0.0
+
+
+def select_terms_by_coverage(
+    universe: WeightedUniverse,
+    candidates: list[str],
+    max_terms: int,
+    min_marginal_share: float,
+) -> TopicSelection:
+    """Pick the terms that reveal the most of a topic, most-revealing first.
+
+    Greedy weighted maximum coverage: take the term covering the most, then
+    repeatedly take whichever term adds the most that is still uncovered. That is
+    the requirement stated directly — the first term has the largest coverage and
+    each next one the largest addition — and it comes with the standard
+    (1 - 1/e) approximation bound. It does *not* find the optimal set: a pair of
+    terms that between them cover everything can be missed because one of them
+    lost the first round.
+
+    Two things fall out of it that used to need a second LLM pass. A term whose
+    rows are all covered already has zero marginal weight and is never taken, so
+    near-synonyms can't stack up — the old line offering "missing women",
+    "sex-selective abortion" and "excess female mortality", three terms and two
+    charts. And a term the block would show nothing for covers nothing, so it
+    can't be taken at all.
+    """
+    matches = {term: match_identities(universe, term) for term in candidates}
+    total_weight = universe.total_weight
+    total_count = len(universe.records)
+    weight_of = universe.weights
+
+    def weight(identities: frozenset[str]) -> float:
+        return sum(weight_of.get(identity, 0.0) for identity in identities)
+
+    selection = TopicSelection(
+        topic_name=universe.topic_name,
+        total_weight=total_weight,
+        total_count=total_count,
+    )
+    covered: set[str] = set()
+    remaining = list(candidates)
+    floor = min_marginal_share * total_weight
+
+    while remaining and len(selection.selected) < max_terms:
+        scored = []
+        for index, term in enumerate(remaining):
+            new = matches[term] - covered
+            if not new:
+                continue
+            scored.append(
+                (
+                    -weight(new),  # most additional weight
+                    -len(new),  # then most additional charts
+                    -weight(matches[term]),  # then describes more of the list
+                    len(split_into_match_words(term)),  # then fewer words
+                    index,  # then the order the candidates arrived in
+                    term,
+                )
+            )
+        if not scored:
+            break
+        scored.sort()
+        best = scored[0]
+        term = best[-1]
+        new = matches[term] - covered
+        marginal = weight(new)
+
+        # A term revealing less than the floor isn't worth one of five slots on a
+        # single line. Stop without recording it here — it stays in `remaining`,
+        # so the near-miss pass below reports it (first, since it has the largest
+        # remaining gain) along with whatever else just missed out.
+        if marginal < floor and selection.selected:
+            break
+
+        selection.selected.append(
+            TermCoverage(
+                term=term,
+                own_weight=weight(matches[term]),
+                own_count=len(matches[term]),
+                marginal_weight=marginal,
+                marginal_count=len(new),
+                cumulative_weight=selection.covered_weight + marginal,
+            )
+        )
+        covered |= new
+        remaining.remove(term)
+
+    # The best few terms that didn't make it, for the same reason.
+    for _, _, _, _, _, term in sorted(
+        (
+            (
+                -weight(matches[term] - covered),
+                -len(matches[term] - covered),
+                0.0,
+                0,
+                index,
+                term,
+            )
+            for index, term in enumerate(remaining)
+            if matches[term] - covered
+        )
+    )[:3]:
+        new = matches[term] - covered
+        selection.near_misses.append(
+            TermCoverage(
+                term=term,
+                own_weight=weight(matches[term]),
+                own_count=len(matches[term]),
+                marginal_weight=weight(new),
+                marginal_count=len(new),
+                cumulative_weight=selection.covered_weight + weight(new),
+            )
+        )
+
+    selection.uncovered = sorted(
+        (
+            (universe.records[identity].get("title") or identity, weight_of[identity])
+            for identity in universe.records
+            if identity not in covered
+        ),
+        key=lambda pair: -pair[1],
+    )
+    return selection

--- a/scripts/vocabulary/coverage_model.py
+++ b/scripts/vocabulary/coverage_model.py
@@ -399,6 +399,7 @@ class TopicSelection:
     # terms are. Reported rather than subtracted: the coverage number stays a
     # plain share of the topic, and this says how much of it was reachable.
     topic_name_share: float = 0.0
+    covered: frozenset[str] = frozenset()
 
     @property
     def covered_weight(self) -> float:
@@ -406,32 +407,23 @@ class TopicSelection:
 
 
 def offerable_candidates(candidates: list[str], topic_name: str) -> list[str]:
-    """Drop the candidates the site would refuse to show anyway.
+    """Drop the candidates that could never be worth a slot: places.
 
-    Two rules, both copied from rankSuggestedKeywords in owid-grapher: a term the
-    topic's own name already contains narrows nothing for a reader already on
-    that page, and places are never suggested. Applying them here rather than
-    only there matters because the site drops them *after* truncating to five, so
-    a term it will discard otherwise costs a slot and shortens the line.
-
-    Deliberately no rule against a term merely resembling the topic name.
-    "Child mortality" on "Child & Infant Mortality" is that topic's single most
-    important term — it names the charts holding half its traffic — and only the
-    exact-containment test above can be trusted to remove a term that truly
-    narrows nothing.
+    Nothing else. A term the topic's own name contains used to be dropped here
+    too, which cost the topics whose charts are simply called after them —
+    Religion reached 39% of its traffic without being allowed to say "religious".
+    Whether a term is too blunt to suggest turns out not to be answerable from
+    its text at all: "religious" is not a substring of "Religion" and covers 81%
+    of it, while "poverty line" contains the whole of "Poverty" and covers 12%.
+    It is answerable from what the term covers, which is what
+    select_terms_by_coverage does with BROAD_TERM_SHARE.
     """
-    lower_topic = topic_name.lower()
-    return [
-        candidate
-        for candidate in candidates
-        if candidate.lower() not in lower_topic and not _is_place_name(candidate)
-    ]
+    return [candidate for candidate in candidates if not _is_place_name(candidate)]
 
 
-# Region names are the site's business, and it filters them itself; here we only
-# need the obvious ones out of the way so they don't win a slot on coverage. The
-# site's check (getRegionByNameOrVariantName) knows every variant name, so this is
-# a cheap first pass rather than a replacement for it.
+# Region names are the site's business, and it filters them itself with the
+# lookup that knows every variant name; this is a cheap first pass so an obvious
+# one can't win a slot on coverage alone.
 _COMMON_PLACE_WORDS = frozenset(
     {"world", "africa", "asia", "europe", "america", "oceania", "antarctica"}
 )
@@ -439,6 +431,23 @@ _COMMON_PLACE_WORDS = frozenset(
 
 def _is_place_name(term: str) -> bool:
     return term.strip().lower() in _COMMON_PLACE_WORDS
+
+
+# When one term covers more than this share of a topic, it is a blunt
+# instrument: a reader clicking it is shown most of the page they are already on.
+# Such a term is held back and used only when the sharper terms together cannot
+# reach this same share — the case for a topic whose charts are all named after
+# it, where nothing else reaches them at all.
+#
+# Used for both halves on purpose, so there is one number rather than two: "a
+# term covering more than half the topic is blunt, and a blunt one is worth it
+# only if the rest cannot reach half". Both halves are reported per topic, so the
+# number can be judged from output rather than taste.
+#
+# It buys a great deal. Allowed everywhere, blunt terms lift median coverage from
+# 90% to 98% but collapse fifteen topics to a single chip — Poverty's 250 charts
+# reduced to "poverty". Held back entirely, thirty topics under-cover badly.
+BROAD_TERM_SHARE = 0.5
 
 
 def select_terms_by_coverage(
@@ -474,11 +483,49 @@ def select_terms_by_coverage(
         return sum(weight_of.get(identity, 0.0) for identity in identities)
 
     self_named = match_identities(universe, universe.topic_name)
+    # Blunt terms — ones that alone reveal most of the topic — are set aside and
+    # only brought back if the rest cannot do the job. See BROAD_TERM_SHARE.
+    blunt = {
+        term
+        for term, identities in matches.items()
+        if total_weight and weight(identities) / total_weight > BROAD_TERM_SHARE
+    }
+    sharp = [term for term in candidates if term not in blunt]
+
+    selection = _greedy(
+        universe, sharp, matches, weight, max_terms, min_marginal_share
+    )
+    if (
+        blunt
+        and total_weight
+        and selection.covered_weight / total_weight <= BROAD_TERM_SHARE
+    ):
+        # The sharp terms can't reach half the topic, so its charts really are
+        # only findable by the name they share with it.
+        selection = _greedy(
+            universe, candidates, matches, weight, max_terms, min_marginal_share
+        )
+    selection.topic_name_share = (
+        weight(self_named) / total_weight if total_weight else 0.0
+    )
+    selection.uncovered = _uncovered(universe, selection, matches)
+    return selection
+
+
+def _greedy(
+    universe: WeightedUniverse,
+    candidates: list[str],
+    matches: dict[str, frozenset[str]],
+    weight,
+    max_terms: int,
+    min_marginal_share: float,
+) -> TopicSelection:
+    """One pass of greedy weighted maximum coverage over `candidates`."""
+    total_weight = universe.total_weight
     selection = TopicSelection(
         topic_name=universe.topic_name,
         total_weight=total_weight,
-        total_count=total_count,
-        topic_name_share=(weight(self_named) / total_weight if total_weight else 0.0),
+        total_count=len(universe.records),
     )
     covered: set[str] = set()
     remaining = list(candidates)
@@ -555,12 +602,24 @@ def select_terms_by_coverage(
             )
         )
 
-    selection.uncovered = sorted(
+    selection.covered = frozenset(covered)
+    return selection
+
+
+def _uncovered(
+    universe: WeightedUniverse,
+    selection: TopicSelection,
+    matches: dict[str, frozenset[str]],
+) -> list[tuple[str, float]]:
+    """The records no selected term reaches, most-viewed first."""
+    covered: set[str] = set()
+    for term in selection.selected:
+        covered |= matches.get(term.term, frozenset())
+    return sorted(
         (
-            (universe.records[identity].get("title") or identity, weight_of[identity])
+            (universe.records[identity].get("title") or identity, universe.weights[identity])
             for identity in universe.records
             if identity not in covered
         ),
         key=lambda pair: -pair[1],
     )
-    return selection

--- a/scripts/vocabulary/coverage_report.py
+++ b/scripts/vocabulary/coverage_report.py
@@ -42,6 +42,12 @@ def render_topic_table(selection: TopicSelection, universe: WeightedUniverse) ->
         f"  uncovered: {uncovered_weight / total if total else 0:.1%} of views, "
         f"{len(selection.uncovered)} records"
     )
+    if selection.topic_name_share > 0.2:
+        lines.append(
+            f"  note: the topic's own name alone reaches "
+            f"{selection.topic_name_share:.0%} of these views, which no suggestion "
+            f"can narrow — the reachable share is smaller than 100%"
+        )
     for title, weight in selection.uncovered[:5]:
         lines.append(f"      {weight:>9,.0f}  {title[:64]}")
     return "\n".join(lines)
@@ -168,6 +174,13 @@ def render_html_report(
                 f"<div class='note'>Weights: {resolution.get('per-view', 0)} records per view, "
                 f"{resolution.get('averaged', 0)} averaged over their explorer or multi-dim, "
                 f"{resolution.get('unmatched', 0)} with no view data.</div>"
+            )
+        if selection.topic_name_share > 0.2:
+            out.append(
+                f"<div class='note'>The topic's own name alone reaches "
+                f"<strong>{selection.topic_name_share:.0%}</strong> of these views. A reader here "
+                "has already applied it, so that much of the topic is not narrowable by any "
+                "suggestion and the coverage above is measured against a ceiling below 100%.</div>"
             )
         out.append(
             f"<div class='note'>Uncovered: {1 - share:.1%} of views across "

--- a/scripts/vocabulary/coverage_report.py
+++ b/scripts/vocabulary/coverage_report.py
@@ -1,0 +1,184 @@
+"""Rendering for what the term selection chose, and what it left behind.
+
+A run covers 125 topics, so the terminal gets one line per topic — enough to see
+which topics are badly covered, which is the thing worth acting on — and the full
+per-term arithmetic goes to an HTML file where it can be read.
+"""
+
+from __future__ import annotations
+
+import html
+import statistics
+from datetime import UTC, datetime
+
+from coverage_model import TopicSelection, WeightedUniverse
+
+
+def render_topic_table(selection: TopicSelection, universe: WeightedUniverse) -> str:
+    """The full per-term arithmetic for one topic, as text."""
+    total = selection.total_weight
+    resolution = universe.resolution_counts()
+    lines = [
+        f"{selection.topic_name} — {selection.total_count} records, {total:,.0f} views "
+        f"({resolution.get('per-view', 0)} weighted per view, "
+        f"{resolution.get('averaged', 0)} averaged, {resolution.get('unmatched', 0)} unmatched)",
+        f"  {'#':<3}{'term':<34}{'own':>17}{'adds':>17}{'cumulative':>12}",
+    ]
+    for index, term in enumerate(selection.selected, 1):
+        lines.append(
+            f"  {index:<3}{term.term:<34}"
+            f"{term.own_share(total):>8.1%} /{term.own_count:>6}"
+            f"{term.marginal_share(total):>8.1%} /{term.marginal_count:>6}"
+            f"{term.cumulative_share(total):>12.1%}"
+        )
+    if selection.near_misses:
+        misses = ", ".join(
+            f"{miss.term!r} +{miss.marginal_share(total):.1%}"
+            for miss in selection.near_misses[:3]
+        )
+        lines.append(f"  not taken: {misses}")
+    uncovered_weight = total - selection.covered_weight
+    lines.append(
+        f"  uncovered: {uncovered_weight / total if total else 0:.1%} of views, "
+        f"{len(selection.uncovered)} records"
+    )
+    for title, weight in selection.uncovered[:5]:
+        lines.append(f"      {weight:>9,.0f}  {title[:64]}")
+    return "\n".join(lines)
+
+
+def render_run_summary(selections: list[TopicSelection]) -> str:
+    """One line per topic, worst-covered first — that is what needs attention."""
+    if not selections:
+        return "no topics selected"
+    rows = sorted(
+        selections,
+        key=lambda s: (s.covered_weight / s.total_weight) if s.total_weight else 0.0,
+    )
+    lines = [f"  {'topic':<38}{'terms':>6}{'views covered':>15}{'records':>10}"]
+    for selection in rows:
+        share = (
+            selection.covered_weight / selection.total_weight
+            if selection.total_weight
+            else 0.0
+        )
+        covered_records = selection.total_count - len(selection.uncovered)
+        lines.append(
+            f"  {selection.topic_name[:36]:<38}{len(selection.selected):>6}"
+            f"{share:>14.1%} {covered_records:>6}/{selection.total_count:<6}"
+        )
+    shares = [
+        (s.covered_weight / s.total_weight) if s.total_weight else 0.0
+        for s in selections
+    ]
+    thin = sum(1 for share in shares if share < 0.35)
+    lines.append(
+        f"  ── median {statistics.median(shares):.1%} of views covered; "
+        f"{thin} topics below 35%; "
+        f"{sum(1 for s in selections if len(s.selected) <= 1)} topics with one term or none"
+    )
+    return "\n".join(lines)
+
+
+_CSS = """
+body{margin:0;background:#fff;color:#1a1a1a;font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
+.wrap{max-width:1040px;margin:0 auto;padding:40px 24px 80px}
+h1{font-family:Georgia,serif;font-size:30px;color:#002147;margin:0 0 6px}
+.meta{color:#6e6e6e;font-size:13.5px;margin-bottom:28px}
+details{border:1px solid #e3e3e3;border-radius:6px;margin:10px 0;background:#fff}
+details[open]{box-shadow:0 1px 3px rgba(0,0,0,.05)}
+summary{cursor:pointer;padding:11px 16px;font-weight:600;color:#002147;display:flex;gap:14px;align-items:baseline}
+summary .share{font-family:Georgia,serif;font-size:19px;min-width:74px}
+summary .sub{font-weight:400;color:#6e6e6e;font-size:13px}
+.body{padding:4px 16px 16px}
+table{border-collapse:collapse;width:100%;font-size:14px;margin:8px 0 14px}
+th,td{text-align:left;padding:6px 9px;border-bottom:1px solid #eee}
+th{background:#f7f8f9;font-size:11.5px;text-transform:uppercase;letter-spacing:.05em;color:#6e6e6e}
+td.n{text-align:right;font-variant-numeric:tabular-nums}
+.term{font-weight:600}
+.bar{background:#e8eef5;height:7px;border-radius:4px;overflow:hidden;min-width:80px}
+.bar span{display:block;height:100%;background:#1d3d63}
+.note{font-size:13px;color:#4a4a4a;margin:6px 0}
+.uncov td{color:#4a4a4a}
+.thin summary{background:#fdf6ec}
+"""
+
+
+def render_html_report(
+    selections: list[TopicSelection],
+    universes: dict[str, WeightedUniverse],
+    weighting: str,
+    views_column: str,
+) -> str:
+    """One collapsible section per topic, worst-covered first."""
+    rows = sorted(
+        selections,
+        key=lambda s: (s.covered_weight / s.total_weight) if s.total_weight else 0.0,
+    )
+    out = [
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>",
+        "<meta name='viewport' content='width=device-width, initial-scale=1'>",
+        "<title>Topic vocabulary coverage</title>",
+        f"<style>{_CSS}</style></head><body><div class='wrap'>",
+        "<h1>Topic vocabulary coverage</h1>",
+        f"<div class='meta'>{len(selections)} topics · weighting <code>{html.escape(weighting)}</code>"
+        f" on <code>{html.escape(views_column)}</code> · generated "
+        f"{datetime.now(UTC).strftime('%Y-%m-%d %H:%M UTC')}<br>"
+        "Each term's <em>own</em> coverage is everything it reveals; <em>adds</em> is what it "
+        "reveals that the terms above it did not. Sorted worst-covered first.</div>",
+    ]
+
+    for selection in rows:
+        total = selection.total_weight
+        share = selection.covered_weight / total if total else 0.0
+        universe = universes.get(selection.topic_name)
+        resolution = universe.resolution_counts() if universe else {}
+        thin = " class='thin'" if share < 0.35 else ""
+        out.append(f"<details{thin}><summary><span class='share'>{share:.0%}</span>")
+        out.append(
+            f"<span>{html.escape(selection.topic_name)}</span>"
+            f"<span class='sub'>{len(selection.selected)} terms · "
+            f"{selection.total_count} records · {total:,.0f} views</span></summary>"
+        )
+        out.append("<div class='body'>")
+        out.append(
+            "<table><tr><th>#</th><th>term</th><th class='n'>own</th>"
+            "<th class='n'>records</th><th class='n'>adds</th>"
+            "<th class='n'>cumulative</th><th></th></tr>"
+        )
+        for index, term in enumerate(selection.selected, 1):
+            out.append(
+                f"<tr><td class='n'>{index}</td><td class='term'>{html.escape(term.term)}</td>"
+                f"<td class='n'>{term.own_share(total):.1%}</td>"
+                f"<td class='n'>{term.own_count}</td>"
+                f"<td class='n'>{term.marginal_share(total):.1%}</td>"
+                f"<td class='n'>{term.cumulative_share(total):.1%}</td>"
+                f"<td><div class='bar'><span style='width:{min(100, term.cumulative_share(total) * 100):.1f}%'></span></div></td></tr>"
+            )
+        out.append("</table>")
+
+        if selection.near_misses:
+            misses = ", ".join(
+                f"<code>{html.escape(miss.term)}</code> +{miss.marginal_share(total):.1%}"
+                for miss in selection.near_misses[:3]
+            )
+            out.append(f"<div class='note'>Not taken: {misses}</div>")
+        if resolution:
+            out.append(
+                f"<div class='note'>Weights: {resolution.get('per-view', 0)} records per view, "
+                f"{resolution.get('averaged', 0)} averaged over their explorer or multi-dim, "
+                f"{resolution.get('unmatched', 0)} with no view data.</div>"
+            )
+        out.append(
+            f"<div class='note'>Uncovered: {1 - share:.1%} of views across "
+            f"{len(selection.uncovered)} records — the most-viewed of them:</div>"
+        )
+        out.append("<table class='uncov'><tr><th class='n'>views</th><th>chart</th></tr>")
+        for title, weight in selection.uncovered[:15]:
+            out.append(
+                f"<tr><td class='n'>{weight:,.0f}</td><td>{html.escape(title)}</td></tr>"
+            )
+        out.append("</table></div></details>")
+
+    out.append("</div></body></html>")
+    return "\n".join(out)

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -33,6 +33,7 @@ from pathlib import Path
 import click
 from dotenv import load_dotenv  # ty: ignore
 from google import genai  # ty: ignore
+from google.genai import errors as genai_errors  # ty: ignore
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -45,6 +46,13 @@ S3_BUCKET_NAME = "owid-public"
 DEFAULT_S3_VOCABULARY_PATH = "topic_vocabulary.json"
 
 DEFAULT_MODEL = "gemini-3.7-flash"
+
+# A whole-vocabulary run fires one request per topic at once, which draws the
+# occasional 503/429 out of the API. Those are transient, but a topic that
+# gives up is a topic missing from the upload, so retry each one a few times
+# before letting it fail.
+LLM_MAX_ATTEMPTS = 4
+LLM_RETRY_BACKOFF_SECONDS = 4
 
 # Gemini pricing per million tokens, for the cost estimate the CLI prints.
 # Models absent from here still run; their cost is simply reported as unknown,
@@ -67,6 +75,7 @@ def get_all_topic_slugs() -> list[str]:
         JOIN chart_tags ct ON t.id = ct.tagId
         JOIN charts c ON ct.chartId = c.id
         WHERE c.publishedAt IS NOT NULL
+          AND t.slug IS NOT NULL
         ORDER BY t.slug
     """
     df = OWID_ENV.read_sql(query)
@@ -132,29 +141,73 @@ async def extract_keywords_with_llm(
     # Combine all texts
     combined_text = "\n".join(texts)
 
-    prompt = f"""Extract search keywords for the topic "{topic_name}" from these chart titles and subtitles:
+    prompt = f"""Below are the titles and subtitles of every chart Our World in Data
+publishes on the topic "{topic_name}":
 
 {combined_text}
 
-Rules:
-1. Extract ONLY modern, currently-relevant terms for "{topic_name}"
-2. Keep: specific technologies, energy sources, or concepts people search for TODAY
-   - Good: "solar panels", "fossil fuels", "coal", "wind turbines", "nuclear power"
-   - Bad: "muscle energy", "firewood", "water engines" (historical, not searchable)
-3. Remove generic words from phrases:
-   - "oil prices" → "oil"
-   - "energy consumption" → skip (both words generic)
-4. Skip ALL terms containing: consumption, production, prices, investment, trade, access, growth, change, demand, supply, emissions, generation, reserves, intensity, transition, costs, spending
-5. Skip measurements: percentage, per capita, share, rate, level, annual, total, average
-6. Skip historical/obsolete terms unless still relevant today
+Give me search terms for this topic. They are offered to a reader on the topic's
+page, under a search box that filters exactly the charts listed above, as a short
+line of suggestions: "Suggested: term, term, term…". Only the first few are ever
+shown, so put the ones you would most want a reader to see first.
 
-Output JSON (up to 30 terms, but fewer is fine if not enough relevant ones):
+What makes this list good is that each term takes the reader somewhere *different*.
+
+1. Cover the range of what these charts are about. Read the whole list above and
+   work out which distinct subjects it spans, then give at least one term for
+   each. A topic's charts usually cover several: charts about sex ratios AND
+   about unemployment AND about mental health all belong to "Gender Ratio", so a
+   list that only describes the sex-ratio charts has missed most of the topic.
+2. One term per subject. Do not give near-synonyms or variations on the same
+   phrase — they land the reader on the same charts and waste the line. Pick the
+   single most natural form and move on.
+   - Bad: "sex ratio", "sex ratio at birth", "sex ratio by age", "sex ratio at age 5"
+     (one subject, four terms)
+   - Bad: "missing women", "sex-selective abortion", "excess female mortality"
+     (all three lead to the same two charts)
+   - Good: "sex ratio", "missing women", "life expectancy", "unemployment", "judiciary"
+     (five terms, five different parts of the chart list)
+3. Order the list so that each term adds something the ones before it did not.
+4. Terms should be things a reader would plausibly type: specific subjects,
+   technologies, diseases, materials, policies, groups.
+5. Skip anything too broad to narrow the list down: a bare "men", "women",
+   "children", "countries", "population", or the topic's own name.
+6. Never name a place. No countries, regions, continents or income groups —
+   not "United States", "Ukraine", "China", "low-income countries". The charts
+   above mention them constantly and they are searched for separately.
+7. Skip measurement and units language: percentage, per capita, share, rate,
+   level, annual, total, average, "GDP per capita", and terms that are only a
+   generic process word, such as "energy consumption" or "oil prices" (prefer
+   "oil"). "GDP" on its own is only a term for a topic that is actually about
+   GDP.
+8. Skip historical or obsolete terms unless they are still what people search for.
+
+Output JSON (up to 30 terms; far fewer is right when the topic is narrow —
+never pad the list with variations to reach a number):
 {{
   "keywords": ["term1", "term2", ...]
 }}"""
 
     try:
-        response = await client.aio.models.generate_content(model=model_id, contents=prompt)
+        response = None
+        for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
+            try:
+                response = await client.aio.models.generate_content(model=model_id, contents=prompt)
+                break
+            except (genai_errors.ServerError, genai_errors.ClientError) as e:
+                # 429 (rate limited) and 5xx are worth another go; anything else
+                # (a bad model id, a rejected prompt) will fail again identically.
+                retriable = getattr(e, "code", None) == 429 or isinstance(e, genai_errors.ServerError)
+                if not retriable or attempt == LLM_MAX_ATTEMPTS:
+                    raise
+                delay = LLM_RETRY_BACKOFF_SECONDS * attempt
+                click.secho(
+                    f"  {topic_name}: {getattr(e, 'code', '?')} from the API, retrying in {delay}s "
+                    f"(attempt {attempt}/{LLM_MAX_ATTEMPTS - 1})",
+                    fg="yellow",
+                )
+                await asyncio.sleep(delay)
+        assert response is not None
         result_text = response.text.strip()
 
         # Extract token counts
@@ -195,12 +248,13 @@ Output JSON (up to 30 terms, but fewer is fine if not enough relevant ones):
         raise RuntimeError(f"LLM extraction failed for {topic_name}: {e}")
 
 
-async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> list[dict]:
+async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> tuple[list[dict], list[str]]:
     """Process multiple topics in parallel using asyncio.gather.
 
-    Returns: list of results (one per topic)
+    Returns: (results, slugs that failed)
     """
     # Extract chart texts for all topics first
+    failed: list[str] = []
     topic_data = []
     for topic_slug in topic_slugs:
         try:
@@ -209,9 +263,10 @@ async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> li
             click.secho(f"✓ {topic_name}: Found {len(texts)} texts", fg="green")
         except ValueError as e:
             click.secho(f"✗ {topic_slug}: {e}", fg="red")
+            failed.append(topic_slug)
 
     if not topic_data:
-        return []
+        return [], failed
 
     # Extract keywords for all topics in parallel
     click.echo(f"\nExtracting keywords using LLM for {len(topic_data)} topics in parallel...")
@@ -228,11 +283,12 @@ async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> li
         if isinstance(result, Exception):
             topic_slug = topic_data[i][0]
             click.secho(f"✗ {topic_slug}: {result}", fg="red")
+            failed.append(topic_slug)
         else:
             final_results.append(result)
             click.secho(f"✓ {result['topic_name']}: Extracted {len(result['keywords'])} keywords", fg="green")
 
-    return final_results
+    return final_results, failed
 
 
 @click.command()
@@ -293,7 +349,7 @@ def main(topic: tuple[str, ...], output: str | None, model: str, upload_path: st
 
     # Extract chart texts and process with LLM
     click.echo("Extracting chart titles and subtitles from database...")
-    results = asyncio.run(process_topics(topic_slugs, api_key, model))
+    results, failed_slugs = asyncio.run(process_topics(topic_slugs, api_key, model))
 
     if not results:
         click.secho("\n✗ No results generated", fg="red")
@@ -354,6 +410,24 @@ def main(topic: tuple[str, ...], output: str | None, model: str, upload_path: st
         output_data = results[0]
     else:
         output_data = {r["topic_slug"]: r for r in results}
+
+    # Refuse to publish a vocabulary that is missing topics. A run fans out one
+    # request per topic, so a transient API failure used to mean those topics
+    # quietly vanished from the file — and uploading that over a complete
+    # vocabulary loses their suggestions until someone notices. Keep the result
+    # (--output still writes it) but make publishing it a deliberate choice.
+    if failed_slugs and not no_upload:
+        click.echo()
+        click.secho(
+            f"✗ {len(failed_slugs)} of {len(topic_slugs)} topics failed: {', '.join(failed_slugs)}",
+            fg="red",
+        )
+        click.secho(
+            "  Not uploading a partial vocabulary over a complete one. Re-run (optionally with "
+            f"{' '.join('--topic ' + s for s in failed_slugs)}) or pass --no-upload to keep the partial result.",
+            fg="red",
+        )
+        sys.exit(1)
 
     # Upload to R2
     if not no_upload:

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -208,10 +208,16 @@ What makes this list good is that each term takes the reader somewhere *differen
    call their subject is the term readers want, even when it repeats the topic's
    name almost exactly. On "Child & Infant Mortality", whose biggest charts are
    titled "Child mortality rate", give "child mortality". On "Electricity Mix",
-   give "electricity production". Offer them first. Don't worry about a term
-   being too close to the topic's name — anything that genuinely narrows nothing
-   is dropped afterwards, so the cost of including it is zero and the cost of
-   leaving it out is the topic's most important term.
+   give "electricity production". Offer them first.
+
+   This includes the topic's own name, and the bare root of it. On "Religion",
+   "religion" and "religious" are allowed and are probably the best first
+   suggestions, because a third of that topic's traffic is one chart called
+   "Share of the population who are religious" and nothing narrower reaches it.
+   Include the short form as well as the compounds: give "religious" as well as
+   "religious affiliation", "mortality" as well as "child mortality". The short
+   one brings up everything the long one does and more, and if it turns out to
+   add nothing it is dropped, so it costs nothing to offer.
 7. Skip anything too broad to narrow the list down: a bare "men", "women",
    "children", "countries", "population".
 8. Never name a place. No countries, regions, continents or income groups —

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -42,9 +42,14 @@ from owid.catalog import s3_utils  # ty: ignore
 from etl.config import OWID_ENV  # ty: ignore
 
 S3_BUCKET_NAME = "owid-public"
-S3_VOCABULARY_PATH = "topic_vocabulary.json"
+DEFAULT_S3_VOCABULARY_PATH = "topic_vocabulary.json"
 
-# Gemini pricing (as of Feb 2025)
+DEFAULT_MODEL = "gemini-3.7-flash"
+
+# Gemini pricing per million tokens, for the cost estimate the CLI prints.
+# Models absent from here still run; their cost is simply reported as unknown,
+# so this list going out of date can't stop a regeneration (the whole run costs
+# a couple of cents either way).
 PRICING = {
     "gemini-2.5-flash-lite": {"input": 0.015, "output": 0.06},
     "gemini-3-flash-preview": {"input": 0.0375, "output": 0.15},
@@ -116,7 +121,7 @@ def extract_chart_texts(topic_slug: str) -> tuple[str, list[str]]:
 
 
 async def extract_keywords_with_llm(
-    topic_slug: str, topic_name: str, texts: list[str], api_key: str, model_id: str = "gemini-3-flash-preview"
+    topic_slug: str, topic_name: str, texts: list[str], api_key: str, model_id: str = DEFAULT_MODEL
 ) -> dict:
     """Use Gemini to extract good keywords/phrases from chart texts.
 
@@ -239,12 +244,20 @@ async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> li
 @click.option("--output", help="Output JSON file path (optional, prints to console if not provided)")
 @click.option(
     "--model",
-    default="gemini-3-flash-preview",
-    type=click.Choice(["gemini-2.5-flash-lite", "gemini-3-flash-preview"], case_sensitive=False),
-    help="Gemini model to use (default: gemini-3-flash-preview)",
+    default=DEFAULT_MODEL,
+    help=f"Gemini model to use (default: {DEFAULT_MODEL}). Any model id the API accepts works.",
+)
+@click.option(
+    "--upload-path",
+    default=DEFAULT_S3_VOCABULARY_PATH,
+    help=(
+        f"Key to upload to inside the {S3_BUCKET_NAME} bucket (default: {DEFAULT_S3_VOCABULARY_PATH}, "
+        "the one the site reads). Use another key to try a vocabulary on a staging server without "
+        "overwriting production, e.g. --upload-path topic_vocabulary/my-branch.json"
+    ),
 )
 @click.option("--no-upload", is_flag=True, help="Skip uploading to R2 (useful for testing)")
-def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool):
+def main(topic: tuple[str, ...], output: str | None, model: str, upload_path: str, no_upload: bool):
     """Extract vocabulary for topics using LLM (simple approach).
 
     Takes all chart titles and subtitles for topics and asks an LLM to extract
@@ -273,6 +286,8 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
     click.echo("SIMPLE LLM-BASED VOCABULARY EXTRACTION")
     click.echo(f"Topics: {len(topic_slugs)}")
     click.echo(f"Model: {model}")
+    upload_target = "skipped" if no_upload else f"s3://{S3_BUCKET_NAME}/{upload_path}"
+    click.echo(f"Upload: {upload_target}")
     click.echo("=" * 80)
     click.echo()
 
@@ -285,19 +300,20 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
         sys.exit(1)
 
     # Calculate total costs
-    pricing = PRICING[model]
+    pricing = PRICING.get(model)
     total_input_tokens = sum(r["stats"]["input_tokens"] for r in results)
     total_output_tokens = sum(r["stats"]["output_tokens"] for r in results)
-    total_input_cost = (total_input_tokens / 1_000_000) * pricing["input"]
-    total_output_cost = (total_output_tokens / 1_000_000) * pricing["output"]
-    total_cost = total_input_cost + total_output_cost
+    if pricing:
+        total_input_cost = (total_input_tokens / 1_000_000) * pricing["input"]
+        total_output_cost = (total_output_tokens / 1_000_000) * pricing["output"]
+        total_cost = total_input_cost + total_output_cost
 
-    # Add cost to each result
-    for result in results:
-        stats = result["stats"]
-        input_cost = (stats["input_tokens"] / 1_000_000) * pricing["input"]
-        output_cost = (stats["output_tokens"] / 1_000_000) * pricing["output"]
-        stats["total_cost_usd"] = round(input_cost + output_cost, 6)
+        # Add cost to each result
+        for result in results:
+            stats = result["stats"]
+            input_cost = (stats["input_tokens"] / 1_000_000) * pricing["input"]
+            output_cost = (stats["output_tokens"] / 1_000_000) * pricing["output"]
+            stats["total_cost_usd"] = round(input_cost + output_cost, 6)
 
     # Output results
     click.echo()
@@ -326,9 +342,12 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
     click.echo(f"Output tokens: {total_output_tokens:,}")
     click.echo(f"Total tokens:  {total_input_tokens + total_output_tokens:,}")
     click.echo()
-    click.echo(f"Input cost:  ${total_input_cost:.6f}")
-    click.echo(f"Output cost: ${total_output_cost:.6f}")
-    click.echo(f"Total cost:  ${total_cost:.6f}")
+    if pricing:
+        click.echo(f"Input cost:  ${total_input_cost:.6f}")
+        click.echo(f"Output cost: ${total_output_cost:.6f}")
+        click.echo(f"Total cost:  ${total_cost:.6f}")
+    else:
+        click.secho(f"Cost: unknown — no pricing recorded for {model} (add it to PRICING)", fg="yellow")
 
     # Build output data
     if len(results) == 1:
@@ -343,10 +362,17 @@ def main(topic: tuple[str, ...], output: str | None, model: str, no_upload: bool
             tmp_path = f.name
 
         try:
-            s3_url = f"s3://{S3_BUCKET_NAME}/{S3_VOCABULARY_PATH}"
+            s3_url = f"s3://{S3_BUCKET_NAME}/{upload_path}"
             s3_utils.upload(s3_url, tmp_path, public=True)
             click.echo()
-            click.secho(f"✓ Uploaded to: https://{S3_BUCKET_NAME}.owid.io/{S3_VOCABULARY_PATH}", fg="green")
+            # files.ourworldindata.org is the worker in front of this bucket; it
+            # is what the site reads, because it adds CORS and an edge cache.
+            click.secho(f"✓ Uploaded to: https://files.ourworldindata.org/{upload_path}", fg="green")
+            if upload_path != DEFAULT_S3_VOCABULARY_PATH:
+                click.secho(
+                    "  (not the key the site reads by default — point TOPIC_VOCABULARY_URL at it to try it out)",
+                    fg="yellow",
+                )
         finally:
             os.unlink(tmp_path)
 

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -198,57 +198,46 @@ What makes this list good is that each term takes the reader somewhere *differen
    about unemployment AND about mental health all belong to "Gender Ratio", so a
    list that only describes the sex-ratio charts has missed most of the topic.
 2. One term per subject. Do not give near-synonyms or variations on the same
-   phrase — they land the reader on the same charts and waste the line. Pick the
-   single most natural form and move on.
-   - Bad: "sex ratio", "sex ratio at birth", "sex ratio by age", "sex ratio at age 5"
-     (one subject, four terms)
-   - Bad: "missing women", "sex-selective abortion", "excess female mortality"
-     (all three lead to the same two charts)
+   phrase — they land the reader on the same charts and waste the line.
+   - Bad: "sex ratio", "sex ratio at birth", "sex ratio by age" (one subject, three terms)
    - Good: "sex ratio", "missing women", "life expectancy", "unemployment", "judiciary"
      (five terms, five different parts of the chart list)
 3. Order the list so that each term adds something the ones before it did not.
-4. Terms should be things a reader would plausibly type: specific subjects,
-   technologies, diseases, materials, policies, groups.
-5. Prefer the shortest form of a term that still names its subject. A reader
-   clicking "sex ratio" is shown every chart about it; "sex ratio at birth"
-   hides most of them for no gain. Give the broad form, not the specific one.
-6. Words from the topic's own name are not just allowed, they are usually
-   required. Look at the most-viewed charts at the top of the list: whatever they
-   call their subject is the term readers want, even when it repeats the topic's
-   name almost exactly. On "Child & Infant Mortality", whose biggest charts are
-   titled "Child mortality rate", give "child mortality". On "Electricity Mix",
-   give "electricity production". Offer them first.
+4. Give the shortest form that still names the subject. A reader clicking "sex
+   ratio" is shown every chart about it; "sex ratio at birth" hides most of them
+   for no gain.
+5. Every term must name **what a chart is about** — its subject. That is the
+   whole test, and everything below follows from it rather than being a separate
+   rule to remember:
+   - Not how a number is expressed. A measurement's shape is not a subject, and
+     a reader looking for one is not looking for charts. Prefer "oil" to "oil
+     prices", "electricity" to "electricity consumption". Never on its own, and
+     never as the head of a phrase: per capita, GDP per capita, share, rate,
+     death rate, total, annual, average, level, index, projections, reported,
+     confirmed, vital registration. (This list is spelled out because it is the
+     rule most often broken: asked only for the principle, the model offered
+     "gdp per capita" as the first suggestion on Poverty.)
+   - Not a place. Countries, regions and income groups say *who* rather than
+     *what*; these charts mention them constantly and readers search for them
+     separately.
+   - Not a word that was only ever true of the past, unless people still search
+     for it.
+   Say the term out loud as a thing a reader wants to see charts of. If that
+   doesn't work — "annual", "vital registration", "reported" — leave it out.
 
-   This includes the topic's own name, and the bare root of it. On "Religion",
-   "religion" and "religious" are allowed and are probably the best first
-   suggestions, because a third of that topic's traffic is one chart called
-   "Share of the population who are religious" and nothing narrower reaches it.
-   Include the short form as well as the compounds: give "religious" as well as
-   "religious affiliation", "mortality" as well as "child mortality". The short
-   one brings up everything the long one does and more, and if it turns out to
-   add nothing it is dropped, so it costs nothing to offer.
-7. Skip a bare "men", "women", "children", "countries" or "population" — each
-   is too broad to narrow anything. This applies to the word alone, not to
-   compounds built from it: on Gender Ratio, "female population" names the chart
-   "Share of the population that is female", which is a fifth of that topic's
-   traffic, and skipping it leaves that chart unreachable. If a big chart's
-   subject can only be said with one of these words, say it with two.
-8. Never name a place. No countries, regions, continents or income groups —
-   not "United States", "Ukraine", "China", "low-income countries". The charts
-   above mention them constantly and they are searched for separately.
-9. Skip measurement and units language: percentage, per capita, share, rate,
-   level, annual, total, average, "GDP per capita", and terms that are only a
-   generic process word, such as "energy consumption" or "oil prices" (prefer
-   "oil"). "GDP" on its own is only a term for a topic that is actually about
-   GDP.
-10. Skip historical or obsolete terms unless they are still what people search for.
+Do not worry about whether a term is too broad, or too close to the topic's own
+name. That is measured afterwards against the chart list, far more reliably than
+either of us can guess: a term that turns out to reveal most of the topic is set
+aside unless nothing narrower reaches those charts. So offer the obvious central
+terms — "child mortality" on Child & Infant Mortality, "religious" on Religion,
+"female population" on Gender Ratio — including the topic's own name and the bare
+root of it. Withholding them is how a topic ends up with no way to reach the very
+charts it exists for; offering one that turns out too blunt costs nothing.
 
-Give a generous list — the more real candidates you offer, the better the final
-selection can be. Terms are scored by how many of the charts above they actually
-bring up, so favour the words those titles really use. Only a handful are shown to the reader, and they are chosen
-from your list by measuring how much of the chart list above each one actually
-brings up, so a term that is right but not obvious costs nothing to include and
-a term that duplicates another costs nothing to leave out.
+Give a generous list — only a handful are ever shown, and they are picked from
+yours by measuring how much of the chart list above each one actually brings up.
+So favour the words those titles really use, and include a term that is right but
+not obvious: it costs nothing if it loses, and it is the only way it can win.
 
 Output JSON (up to 40 terms; far fewer is right when the topic is narrow —
 never pad the list with variations to reach a number):

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -34,6 +34,7 @@ import click
 import httpx
 from dotenv import load_dotenv  # ty: ignore
 from google import genai  # ty: ignore
+from google.genai import types as genai_types  # ty: ignore
 from google.genai import errors as genai_errors  # ty: ignore
 
 # Add parent directory to path for imports
@@ -64,6 +65,14 @@ S3_BUCKET_NAME = "owid-public"
 DEFAULT_S3_VOCABULARY_PATH = "topic_vocabulary.json"
 
 DEFAULT_MODEL = "gemini-3.7-flash"
+
+# Ask for the same candidates every time. Left at the model's defaults, two runs
+# of identical code disagreed on almost every topic — Gender Ratio came back
+# covering 30% of its traffic in one run and 79% in the next — which makes a
+# prompt improvement indistinguishable from luck, and this prompt has been
+# iterated on a lot. Deterministic sampling doesn't make the candidates better,
+# it makes a change in them attributable.
+LLM_SAMPLING = {"temperature": 0.0, "seed": 1}
 
 # A whole-vocabulary run fires one request per topic at once, which draws the
 # occasional 503/429 out of the API. Those are transient, but a topic that
@@ -218,8 +227,12 @@ What makes this list good is that each term takes the reader somewhere *differen
    "religious affiliation", "mortality" as well as "child mortality". The short
    one brings up everything the long one does and more, and if it turns out to
    add nothing it is dropped, so it costs nothing to offer.
-7. Skip anything too broad to narrow the list down: a bare "men", "women",
-   "children", "countries", "population".
+7. Skip a bare "men", "women", "children", "countries" or "population" — each
+   is too broad to narrow anything. This applies to the word alone, not to
+   compounds built from it: on Gender Ratio, "female population" names the chart
+   "Share of the population that is female", which is a fifth of that topic's
+   traffic, and skipping it leaves that chart unreachable. If a big chart's
+   subject can only be said with one of these words, say it with two.
 8. Never name a place. No countries, regions, continents or income groups —
    not "United States", "Ukraine", "China", "low-income countries". The charts
    above mention them constantly and they are searched for separately.
@@ -247,7 +260,11 @@ never pad the list with variations to reach a number):
         response = None
         for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
             try:
-                response = await client.aio.models.generate_content(model=model_id, contents=prompt)
+                response = await client.aio.models.generate_content(
+                    model=model_id,
+                    contents=prompt,
+                    config=genai_types.GenerateContentConfig(**LLM_SAMPLING),
+                )
                 break
             except (genai_errors.ServerError, genai_errors.ClientError) as e:
                 # 429 (rate limited) and 5xx are worth another go; anything else

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -31,6 +31,7 @@ import tempfile
 from pathlib import Path
 
 import click
+import httpx
 from dotenv import load_dotenv  # ty: ignore
 from google import genai  # ty: ignore
 from google.genai import errors as genai_errors  # ty: ignore
@@ -53,6 +54,19 @@ DEFAULT_MODEL = "gemini-3.7-flash"
 # before letting it fail.
 LLM_MAX_ATTEMPTS = 4
 LLM_RETRY_BACKOFF_SECONDS = 4
+
+# Phase 2 asks the site's own search API what each candidate term actually
+# returns, so phase 3 can judge the shortlist on real results rather than on how
+# the terms read. This is the same Algolia index the all-charts block searches,
+# filtered to the same topic, so "what would a reader see if they clicked this
+# chip" is answered directly instead of guessed at.
+DEFAULT_SEARCH_API = "https://ourworldindata.org/api/search"
+# How many results define a term's destination. A suggestion is a shortcut to
+# the top of a result list, not to all of it — two terms whose first few charts
+# are identical are duplicates however long their tails are.
+SEARCH_API_TOP_N = 3
+SEARCH_API_CONCURRENCY = 8
+SEARCH_API_TIMEOUT_SECONDS = 30
 
 # Gemini pricing per million tokens, for the cost estimate the CLI prints.
 # Models absent from here still run; their cost is simply reported as unknown,
@@ -248,8 +262,161 @@ never pad the list with variations to reach a number):
         raise RuntimeError(f"LLM extraction failed for {topic_name}: {e}")
 
 
-async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> tuple[list[dict], list[str]]:
+async def fetch_term_results(
+    client: httpx.AsyncClient,
+    api_base: str,
+    topic_name: str,
+    term: str,
+    semaphore: asyncio.Semaphore,
+) -> list[str] | None:
+    """Titles of the first few charts the site's search returns for a term, within a topic.
+
+    Returns: chart titles, best match first; [] when the term genuinely finds
+    nothing, and None when the search could not be performed at all. The two
+    must not be conflated: "no results" is evidence against a term, whereas
+    "unmeasurable" is no evidence either way, and treating the second as the
+    first deletes perfectly good terms.
+
+    Today the API conflates them itself: a topic-filtered search that finds
+    nothing 400s if the topic is outside the 100 commonest of our ~140 topic
+    tags, claiming the topic doesn't exist (owid/owid-grapher#7026 fixes this).
+    Until that ships, terms in those topics come back unmeasurable and keep
+    their place unjudged, which is the safe direction. Afterwards an empty
+    result set arrives as a 200 and counts as evidence, as it should.
+    """
+    params = {"q": term, "topics": topic_name, "hitsPerPage": str(SEARCH_API_TOP_N)}
+    async with semaphore:
+        for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
+            try:
+                response = await client.get(api_base, params=params, timeout=SEARCH_API_TIMEOUT_SECONDS)
+                response.raise_for_status()
+                results = response.json().get("results") or []
+                return [r["title"] for r in results[:SEARCH_API_TOP_N] if r.get("title")]
+            except httpx.HTTPStatusError as e:
+                # A rejected topic or query will be rejected identically on a
+                # retry; only server-side trouble is worth another go.
+                if e.response.status_code < 500:
+                    return None
+                if attempt == LLM_MAX_ATTEMPTS:
+                    return None
+                await asyncio.sleep(LLM_RETRY_BACKOFF_SECONDS * attempt)
+            except (httpx.HTTPError, KeyError, ValueError):
+                if attempt == LLM_MAX_ATTEMPTS:
+                    return None
+                await asyncio.sleep(LLM_RETRY_BACKOFF_SECONDS * attempt)
+    return None
+
+
+async def measure_coverage(
+    api_base: str, topic_name: str, terms: list[str], semaphore: asyncio.Semaphore
+) -> dict[str, list[str] | None]:
+    """What each candidate term actually returns, per the site's search API.
+
+    Returns: term -> titles of its top results, or None where it couldn't be measured
+    """
+    async with httpx.AsyncClient() as client:
+        tasks = [fetch_term_results(client, api_base, topic_name, term, semaphore) for term in terms]
+        results = await asyncio.gather(*tasks)
+    return dict(zip(terms, results, strict=True))
+
+
+async def refine_keywords_with_llm(
+    topic_name: str,
+    candidates: list[str],
+    coverage: dict[str, list[str] | None],
+    api_key: str,
+    model_id: str,
+) -> tuple[list[str], int, int]:
+    """Re-pick the shortlist now that each candidate's real results are known.
+
+    Only terms whose results could actually be measured are put to the model.
+    Unmeasured ones are appended afterwards, unjudged, so a search that couldn't
+    answer never costs a term its place.
+
+    Returns: (keywords, input_tokens, output_tokens)
+    """
+    client = genai.Client(api_key=api_key)
+
+    measured = [c for c in candidates if coverage.get(c) is not None]
+    unmeasured = [c for c in candidates if coverage.get(c) is None]
+    if not measured:
+        return candidates, 0, 0
+
+    lines = []
+    for term in measured:
+        titles = coverage[term] or []
+        shown = "; ".join(titles) if titles else "NOTHING"
+        lines.append(f'- "{term}" → {shown}')
+    findings = "\n".join(lines)
+
+    prompt = f"""These are candidate search terms for the Our World in Data topic
+"{topic_name}", each followed by the charts our site's search actually returns for
+it, within this topic, best match first:
+
+{findings}
+
+They are offered to a reader as a short line of suggestions under a search box:
+"Suggested: term, term, term…". Only the first few are shown. A term is worth a
+slot only if clicking it takes the reader somewhere the earlier terms didn't.
+
+Return the terms worth keeping, best first, applying what the results above show:
+
+1. Drop a term whose results are the same charts an earlier kept term already
+   returns. Keep whichever of them is the more natural thing to type.
+2. Drop a term that returned NOTHING.
+3. Drop a term whose results are unrelated to it — that means our search doesn't
+   understand the term, so the reader would get nonsense. Acronyms often fail
+   this way: check the titles actually concern the term's subject.
+4. Order them so each adds a subject the ones before it didn't, most central to
+   "{topic_name}" first.
+5. Keep every term that earns its slot; don't trim to a round number, and don't
+   invent terms that weren't offered above.
+
+Output JSON:
+{{
+  "keywords": ["term1", "term2", ...]
+}}"""
+
+    response = None
+    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
+        try:
+            response = await client.aio.models.generate_content(model=model_id, contents=prompt)
+            break
+        except (genai_errors.ServerError, genai_errors.ClientError) as e:
+            retriable = getattr(e, "code", None) == 429 or isinstance(e, genai_errors.ServerError)
+            if not retriable or attempt == LLM_MAX_ATTEMPTS:
+                raise
+            await asyncio.sleep(LLM_RETRY_BACKOFF_SECONDS * attempt)
+    assert response is not None
+
+    result_text = response.text.strip()
+    if "```json" in result_text:
+        result_text = result_text.split("```json")[1].split("```")[0].strip()
+    elif "```" in result_text:
+        result_text = result_text.split("```")[1].split("```")[0].strip()
+    parsed = json.loads(result_text)
+
+    usage = response.usage_metadata
+    input_tokens = int(getattr(usage, "prompt_token_count", 0) or 0)
+    output_tokens = int(getattr(usage, "candidates_token_count", 0) or 0)
+
+    # Never let the refinement introduce a term that wasn't measured.
+    allowed = {c.lower(): c for c in measured}
+    keywords = [allowed[k.lower()] for k in parsed.get("keywords", []) if k.lower() in allowed]
+    return keywords + unmeasured, input_tokens, output_tokens
+
+
+async def process_topics(
+    topic_slugs: list[str],
+    api_key: str,
+    model: str,
+    search_api: str | None,
+) -> tuple[list[dict], list[str]]:
     """Process multiple topics in parallel using asyncio.gather.
+
+    When `search_api` is set, each topic's candidates go through two more
+    phases: ask that API what each candidate actually returns, then ask the
+    model to re-pick the shortlist knowing the real results.
 
     Returns: (results, slugs that failed)
     """
@@ -288,6 +455,60 @@ async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> tu
             final_results.append(result)
             click.secho(f"✓ {result['topic_name']}: Extracted {len(result['keywords'])} keywords", fg="green")
 
+    if search_api and final_results:
+        click.echo(f"\nChecking what each candidate returns via {search_api} ...")
+        semaphore = asyncio.Semaphore(SEARCH_API_CONCURRENCY)
+        coverages = await asyncio.gather(
+            *(measure_coverage(search_api, r["topic_name"], r["keywords"], semaphore) for r in final_results)
+        )
+
+        click.echo("Re-picking each shortlist from those results ...")
+        refinements = await asyncio.gather(
+            *(
+                refine_keywords_with_llm(r["topic_name"], r["keywords"], coverage, api_key, model)
+                for r, coverage in zip(final_results, coverages, strict=True)
+            ),
+            return_exceptions=True,
+        )
+
+        unmeasurable = [
+            r["topic_name"]
+            for r, coverage in zip(final_results, coverages, strict=True)
+            if coverage and all(c is None for c in coverage.values())
+        ]
+        if unmeasurable:
+            click.secho(
+                f"! {len(unmeasurable)} topics could not be measured and keep their unrefined "
+                f"candidates: {', '.join(unmeasurable)}",
+                fg="yellow",
+            )
+
+        for result, coverage, refinement in zip(final_results, coverages, refinements, strict=True):
+            if isinstance(refinement, BaseException):
+                # Keep the unrefined shortlist rather than losing the topic; say
+                # so, since it is measurably weaker than the refined ones.
+                click.secho(f"! {result['topic_name']}: refinement failed, keeping candidates ({refinement})", fg="yellow")
+                result["stats"]["refined"] = False
+                continue
+            keywords, input_tokens, output_tokens = refinement
+            if not keywords:
+                click.secho(f"! {result['topic_name']}: refinement returned nothing, keeping candidates", fg="yellow")
+                result["stats"]["refined"] = False
+                continue
+            dropped = [k for k in result["keywords"] if k not in keywords]
+            result["keywords"] = keywords
+            result["stats"]["refined"] = True
+            result["stats"]["num_keywords"] = len(keywords)
+            result["stats"]["input_tokens"] += input_tokens
+            result["stats"]["output_tokens"] += output_tokens
+            result["stats"]["terms_measured"] = sum(1 for c in coverage.values() if c is not None)
+            result["stats"]["terms_returning_nothing"] = sum(1 for c in coverage.values() if c == [])
+            click.secho(
+                f"✓ {result['topic_name']}: kept {len(keywords)}"
+                + (f", dropped {', '.join(dropped)}" if dropped else ""),
+                fg="green",
+            )
+
     return final_results, failed
 
 
@@ -312,8 +533,29 @@ async def process_topics(topic_slugs: list[str], api_key: str, model: str) -> tu
         "overwriting production, e.g. --upload-path topic_vocabulary/my-branch.json"
     ),
 )
+@click.option(
+    "--search-api",
+    default=DEFAULT_SEARCH_API,
+    help=(
+        f"Search API used to check what each candidate term actually returns (default: {DEFAULT_SEARCH_API}). "
+        "Point it at a staging server to measure against that branch's index."
+    ),
+)
+@click.option(
+    "--no-refine",
+    is_flag=True,
+    help="Skip the search-API check and the second LLM pass; keep the first set of candidates as-is.",
+)
 @click.option("--no-upload", is_flag=True, help="Skip uploading to R2 (useful for testing)")
-def main(topic: tuple[str, ...], output: str | None, model: str, upload_path: str, no_upload: bool):
+def main(
+    topic: tuple[str, ...],
+    output: str | None,
+    model: str,
+    upload_path: str,
+    search_api: str,
+    no_refine: bool,
+    no_upload: bool,
+):
     """Extract vocabulary for topics using LLM (simple approach).
 
     Takes all chart titles and subtitles for topics and asks an LLM to extract
@@ -344,12 +586,15 @@ def main(topic: tuple[str, ...], output: str | None, model: str, upload_path: st
     click.echo(f"Model: {model}")
     upload_target = "skipped" if no_upload else f"s3://{S3_BUCKET_NAME}/{upload_path}"
     click.echo(f"Upload: {upload_target}")
+    click.echo(f"Refine: {'skipped' if no_refine else search_api}")
     click.echo("=" * 80)
     click.echo()
 
     # Extract chart texts and process with LLM
     click.echo("Extracting chart titles and subtitles from database...")
-    results, failed_slugs = asyncio.run(process_topics(topic_slugs, api_key, model))
+    results, failed_slugs = asyncio.run(
+        process_topics(topic_slugs, api_key, model, None if no_refine else search_api)
+    )
 
     if not results:
         click.secho("\n✗ No results generated", fg="red")

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -584,6 +584,26 @@ def main(
         click.echo("No topics specified, extracting for all topics...")
         topic_slugs = get_all_topic_slugs()
 
+    # A run over some of the topics cannot be published to the key the site
+    # reads: the file *replaces* the vocabulary rather than merging into it, so
+    # every topic the run skipped would lose its suggestions. Retrying a handful
+    # of topics is still useful — point --upload-path at another key to look at
+    # the result, or --no-upload --output to keep it locally — but publishing
+    # takes a run over every topic. Checked before the first API call, so the
+    # mistake costs nothing.
+    if topic and not no_upload and upload_path == DEFAULT_S3_VOCABULARY_PATH:
+        click.secho(
+            f"✗ Refusing to publish a {len(topic_slugs)}-topic run to {DEFAULT_S3_VOCABULARY_PATH}, "
+            "the key the site reads: it would drop every other topic's suggestions.",
+            fg="red",
+        )
+        click.secho(
+            "  Drop --topic to cover every topic, or keep this run out of production with "
+            "--no-upload (optionally with --output) or --upload-path.",
+            fg="red",
+        )
+        sys.exit(1)
+
     click.echo("=" * 80)
     click.echo("OWID TOPIC VOCABULARY")
     click.echo(f"Topics:    {len(topic_slugs)}")
@@ -676,17 +696,23 @@ def main(
     else:
         click.secho(f"Cost: unknown — no pricing recorded for {model} (add it to PRICING)", fg="yellow")
 
-    # Build output data
-    if len(results) == 1:
-        output_data = results[0]
-    else:
-        output_data = {r["topic_slug"]: r for r in results}
+    # Always keyed by topic slug, single-topic runs included: the site reads the
+    # file as a mapping of topics, and a bare entry object indexes to nothing at
+    # all rather than to one topic.
+    output_data = {r["topic_slug"]: r for r in results}
+
+    # Written before the guard below, so a run that ends up refusing to publish
+    # still leaves behind whatever it did manage to produce.
+    if output:
+        with open(output, "w") as f:
+            json.dump(output_data, f, indent=2)
+        click.echo()
+        click.secho(f"✓ Saved results to: {output}", fg="green")
 
     # Refuse to publish a vocabulary that is missing topics. A run fans out one
     # request per topic, so a transient API failure used to mean those topics
     # quietly vanished from the file — and uploading that over a complete
-    # vocabulary loses their suggestions until someone notices. Keep the result
-    # (--output still writes it) but make publishing it a deliberate choice.
+    # vocabulary loses their suggestions until someone notices.
     if failed_slugs and not no_upload:
         click.echo()
         click.secho(
@@ -694,8 +720,9 @@ def main(
             fg="red",
         )
         click.secho(
-            "  Not uploading a partial vocabulary over a complete one. Re-run (optionally with "
-            f"{' '.join('--topic ' + s for s in failed_slugs)}) or pass --no-upload to keep the partial result.",
+            "  Not uploading a partial vocabulary over a complete one. Re-run over every topic to "
+            "publish — re-running just these few can't be, since the file replaces the whole "
+            "vocabulary. Pass --no-upload to keep this partial result.",
             fg="red",
         )
         sys.exit(1)
@@ -720,13 +747,6 @@ def main(
                 )
         finally:
             os.unlink(tmp_path)
-
-    # Save to local file if requested
-    if output:
-        with open(output, "w") as f:
-            json.dump(output_data, f, indent=2)
-        click.echo()
-        click.secho(f"✓ Saved results to: {output}", fg="green")
 
 
 if __name__ == "__main__":

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -203,10 +203,15 @@ What makes this list good is that each term takes the reader somewhere *differen
 5. Prefer the shortest form of a term that still names its subject. A reader
    clicking "sex ratio" is shown every chart about it; "sex ratio at birth"
    hides most of them for no gain. Give the broad form, not the specific one.
-6. Words from the topic's own name are not just allowed but usually necessary —
-   most of these charts say them. Give "maternal deaths" and "maternal mortality
-   ratio" on Maternal Mortality; just don't offer the bare topic name itself,
-   which narrows nothing.
+6. Words from the topic's own name are not just allowed, they are usually
+   required. Look at the most-viewed charts at the top of the list: whatever they
+   call their subject is the term readers want, even when it repeats the topic's
+   name almost exactly. On "Child & Infant Mortality", whose biggest charts are
+   titled "Child mortality rate", give "child mortality". On "Electricity Mix",
+   give "electricity production". Offer them first. Don't worry about a term
+   being too close to the topic's name — anything that genuinely narrows nothing
+   is dropped afterwards, so the cost of including it is zero and the cost of
+   leaving it out is the topic's most important term.
 7. Skip anything too broad to narrow the list down: a bare "men", "women",
    "children", "countries", "population".
 8. Never name a place. No countries, regions, continents or income groups —
@@ -436,6 +441,7 @@ async def process_topics(
                     else 0.0,
                     4,
                 ),
+                "topic_name_share": round(selection.topic_name_share, 4),
                 "weighting": weighting,
                 "views_column": views_column,
                 "selection": "coverage",

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -41,6 +41,23 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from owid.catalog import s3_utils  # ty: ignore
 
+from coverage_model import (  # ty: ignore
+    DEFAULT_VIEWS_COLUMN,
+    EmptyAnalyticsError,
+    TopicSelection,
+    ViewAnalytics,
+    WeightedUniverse,
+    fetch_topic_universe,
+    load_mdim_view_config_ids,
+    load_view_analytics,
+    select_terms_by_coverage,
+    weigh_universe,
+)
+from coverage_report import (  # ty: ignore
+    render_html_report,
+    render_run_summary,
+    render_topic_table,
+)
 from etl.config import OWID_ENV  # ty: ignore
 
 S3_BUCKET_NAME = "owid-public"
@@ -55,18 +72,17 @@ DEFAULT_MODEL = "gemini-3.7-flash"
 LLM_MAX_ATTEMPTS = 4
 LLM_RETRY_BACKOFF_SECONDS = 4
 
-# Phase 2 asks the site's own search API what each candidate term actually
-# returns, so phase 3 can judge the shortlist on real results rather than on how
-# the terms read. This is the same Algolia index the all-charts block searches,
-# filtered to the same topic, so "what would a reader see if they clicked this
-# chip" is answered directly instead of guessed at.
-DEFAULT_SEARCH_API = "https://ourworldindata.org/api/search"
-# How many results define a term's destination. A suggestion is a shortcut to
-# the top of a result list, not to all of it — two terms whose first few charts
-# are identical are duplicates however long their tails are.
-SEARCH_API_TOP_N = 3
-SEARCH_API_CONCURRENCY = 8
-SEARCH_API_TIMEOUT_SECONDS = 30
+# How many topics' record sets to fetch at once.
+SEARCH_CONCURRENCY = 8
+
+# How many terms to publish. The site shows five, then drops any that name a place
+# or repeat the topic's own name, so a couple of spares keep the line full.
+DEFAULT_MAX_TERMS = 8
+
+# A term revealing less than this share of a topic's views is not worth one of
+# five slots on a single line. Terms just below it are reported as near misses so
+# the floor can be judged from the output.
+DEFAULT_MIN_MARGINAL_SHARE = 0.01
 
 # Gemini pricing per million tokens, for the cost estimate the CLI prints.
 # Models absent from here still run; their cost is simply reported as unknown,
@@ -96,52 +112,50 @@ def get_all_topic_slugs() -> list[str]:
     return df["slug"].tolist()
 
 
-def extract_chart_texts(topic_slug: str) -> tuple[str, list[str]]:
-    """Extract all chart titles and subtitles for a topic.
+def get_topic_names(topic_slugs: list[str]) -> dict[str, str]:
+    """Map topic slugs to the tag names the search index and gdocs use.
 
-    Returns: (topic_name, list_of_texts)
+    One query for every topic rather than one per topic: OWID_ENV.read_sql opens a
+    connection per call, and the old per-topic version spent most of a run's
+    wall-clock on 125 of them.
     """
-    query = """
-        SELECT DISTINCT
-            t.name as topic_name,
-            t.slug as topic_slug,
-            cc.full->'$.title' as chart_title,
-            cc.full->'$.subtitle' as chart_subtitle
-        FROM charts c
-        JOIN chart_configs cc ON c.configId = cc.id
-        JOIN chart_tags ct ON c.id = ct.chartId
-        JOIN tags t ON ct.tagId = t.id
-        WHERE c.publishedAt IS NOT NULL
-          AND t.slug = %s
+    placeholders = ", ".join(["%s"] * len(topic_slugs))
+    rows = OWID_ENV.read_sql(
+        f"SELECT slug, name FROM tags WHERE slug IN ({placeholders})",
+        params=tuple(topic_slugs),
+    )
+    return {row.slug: row.name for row in rows.itertuples(index=False)}
+
+
+def texts_for_prompt(universe: WeightedUniverse, limit: int = 200) -> list[str]:
+    """The topic's chart texts to show the model, most-viewed first.
+
+    Taken from the topic's *rendered* record set rather than from the `charts`
+    table, which was the old source and a real hole: multi-dim and explorer views
+    never reached the model, so on a topic like Climate Change it was proposing
+    terms having seen 67 of 714 records. Since selection now scores terms on how
+    much of that list they cover, the model has to be shown the list it is
+    being scored against.
+
+    Ordered by views and cut at `limit` rather than sampled at random, so the
+    terms proposed are the ones describing what people actually look at, and two
+    runs see the same input.
     """
-
-    df = OWID_ENV.read_sql(query, params=(topic_slug,))
-
-    if df.empty:
-        raise ValueError(f"No charts found for topic '{topic_slug}'")
-
-    topic_name = df["topic_name"].iloc[0]
-
-    # Collect all non-null titles and subtitles
-    texts = []
-    for _, row in df.iterrows():
-        if row["chart_title"]:
-            texts.append(str(row["chart_title"]))
-        if row["chart_subtitle"]:
-            texts.append(str(row["chart_subtitle"]))
-
-    # Deduplicate texts (many charts have similar/identical titles)
-    unique_texts = list(set(texts))
-
-    # If still too many, take a representative sample
-    if len(unique_texts) > 200:
-        import random
-
-        random.seed(42)  # Reproducible sampling
-        unique_texts = random.sample(unique_texts, 200)
-
-    return topic_name, unique_texts
-
+    ordered = sorted(
+        universe.records.items(),
+        key=lambda item: -universe.weights.get(item[0], 0.0),
+    )
+    texts: list[str] = []
+    seen: set[str] = set()
+    for _, record in ordered:
+        for text in (record.get("title"), record.get("subtitle")):
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            texts.append(str(text))
+        if len(texts) >= limit:
+            break
+    return texts[:limit]
 
 async def extract_keywords_with_llm(
     topic_slug: str, topic_name: str, texts: list[str], api_key: str, model_id: str = DEFAULT_MODEL
@@ -155,8 +169,10 @@ async def extract_keywords_with_llm(
     # Combine all texts
     combined_text = "\n".join(texts)
 
-    prompt = f"""Below are the titles and subtitles of every chart Our World in Data
-publishes on the topic "{topic_name}":
+    prompt = f"""Below are the titles and subtitles of the charts Our World in Data publishes on
+the topic "{topic_name}", most-viewed first. They include the individual views of
+its multi-dimensional charts and its explorers, which is what the topic page
+actually lists:
 
 {combined_text}
 
@@ -184,19 +200,33 @@ What makes this list good is that each term takes the reader somewhere *differen
 3. Order the list so that each term adds something the ones before it did not.
 4. Terms should be things a reader would plausibly type: specific subjects,
    technologies, diseases, materials, policies, groups.
-5. Skip anything too broad to narrow the list down: a bare "men", "women",
-   "children", "countries", "population", or the topic's own name.
-6. Never name a place. No countries, regions, continents or income groups —
+5. Prefer the shortest form of a term that still names its subject. A reader
+   clicking "sex ratio" is shown every chart about it; "sex ratio at birth"
+   hides most of them for no gain. Give the broad form, not the specific one.
+6. Words from the topic's own name are not just allowed but usually necessary —
+   most of these charts say them. Give "maternal deaths" and "maternal mortality
+   ratio" on Maternal Mortality; just don't offer the bare topic name itself,
+   which narrows nothing.
+7. Skip anything too broad to narrow the list down: a bare "men", "women",
+   "children", "countries", "population".
+8. Never name a place. No countries, regions, continents or income groups —
    not "United States", "Ukraine", "China", "low-income countries". The charts
    above mention them constantly and they are searched for separately.
-7. Skip measurement and units language: percentage, per capita, share, rate,
+9. Skip measurement and units language: percentage, per capita, share, rate,
    level, annual, total, average, "GDP per capita", and terms that are only a
    generic process word, such as "energy consumption" or "oil prices" (prefer
    "oil"). "GDP" on its own is only a term for a topic that is actually about
    GDP.
-8. Skip historical or obsolete terms unless they are still what people search for.
+10. Skip historical or obsolete terms unless they are still what people search for.
 
-Output JSON (up to 30 terms; far fewer is right when the topic is narrow —
+Give a generous list — the more real candidates you offer, the better the final
+selection can be. Terms are scored by how many of the charts above they actually
+bring up, so favour the words those titles really use. Only a handful are shown to the reader, and they are chosen
+from your list by measuring how much of the chart list above each one actually
+brings up, so a term that is right but not obvious costs nothing to include and
+a term that duplicates another costs nothing to leave out.
+
+Output JSON (up to 40 terms; far fewer is right when the topic is narrow —
 never pad the list with variations to reach a number):
 {{
   "keywords": ["term1", "term2", ...]
@@ -262,254 +292,180 @@ never pad the list with variations to reach a number):
         raise RuntimeError(f"LLM extraction failed for {topic_name}: {e}")
 
 
-async def fetch_term_results(
+async def build_topic_universe(
     client: httpx.AsyncClient,
-    api_base: str,
+    topic_slug: str,
     topic_name: str,
-    term: str,
+    analytics: ViewAnalytics | None,
+    mdim_config_ids: dict,
     semaphore: asyncio.Semaphore,
-) -> list[str] | None:
-    """Titles of the first few charts the site's search returns for a term, within a topic.
-
-    Returns: chart titles, best match first; [] when the term genuinely finds
-    nothing, and None when the search could not be performed at all. The two
-    must not be conflated: "no results" is evidence against a term, whereas
-    "unmeasurable" is no evidence either way, and treating the second as the
-    first deletes perfectly good terms.
-
-    Today the API conflates them itself: a topic-filtered search that finds
-    nothing 400s if the topic is outside the 100 commonest of our ~140 topic
-    tags, claiming the topic doesn't exist (owid/owid-grapher#7026 fixes this).
-    Until that ships, terms in those topics come back unmeasurable and keep
-    their place unjudged, which is the safe direction. Afterwards an empty
-    result set arrives as a 200 and counts as evidence, as it should.
-    """
-    params = {"q": term, "topics": topic_name, "hitsPerPage": str(SEARCH_API_TOP_N)}
-    async with semaphore:
-        for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
-            try:
-                response = await client.get(api_base, params=params, timeout=SEARCH_API_TIMEOUT_SECONDS)
-                response.raise_for_status()
-                results = response.json().get("results") or []
-                return [r["title"] for r in results[:SEARCH_API_TOP_N] if r.get("title")]
-            except httpx.HTTPStatusError as e:
-                # A rejected topic or query will be rejected identically on a
-                # retry; only server-side trouble is worth another go.
-                if e.response.status_code < 500:
-                    return None
-                if attempt == LLM_MAX_ATTEMPTS:
-                    return None
-                await asyncio.sleep(LLM_RETRY_BACKOFF_SECONDS * attempt)
-            except (httpx.HTTPError, KeyError, ValueError):
-                if attempt == LLM_MAX_ATTEMPTS:
-                    return None
-                await asyncio.sleep(LLM_RETRY_BACKOFF_SECONDS * attempt)
-    return None
-
-
-async def measure_coverage(
-    api_base: str, topic_name: str, terms: list[str], semaphore: asyncio.Semaphore
-) -> dict[str, list[str] | None]:
-    """What each candidate term actually returns, per the site's search API.
-
-    Returns: term -> titles of its top results, or None where it couldn't be measured
-    """
-    async with httpx.AsyncClient() as client:
-        tasks = [fetch_term_results(client, api_base, topic_name, term, semaphore) for term in terms]
-        results = await asyncio.gather(*tasks)
-    return dict(zip(terms, results, strict=True))
-
-
-async def refine_keywords_with_llm(
-    topic_name: str,
-    candidates: list[str],
-    coverage: dict[str, list[str] | None],
-    api_key: str,
-    model_id: str,
-) -> tuple[list[str], int, int]:
-    """Re-pick the shortlist now that each candidate's real results are known.
-
-    Only terms whose results could actually be measured are put to the model.
-    Unmeasured ones are appended afterwards, unjudged, so a search that couldn't
-    answer never costs a term its place.
-
-    Returns: (keywords, input_tokens, output_tokens)
-    """
-    client = genai.Client(api_key=api_key)
-
-    measured = [c for c in candidates if coverage.get(c) is not None]
-    unmeasured = [c for c in candidates if coverage.get(c) is None]
-    if not measured:
-        return candidates, 0, 0
-
-    lines = []
-    for term in measured:
-        titles = coverage[term] or []
-        shown = "; ".join(titles) if titles else "NOTHING"
-        lines.append(f'- "{term}" → {shown}')
-    findings = "\n".join(lines)
-
-    prompt = f"""These are candidate search terms for the Our World in Data topic
-"{topic_name}", each followed by the charts our site's search actually returns for
-it, within this topic, best match first:
-
-{findings}
-
-They are offered to a reader as a short line of suggestions under a search box:
-"Suggested: term, term, term…". Only the first few are shown. A term is worth a
-slot only if clicking it takes the reader somewhere the earlier terms didn't.
-
-Return the terms worth keeping, best first, applying what the results above show:
-
-1. Drop a term whose results are the same charts an earlier kept term already
-   returns. Keep whichever of them is the more natural thing to type.
-2. Drop a term that returned NOTHING.
-3. Drop a term whose results are unrelated to it — that means our search doesn't
-   understand the term, so the reader would get nonsense. Acronyms often fail
-   this way: check the titles actually concern the term's subject.
-4. Order them so each adds a subject the ones before it didn't, most central to
-   "{topic_name}" first.
-5. Keep every term that earns its slot; don't trim to a round number, and don't
-   invent terms that weren't offered above.
-
-Output JSON:
-{{
-  "keywords": ["term1", "term2", ...]
-}}"""
-
-    response = None
-    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
-        try:
-            response = await client.aio.models.generate_content(model=model_id, contents=prompt)
-            break
-        except (genai_errors.ServerError, genai_errors.ClientError) as e:
-            retriable = getattr(e, "code", None) == 429 or isinstance(e, genai_errors.ServerError)
-            if not retriable or attempt == LLM_MAX_ATTEMPTS:
-                raise
-            await asyncio.sleep(LLM_RETRY_BACKOFF_SECONDS * attempt)
-    assert response is not None
-
-    result_text = response.text.strip()
-    if "```json" in result_text:
-        result_text = result_text.split("```json")[1].split("```")[0].strip()
-    elif "```" in result_text:
-        result_text = result_text.split("```")[1].split("```")[0].strip()
-    parsed = json.loads(result_text)
-
-    usage = response.usage_metadata
-    input_tokens = int(getattr(usage, "prompt_token_count", 0) or 0)
-    output_tokens = int(getattr(usage, "candidates_token_count", 0) or 0)
-
-    # Never let the refinement introduce a term that wasn't measured.
-    allowed = {c.lower(): c for c in measured}
-    keywords = [allowed[k.lower()] for k in parsed.get("keywords", []) if k.lower() in allowed]
-    return keywords + unmeasured, input_tokens, output_tokens
+) -> WeightedUniverse:
+    """Fetch and weight everything the all-charts block lists for one topic."""
+    records = await fetch_topic_universe(client, topic_name, semaphore)
+    if not records:
+        raise ValueError(f"no charts indexed for topic '{topic_slug}'")
+    return weigh_universe(topic_name, records, analytics, mdim_config_ids)
 
 
 async def process_topics(
     topic_slugs: list[str],
     api_key: str,
     model: str,
-    search_api: str | None,
-) -> tuple[list[dict], list[str]]:
-    """Process multiple topics in parallel using asyncio.gather.
+    weighting: str,
+    views_column: str,
+    max_terms: int,
+    min_marginal_share: float,
+) -> tuple[list[dict], list[str], dict[str, WeightedUniverse], list[TopicSelection]]:
+    """Generate a vocabulary for each topic and choose its terms by coverage.
 
-    When `search_api` is set, each topic's candidates go through two more
-    phases: ask that API what each candidate actually returns, then ask the
-    model to re-pick the shortlist knowing the real results.
+    Four phases. The first three are shared setup and one request per topic; only
+    the LLM call is per topic and expensive.
 
-    Returns: (results, slugs that failed)
+    1. Load, once: topic names, chart view counts, and the multi-dim view →
+       config id map that lets a view's own popularity be found.
+    2. Per topic, fetch the record set the all-charts block lists and weight each
+       record by its views.
+    3. Ask the model for candidate terms, having shown it that record set.
+    4. Choose the terms that cover the most of it — see select_terms_by_coverage.
+
+    There used to be a second LLM pass here, re-picking the shortlist from what
+    the search returned for each candidate. Coverage subsumes it: a term whose
+    rows are already covered adds nothing and is not chosen, and a term the block
+    would show nothing for covers nothing and cannot be chosen at all.
+
+    Returns: (results, failed slugs, universes by topic name, selections)
     """
-    # Extract chart texts for all topics first
     failed: list[str] = []
-    topic_data = []
-    for topic_slug in topic_slugs:
-        try:
-            topic_name, texts = extract_chart_texts(topic_slug)
-            topic_data.append((topic_slug, topic_name, texts))
-            click.secho(f"✓ {topic_name}: Found {len(texts)} texts", fg="green")
-        except ValueError as e:
-            click.secho(f"✗ {topic_slug}: {e}", fg="red")
-            failed.append(topic_slug)
 
-    if not topic_data:
-        return [], failed
-
-    # Extract keywords for all topics in parallel
-    click.echo(f"\nExtracting keywords using LLM for {len(topic_data)} topics in parallel...")
-    tasks = [
-        extract_keywords_with_llm(topic_slug, topic_name, texts, api_key, model)
-        for topic_slug, topic_name, texts in topic_data
-    ]
-
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-
-    # Handle any exceptions
-    final_results = []
-    for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            topic_slug = topic_data[i][0]
-            click.secho(f"✗ {topic_slug}: {result}", fg="red")
-            failed.append(topic_slug)
-        else:
-            final_results.append(result)
-            click.secho(f"✓ {result['topic_name']}: Extracted {len(result['keywords'])} keywords", fg="green")
-
-    if search_api and final_results:
-        click.echo(f"\nChecking what each candidate returns via {search_api} ...")
-        semaphore = asyncio.Semaphore(SEARCH_API_CONCURRENCY)
-        coverages = await asyncio.gather(
-            *(measure_coverage(search_api, r["topic_name"], r["keywords"], semaphore) for r in final_results)
+    click.echo("Loading topic names, chart views and multi-dim views...")
+    names_by_slug = get_topic_names(topic_slugs)
+    analytics = None if weighting == "uniform" else load_view_analytics(views_column)
+    mdim_config_ids = load_mdim_view_config_ids() if analytics else {}
+    if analytics:
+        click.secho(
+            f"✓ {len(analytics.by_slug):,} charts and {len(analytics.by_config_id):,} "
+            f"views have {views_column}; {len(mdim_config_ids):,} multi-dim views mapped",
+            fg="green",
+        )
+    else:
+        click.secho(
+            "! --weighting uniform: every chart counts the same, popularity is ignored",
+            fg="yellow",
         )
 
-        click.echo("Re-picking each shortlist from those results ...")
-        refinements = await asyncio.gather(
-            *(
-                refine_keywords_with_llm(r["topic_name"], r["keywords"], coverage, api_key, model)
-                for r, coverage in zip(final_results, coverages, strict=True)
-            ),
-            return_exceptions=True,
-        )
+    semaphore = asyncio.Semaphore(SEARCH_CONCURRENCY)
+    universes: dict[str, WeightedUniverse] = {}
+    prompt_inputs: list[tuple[str, str, list[str]]] = []
 
-        unmeasurable = [
-            r["topic_name"]
-            for r, coverage in zip(final_results, coverages, strict=True)
-            if coverage and all(c is None for c in coverage.values())
-        ]
-        if unmeasurable:
-            click.secho(
-                f"! {len(unmeasurable)} topics could not be measured and keep their unrefined "
-                f"candidates: {', '.join(unmeasurable)}",
-                fg="yellow",
+    click.echo(f"\nFetching the chart list for {len(topic_slugs)} topics...")
+    async with httpx.AsyncClient() as client:
+        async def load(topic_slug: str):
+            topic_name = names_by_slug.get(topic_slug)
+            if not topic_name:
+                raise ValueError(f"no tag named for topic '{topic_slug}'")
+            return topic_slug, topic_name, await build_topic_universe(
+                client, topic_slug, topic_name, analytics, mdim_config_ids, semaphore
             )
 
-        for result, coverage, refinement in zip(final_results, coverages, refinements, strict=True):
-            if isinstance(refinement, BaseException):
-                # Keep the unrefined shortlist rather than losing the topic; say
-                # so, since it is measurably weaker than the refined ones.
-                click.secho(f"! {result['topic_name']}: refinement failed, keeping candidates ({refinement})", fg="yellow")
-                result["stats"]["refined"] = False
+        for outcome in await asyncio.gather(
+            *(load(slug) for slug in topic_slugs), return_exceptions=True
+        ):
+            if isinstance(outcome, BaseException):
+                click.secho(f"✗ {outcome}", fg="red")
                 continue
-            keywords, input_tokens, output_tokens = refinement
-            if not keywords:
-                click.secho(f"! {result['topic_name']}: refinement returned nothing, keeping candidates", fg="yellow")
-                result["stats"]["refined"] = False
-                continue
-            dropped = [k for k in result["keywords"] if k not in keywords]
-            result["keywords"] = keywords
-            result["stats"]["refined"] = True
-            result["stats"]["num_keywords"] = len(keywords)
-            result["stats"]["input_tokens"] += input_tokens
-            result["stats"]["output_tokens"] += output_tokens
-            result["stats"]["terms_measured"] = sum(1 for c in coverage.values() if c is not None)
-            result["stats"]["terms_returning_nothing"] = sum(1 for c in coverage.values() if c == [])
+            topic_slug, topic_name, universe = outcome
+            universes[topic_name] = universe
+            prompt_inputs.append((topic_slug, topic_name, texts_for_prompt(universe)))
             click.secho(
-                f"✓ {result['topic_name']}: kept {len(keywords)}"
-                + (f", dropped {', '.join(dropped)}" if dropped else ""),
+                f"✓ {topic_name}: {len(universe.records)} records, "
+                f"{universe.total_weight:,.0f} views",
                 fg="green",
             )
 
-    return final_results, failed
+    # Any topic whose record set didn't load can't be generated at all.
+    loaded = {slug for slug, _, _ in prompt_inputs}
+    failed.extend(slug for slug in topic_slugs if slug not in loaded)
+
+    if not prompt_inputs:
+        return [], failed, universes, []
+
+    click.echo(f"\nAsking for candidate terms for {len(prompt_inputs)} topics...")
+    candidate_results = await asyncio.gather(
+        *(
+            extract_keywords_with_llm(topic_slug, topic_name, texts, api_key, model)
+            for topic_slug, topic_name, texts in prompt_inputs
+        ),
+        return_exceptions=True,
+    )
+
+    click.echo("\nChoosing the terms that cover the most of each topic...")
+    results: list[dict] = []
+    selections: list[TopicSelection] = []
+    for (topic_slug, topic_name, _), candidates in zip(
+        prompt_inputs, candidate_results, strict=True
+    ):
+        if isinstance(candidates, BaseException):
+            click.secho(f"✗ {topic_slug}: {candidates}", fg="red")
+            failed.append(topic_slug)
+            continue
+
+        universe = universes[topic_name]
+        offered = list(candidates["keywords"])
+        selection = select_terms_by_coverage(
+            universe,
+            candidates["keywords"],
+            max_terms=max_terms,
+            min_marginal_share=min_marginal_share,
+        )
+        selections.append(selection)
+
+        total = selection.total_weight
+        candidates["keywords"] = [term.term for term in selection.selected]
+        candidates["stats"].update(
+            {
+                "num_keywords": len(selection.selected),
+                "num_candidates": len(offered),
+                "num_records": selection.total_count,
+                "weighted_coverage": round(
+                    selection.covered_weight / total if total else 0.0, 4
+                ),
+                "chart_coverage": round(
+                    (selection.total_count - len(selection.uncovered))
+                    / selection.total_count
+                    if selection.total_count
+                    else 0.0,
+                    4,
+                ),
+                "weighting": weighting,
+                "views_column": views_column,
+                "selection": "coverage",
+                # The consumer keys "trust this order" off `refined`; the order is
+                # now measured rather than guessed, so it still holds. See
+                # rankSuggestedKeywords in owid-grapher.
+                "refined": True,
+            }
+        )
+        candidates["keyword_stats"] = [
+            {
+                "term": term.term,
+                "own_share": round(term.own_share(total), 4),
+                "own_records": term.own_count,
+                "marginal_share": round(term.marginal_share(total), 4),
+                "marginal_records": term.marginal_count,
+                "cumulative_share": round(term.cumulative_share(total), 4),
+            }
+            for term in selection.selected
+        ]
+        results.append(candidates)
+
+        share = selection.covered_weight / total if total else 0.0
+        click.secho(
+            f"✓ {topic_name}: {len(selection.selected)} terms cover {share:.0%} of views "
+            f"— {', '.join(term.term for term in selection.selected) or '(none)'}",
+            fg="green" if share >= 0.35 else "yellow",
+        )
+
+    return results, failed, universes, selections
 
 
 @click.command()
@@ -534,17 +490,37 @@ async def process_topics(
     ),
 )
 @click.option(
-    "--search-api",
-    default=DEFAULT_SEARCH_API,
+    "--report",
+    "report_path",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Write an HTML coverage report here: per term, what it reveals and what it adds.",
+)
+@click.option(
+    "--weighting",
+    type=click.Choice(["views", "uniform"]),
+    default="views",
+    help="Weight charts by how much they are viewed (default), or count them equally.",
+)
+@click.option(
+    "--views-column",
+    type=click.Choice(["views_7d", "views_14d", "views_365d"]),
+    default=DEFAULT_VIEWS_COLUMN,
     help=(
-        f"Search API used to check what each candidate term actually returns (default: {DEFAULT_SEARCH_API}). "
-        "Point it at a staging server to measure against that branch's index."
+        f"Which view window to weight by (default: {DEFAULT_VIEWS_COLUMN}). A vocabulary is "
+        "read for weeks, so the year is steadier than the week."
     ),
 )
 @click.option(
-    "--no-refine",
-    is_flag=True,
-    help="Skip the search-API check and the second LLM pass; keep the first set of candidates as-is.",
+    "--max-terms",
+    default=DEFAULT_MAX_TERMS,
+    show_default=True,
+    help="Most terms to publish per topic.",
+)
+@click.option(
+    "--min-marginal-share",
+    default=DEFAULT_MIN_MARGINAL_SHARE,
+    show_default=True,
+    help="Stop once the next term would reveal less than this share of a topic's views.",
 )
 @click.option("--no-upload", is_flag=True, help="Skip uploading to R2 (useful for testing)")
 def main(
@@ -552,15 +528,19 @@ def main(
     output: str | None,
     model: str,
     upload_path: str,
-    search_api: str,
-    no_refine: bool,
+    report_path: str | None,
+    weighting: str,
+    views_column: str,
+    max_terms: int,
+    min_marginal_share: float,
     no_upload: bool,
 ):
-    """Extract vocabulary for topics using LLM (simple approach).
+    """Build the OWID topic vocabulary: the suggested search terms per topic.
 
-    Takes all chart titles and subtitles for topics and asks an LLM to extract
-    characteristic keywords/phrases. Processes multiple topics in parallel.
-    Shows API cost by default.
+    For each topic, fetches the chart list its all-charts block shows, weights
+    every chart by how much it is viewed, asks an LLM for candidate search terms,
+    and then picks the terms covering the most of that list — most-revealing
+    first, each next one adding the most that is still uncovered.
     """
     # Load .env file from project root
     env_path = Path(__file__).parent.parent.parent / ".env"
@@ -581,20 +561,34 @@ def main(
         topic_slugs = get_all_topic_slugs()
 
     click.echo("=" * 80)
-    click.echo("SIMPLE LLM-BASED VOCABULARY EXTRACTION")
-    click.echo(f"Topics: {len(topic_slugs)}")
-    click.echo(f"Model: {model}")
+    click.echo("OWID TOPIC VOCABULARY")
+    click.echo(f"Topics:    {len(topic_slugs)}")
+    click.echo(f"Model:     {model}")
+    click.echo(
+        f"Weighting: {'every chart equally' if weighting == 'uniform' else views_column}"
+    )
+    click.echo(f"Terms:     at most {max_terms}, stopping below {min_marginal_share:.1%}")
     upload_target = "skipped" if no_upload else f"s3://{S3_BUCKET_NAME}/{upload_path}"
-    click.echo(f"Upload: {upload_target}")
-    click.echo(f"Refine: {'skipped' if no_refine else search_api}")
+    click.echo(f"Upload:    {upload_target}")
     click.echo("=" * 80)
     click.echo()
 
-    # Extract chart texts and process with LLM
-    click.echo("Extracting chart titles and subtitles from database...")
-    results, failed_slugs = asyncio.run(
-        process_topics(topic_slugs, api_key, model, None if no_refine else search_api)
-    )
+    try:
+        results, failed_slugs, universes, selections = asyncio.run(
+            process_topics(
+                topic_slugs,
+                api_key,
+                model,
+                weighting=weighting,
+                views_column=views_column,
+                max_terms=max_terms,
+                min_marginal_share=min_marginal_share,
+            )
+        )
+    except EmptyAnalyticsError as e:
+        click.echo()
+        click.secho(f"✗ {e}", fg="red")
+        sys.exit(1)
 
     if not results:
         click.secho("\n✗ No results generated", fg="red")
@@ -623,15 +617,23 @@ def main(
     click.echo("=" * 80)
     click.echo()
 
-    for result in results:
-        click.echo(f"Topic: {result['topic_name']}")
-        click.echo(f"Keywords extracted: {len(result['keywords'])}")
+    # A run covers every topic, so the per-term arithmetic only goes to the
+    # terminal when few enough topics were asked for to read it; otherwise it is
+    # one line each, worst-covered first, and the detail goes to --report.
+    if len(selections) <= 3:
+        for selection in selections:
+            click.echo(render_topic_table(selection, universes[selection.topic_name]))
+            click.echo()
+    else:
+        click.echo(render_run_summary(selections))
         click.echo()
-        click.echo("Keywords:")
-        for i, kw in enumerate(result["keywords"], 1):
-            click.echo(f"  {i:2d}. {kw}")
-        click.echo()
-        click.echo("-" * 80)
+
+    if report_path:
+        Path(report_path).write_text(
+            render_html_report(selections, universes, weighting, views_column),
+            encoding="utf-8",
+        )
+        click.secho(f"✓ Coverage report: {report_path}", fg="green")
         click.echo()
 
     # Output total cost

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -211,12 +211,18 @@ What makes this list good is that each term takes the reader somewhere *differen
    rule to remember:
    - Not how a number is expressed. A measurement's shape is not a subject, and
      a reader looking for one is not looking for charts. Prefer "oil" to "oil
-     prices", "electricity" to "electricity consumption". Never on its own, and
-     never as the head of a phrase: per capita, GDP per capita, share, rate,
-     death rate, total, annual, average, level, index, projections, reported,
-     confirmed, vital registration. (This list is spelled out because it is the
-     rule most often broken: asked only for the principle, the model offered
-     "gdp per capita" as the first suggestion on Poverty.)
+     prices", "electricity" to "electricity consumption". These are never a term
+     on their own and never the head of a phrase: per capita, share, rate, death
+     rate, total, annual, average, level, index, projections, reported,
+     confirmed, vital registration. The list is spelled out because it is the
+     rule most often broken.
+
+     **Unless a chart above is actually called that.** Then it is a subject, by
+     definition — someone named a chart after it. "GDP per capita" reads like a
+     unit and is one of the charts on the Poverty topic, worth a third of its
+     traffic; refusing it leaves that chart with nothing pointing at it. The test
+     is the titles in front of you, not how the words sound: if one of them is
+     essentially just this term, give it.
    - Not a place. Countries, regions and income groups say *who* rather than
      *what*; these charts mention them constantly and readers search for them
      separately.


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

The OWID topic vocabulary — the per-topic search terms behind the `SUGGESTED:` line in the all-charts block (owid/owid-grapher#7016). Two changes: it can be published somewhere other than the key the site reads, and term *selection* becomes an optimisation instead of a judgement call.

## Selection

Terms are now chosen to **cover as much of a topic's chart list as a few terms can, weighting charts by how much they are viewed** — the first term revealing the most, each next one adding the most that is still uncovered. Greedy weighted maximum coverage, so that ordering is guaranteed, with the usual (1−1/e) bound; it does not find the optimal set.

Two things follow from this rather than needing an LLM to judge them, so **the second LLM pass is deleted**: a term whose charts are already covered adds nothing and is not chosen, and a term the block would show nothing for covers nothing and cannot be chosen at all. All 47 terms that were rendering an empty list are gone by construction.

The model now only proposes candidates. It is also shown the list it is scored against — previously it saw titles from the `charts` table, so multi-dim and explorer views never reached it, and on Climate Change it was proposing terms having seen 67 of 714 records.

## What it produces

Median **87%** of a topic's views covered; 2 topics below 35%; 6 topics with a single term, all of which have between four and seventeen charts.

| Topic | Suggested | Views covered |
| --- | --- | --- |
| Gender Ratio | sex ratio, female population, life expectancy, missing women, unemployment | 99% |
| Poverty | GDP per capita, extreme poverty, relative poverty, multidimensional poverty, national poverty lines | 78% |
| Religion | religion, religious affiliation, pray, religious services, trust | 97% |
| Energy | electricity, CO₂ emissions, primary energy, battery, solar | 86% |
| Climate Change | temperature anomalies, carbon dioxide, population, sea ice extent, electricity | 43% |

`--report out.html` writes each term's own and additional coverage plus the most-viewed charts nothing reaches; the numbers also go into the published JSON as `keyword_stats`, so a line on the site can be explained later.

## Worth knowing before merging

- **A full run overwrites the key the site reads.** `--upload-path` takes any key in the `owid-public` bucket, which is how a regeneration gets tried on a staging server first. Nothing in production reads the vocabulary yet — that arrives with owid/owid-grapher#7016 — so today the blast radius is nil, and it isn't afterwards. A *partial* run can't do it at all: the file replaces the vocabulary rather than merging into it, so a `--topic` run refuses to publish to that key and says where its result can go instead.
- **A run needs chart view data and refuses without it.** `analytics_chart_views` is empty in a local database (it ships only in the private dump); point `OWID_ENV` at staging or production, run `make refresh.private`, or pass `--weighting uniform`. It aborts rather than silently weighting everything zero.
- **Two poor terms are known and left in**: `death rates` on Life Expectancy, where no chart is called that, and `projections` on Population Growth, which reaches 70% of the topic through subtitle boilerplate. Tightening the prompt further has been trading one topic against another for several rounds, so the report is the way to catch the next one rather than another rule.

<details><summary>Details</summary>

### Files

- **`coverage_model.py`** (new) — the topic's record set, a weight per record, which records each term would put on screen, and the greedy selection.
- **`coverage_report.py`** (new) — one line per topic to stdout, full per-term arithmetic to HTML.
- **`vocabulary.py`** — phases reordered (bulk SQL → universe → LLM → selection); `refine_keywords_with_llm` and the per-candidate search fan-out deleted; new flags.
- **`README.md`** — rewritten "How It Works", the view-data requirement, the new flags.

### Where the numbers come from

The universe is every record in the `explorer-views-and-charts` index carrying the topic's tag, fetched from Algolia directly (one request per topic, paged for the three topics above 1,000 records). Algolia rather than `/api/search` because the row filter needs `datasetProducers`, which the public API does not return — so the producer half of the match was dead when measured through it.

Coverage is computed locally with a transcription of the block's own row filter (`textContainsAllQueryWords`): every word of the term present in one of the row's *rendered* texts — title, subtitle, or a producer — since Algolia matches far more loosely, through `tags`, `availableEntities`, the slug, typo tolerance and synonyms. That is why "artificial intelligence" looked alive on Technological Change while showing nothing: its six matches all say "AI". The transcription is verified against the real TS function on 18 cases including `CO₂`, `Côte`, `PM2.5`, `R&D` and `*bold*` stripping — zero mismatches, because a Python-idiomatic slugifier disagrees on exactly the rows this predicts.

Weights come from `analytics_chart_views.views_365d`, the only table with per-view granularity — which matters because multi-dim and explorer pages contribute one record per view and dominate some topics. Plain charts join on slug; multi-dim views join through their config id, rebuilt from the view's dimension choices; explorer views cannot be joined per view (their records carry no config id) so each takes its explorer's average, and the report says how many records fell back that way. Latest snapshot day only — the primary key allows several and summing them would multiply every weight.

### Selection rules

- **Blunt terms.** A term revealing more than half a topic — of its views *or* its charts — is held back, and used only when the sharper terms together cannot reach that same half. Both measures are needed: "tuberculosis" reaches 50 of that topic's 52 charts but only 47% of its views, and taking it made every real term a subset that added nothing, so coverage hit 100% with three blunt terms. One constant for both halves of the rule, reported per topic.
- **Stopping.** At most 8 terms (the site shows 5), stopping when the next would reveal under 1% of the topic's views. Terms that just missed are printed.
- **Tie-breaks**, in order: more additional weight, more additional charts, more own coverage, fewer words, then the order the candidates arrived in — so runs are reproducible.
- **`topic_name_share`** records what a topic's own name alone reaches. Half of Life Expectancy's traffic is one chart called "Life expectancy", so its ceiling is genuinely low; the report prints this over 20% so a low number reads as a ceiling rather than a fault.

### Reproducibility

Sampling is pinned (temperature 0, fixed seed). Without it two runs of identical code disagreed on nearly every topic — the same Gender Ratio came back at 30% coverage in one run and 79% in the next — which made every prompt change indistinguishable from luck. Verified: two consecutive runs produce byte-identical vocabularies.

### Robustness

Transient 5xx/429 are retried with backoff. A run that still cannot complete every topic **refuses to upload** and exits non-zero, after writing whatever `--output` asked for: previously those topics were logged and dropped, and the partial file was uploaded over a complete one. A `--topic` run refuses the production key up front, before spending anything, and the output is always keyed by topic slug — a single-topic run used to write a bare entry object, which the site's parser reads as no topics at all. `get_all_topic_slugs` also no longer counts the NULL slug as a topic.

### Cost

125 topics in ~25 s: one Algolia request per topic (~130), one LLM call per topic, three bulk SQL queries. Was ~3 min and ~1,000 search requests with two LLM calls per topic.

</details>

