### PR TITLE
🐛 Read grapher views from prod_ga4, on the resolved chart identity

### DIFF
--- a/apps/wizard/app_pages/producer_analytics/charts.py
+++ b/apps/wizard/app_pages/producer_analytics/charts.py
@@ -74,7 +74,7 @@ class UIChartProducerAnalytics:
         df_top_10_daily_views = get_chart_views_from_bq(
             date_start=min_date,
             date_end=max_date,
-            groupby=["day", "grapher"],
+            groupby=["day", "chart_url"],
             grapher_urls=grapher_urls_top_10,
         )
 
@@ -85,7 +85,7 @@ class UIChartProducerAnalytics:
             0 if self.analytics["total_views"] == 0 else df_total_daily_views["renders"].mean()
         )
         ## Get total views of the top 10 charts in the selected date range.
-        self.analytics["df_top_10_total_views"] = df_top_10_daily_views.groupby("grapher", as_index=False).agg(
+        self.analytics["df_top_10_total_views"] = df_top_10_daily_views.groupby("chart_url", as_index=False).agg(
             {"renders": "sum"}
         )
 
@@ -159,11 +159,11 @@ class UIChartProducerAnalytics:
         # Prepare dataframe to plot.
         df_plot = pd.concat(
             [
-                df_total_daily_views.assign(**{"grapher": "Total"}),
+                df_total_daily_views.assign(**{"chart_url": "Total"}),
                 df_top_10_daily_views,
             ]
         ).rename(
-            columns={"grapher": "Chart slug"},
+            columns={"chart_url": "Chart slug"},
         )
         df_plot["Chart slug"] = df_plot["Chart slug"].apply(lambda x: x.split("/")[-1])
         df_plot["day"] = pd.to_datetime(df_plot["day"]).dt.strftime("%Y-%m-%d")

--- a/apps/wizard/app_pages/producer_analytics/data_io.py
+++ b/apps/wizard/app_pages/producer_analytics/data_io.py
@@ -10,7 +10,7 @@ import owid.catalog.processing as pr
 import pandas as pd
 import streamlit as st
 
-from apps.wizard.app_pages.producer_analytics.utils import GRAPHERS_BASE_URL, MIN_DATE, TODAY
+from apps.wizard.app_pages.producer_analytics.utils import MIN_DATE, TODAY
 from apps.wizard.utils.components import st_cache_data
 from etl.analytics.data import get_visualizations_using_data_by_producer
 from etl.google import read_gbq
@@ -56,7 +56,7 @@ def get_chart_views(min_date: str, max_date: str) -> pd.DataFrame:
             date_start=date_start,
             date_end=date_end,
             grapher_urls=None,
-            groupby=["grapher"],
+            groupby=["chart_url"],
         ).rename(columns={"renders": column_name})
         for column_name, (date_start, date_end) in date_ranges.items()
     ]
@@ -64,10 +64,9 @@ def get_chart_views(min_date: str, max_date: str) -> pd.DataFrame:
     # Merge all data frames.
     df = pr.multi_merge(
         dfs,  # ty: ignore
-        on="grapher",
+        on="chart_url",
         how="outer",
     )
-    df = df.rename(columns={"grapher": "chart_url"})
 
     return df
 
@@ -79,18 +78,22 @@ def get_chart_views_from_bq(
     groupby: list[str] | None = None,
     grapher_urls: list[str] | None = None,
 ) -> pd.DataFrame:
+    # Identify charts by the resolved `chart_url`, not by `grapher` (the URL exactly as GA4 recorded
+    # it): that one is truncated at 126 characters and may be a slug the chart has since been renamed
+    # away from, so grouping on it splits or zeroes a chart's views (owid/analytics#733). `chart_url`
+    # is NULL for anything that is not a published chart (explorers, MDIMs, deleted charts).
     grapher_filter = ""
     if grapher_urls:
         # If a list of grapher URLs is given, consider only those.
         grapher_urls_formatted = ", ".join(f"'{url}'" for url in grapher_urls)
-        grapher_filter = f"AND grapher IN ({grapher_urls_formatted})"
+        grapher_filter = f"AND chart_url IN ({grapher_urls_formatted})"
     else:
-        # If no list is given, consider all grapher URLs.
-        grapher_filter = f"AND grapher LIKE '%%{GRAPHERS_BASE_URL}%%'"
+        # If no list is given, consider all published charts.
+        grapher_filter = "AND chart_url IS NOT NULL"
 
     if not groupby:
         # If a groupby list is not given, assume the simplest case, which gives total views for each grapher.
-        groupby = ["grapher"]
+        groupby = ["chart_url"]
 
     # Prepare the query.
     groupby_clause = ", ".join(groupby)
@@ -98,7 +101,7 @@ def get_chart_views_from_bq(
     query = f"""
         SELECT
             {select_clause}
-        FROM prod_ga4.grapher_views_by_day_page_grapher_device_country_iframe
+        FROM prod_ga4.grapher_views_detailed
         WHERE
             day >= '{date_start}'
             AND day <= '{date_end}'

--- a/apps/wizard/app_pages/producer_analytics/summary.py
+++ b/apps/wizard/app_pages/producer_analytics/summary.py
@@ -30,7 +30,7 @@ class UISummary:
         for _, row in (
             self.ui_charts.analytics["df_top_10_total_views"].sort_values("renders", ascending=False).iterrows()
         ):
-            df_summary_str += f"{row['renders']:9,}" + " - " + row["grapher"] + "\n"
+            df_summary_str += f"{row['renders']:9,}" + " - " + row["chart_url"] + "\n"
 
         # Define the content to copy.
         summary = f"""Analytics of charts using data by {producers_selected_str} between {min_date} and {max_date}:

--- a/etl/analytics/config.py
+++ b/etl/analytics/config.py
@@ -21,6 +21,11 @@ MAX_DATASETTE_N_ROWS = 10000
 # resolved. See owid/analytics#735 (DuckDB → BigQuery migration).
 SEMANTIC_LAYER_SCHEMA = "prod_semantic"
 
+# Schema (BigQuery dataset) where the GA4 aggregates live, on the same connection. The grapher-view
+# aggregate used to be copied into the semantic layer as well; owid/analytics#987 consolidated the two
+# into `prod_ga4.grapher_views_detailed` and deleted the semantic copy.
+GA_SCHEMA = "prod_ga4"
+
 # Base OWID URL, used to find views in articles and topic pages.
 OWID_BASE_URL = "https://ourworldindata.org/"
 

--- a/etl/analytics/data.py
+++ b/etl/analytics/data.py
@@ -8,6 +8,7 @@ from etl.analytics.config import (
     COMPONENT_TYPES_TO_LINK_GDOCS_WITH_VIEWS,
     DATE_MAX,
     DATE_MIN,
+    GA_SCHEMA,
     GRAPHERS_BASE_URL,
     OWID_BASE_URL,
     POST_LINK_TYPES_TO_URL,
@@ -64,7 +65,9 @@ def get_number_of_days(
     date_max : str
         Maximum date to consider.
     table_name : str
-        Name of the DB table to query for the maximum informed date.
+        Name of the DB table to query for the maximum informed date, qualified with its schema
+        (BigQuery dataset), e.g. "prod_ga4.grapher_views_detailed". The tables involved no longer all
+        live in the same dataset, so the caller says which one.
     day_column_name : str
         Name of the column in the DB table that contains the date.
 
@@ -84,7 +87,7 @@ def get_number_of_days(
         )
 
     # There is always a lag in analytics, so we need to find out the maximum date informed in the analytics data.
-    query = f"SELECT MAX({day_column_name}) AS date_max FROM {SEMANTIC_LAYER_SCHEMA}.{table_name}"
+    query = f"SELECT MAX({day_column_name}) AS date_max FROM {table_name}"
     date_max_informed = read_analytics(sql=query)["date_max"].item()
     date_end = min(pd.to_datetime(date_max_informed), pd.to_datetime(date_max))
 
@@ -136,6 +139,9 @@ def get_chart_views_per_day_by_chart_id(
 
     where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
 
+    # Join on the resolved `chart_id`, not on the URL as GA4 recorded it: that URL is truncated at 126
+    # characters and may be a slug the chart has since been renamed away from, so matching it against
+    # the chart's current URL loses views (owid/analytics#733).
     query = f"""
     SELECT
         c.chart_id,
@@ -143,7 +149,7 @@ def get_chart_views_per_day_by_chart_id(
         v.day,
         SUM(v.events) AS events
     FROM {SEMANTIC_LAYER_SCHEMA}.charts c
-    JOIN {SEMANTIC_LAYER_SCHEMA}.grapher_views_detailed v ON c.url = v.grapher
+    JOIN {GA_SCHEMA}.grapher_views_detailed v ON v.chart_id = c.chart_id
     {where_sql}
     GROUP BY c.chart_id, c.url, v.day
     ORDER BY c.chart_id, v.day ASC;
@@ -187,6 +193,9 @@ def get_chart_views_by_chart_id(
 
     where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
 
+    # Join on the resolved `chart_id`, not on the URL as GA4 recorded it: that URL is truncated at 126
+    # characters and may be a slug the chart has since been renamed away from, so matching it against
+    # the chart's current URL loses views (owid/analytics#733).
     query = f"""
     SELECT
         c.chart_id,
@@ -194,7 +203,7 @@ def get_chart_views_by_chart_id(
         c.published_at,
         SUM(v.events) AS views
     FROM {SEMANTIC_LAYER_SCHEMA}.charts c
-    JOIN {SEMANTIC_LAYER_SCHEMA}.grapher_views_detailed v ON c.url = v.grapher
+    JOIN {GA_SCHEMA}.grapher_views_detailed v ON v.chart_id = c.chart_id
     {where_sql}
     GROUP BY c.chart_id, c.url, c.published_at
     ORDER BY views DESC
@@ -206,7 +215,7 @@ def get_chart_views_by_chart_id(
         published_at=df_views["published_at"],
         date_min=date_min,
         date_max=date_max,
-        table_name="grapher_views_detailed",
+        table_name=f"{GA_SCHEMA}.grapher_views_detailed",
         day_column_name="day",
     )
 
@@ -323,7 +332,7 @@ def get_post_views_by_url(
     df_views["n_days"] = get_number_of_days(
         date_min=date_min,
         date_max=date_max,
-        table_name="views_detailed",
+        table_name=f"{SEMANTIC_LAYER_SCHEMA}.views_detailed",
         day_column_name="day",
     )
 


### PR DESCRIPTION
Two BigQuery tables this repo reads **stopped being maintained on 2026-07-30**, when [owid/analytics#987](https://github.com/owid/analytics/pull/987) consolidated the grapher-view aggregate into `prod_ga4.grapher_views_detailed` and deleted the semantic-layer copy. dbt doesn't drop removed models, so both tables still exist — frozen. Nothing errors; the numbers just stop moving, and the gap grows daily.

```
prod_ga4.grapher_views_detailed        MAX(day) = 2026-08-19   ← maintained
prod_semantic.grapher_views_detailed   MAX(day) = 2026-07-29   ← what this repo reads today
prod_ga4.grapher_views_by_day_page_grapher_device_country_iframe  frozen 2026-07-30
```

**What has been showing stale numbers for three weeks:** chart-diff's views column (`get_chart_views_last_n_days` → `get_chart_views_by_chart_id`), `etl/scripts/create_report_for_data_producer.py`, and the producer-analytics wizard page. A 30-day window against a table that ends 2026-07-29 is now mostly empty, and will be entirely empty in a few days.

## The change

Four call sites repointed to `prod_ga4.grapher_views_detailed` — and the identity column switched in the same pass, because a bare rename would have kept a real undercount.

Both sites matched charts to views on `grapher`, the URL exactly as GA4 recorded it:

```sql
JOIN {SEMANTIC_LAYER_SCHEMA}.grapher_views_detailed v ON c.url = v.grapher   -- data.py
```
```python
grapher_filter = f"AND grapher IN ({grapher_urls_formatted})"                 # wizard
...
df = df.rename(columns={"grapher": "chart_url"})
```

GA4 truncates that URL at 126 characters, and articles keep embedding slugs a chart has since been renamed away from — so matching it against the chart's *current* URL silently drops views ([owid/analytics#733](https://github.com/owid/analytics/issues/733), the bug that reached the housekeeper queue, grapher admin and Algolia ranking). Both GA tables now carry a resolved `chart_id` / `chart_url` ([analytics#986](https://github.com/owid/analytics/pull/986)), so:

- **`etl/analytics/data.py`** joins `ON v.chart_id = c.chart_id`. `chart_id` rather than `chart_url` because it is stable across a rename, while `chart_url` can lag between backfills.
- **the wizard** filters and groups on `chart_url`, which is already the column name the producer table merges on — so the `grapher` → `chart_url` rename afterwards disappears. The catch-all filter becomes `chart_url IS NOT NULL` (i.e. published charts) in place of `grapher LIKE '%…/grapher/%'`.
- **`get_number_of_days`** now takes a schema-qualified table name; the two tables it's called with no longer live in the same dataset. New `GA_SCHEMA = "prod_ga4"` in `etl/analytics/config.py`, since `SEMANTIC_LAYER_SCHEMA` is still right for `charts`, `pages` and `views_detailed`.

## Effect of the join-key change, measured

Holding the table constant (both sides read `prod_ga4.grapher_views_detailed`) so this isolates the join key, over the last 365 days:

| | |
|---|---|
| charts gaining views | **157** |
| charts going from a hard **0** to a real number | **25** (the >126-char URLs) |
| views recovered | **+1,012,006** |
| charts losing views | 0 |

Largest movers:

| chart | before | after |
|---|---|---|
| `global-primary-energy-by-source` | 7,157 | **346,153** |
| `share-of-primary-energy-by-source` | 2,552 | **145,223** |
| `computation-used-to-train-notable-artificial-intelligence-systems` | 8,037 | **78,442** |
| `primary-energy-by-source` | 977 | **42,812** |

Producer analytics and producer reports have been understating these charts by up to ~48×, on top of the three-week staleness.

## Validation

- All 7 SQL shapes the changed code generates (both `data.py` queries, both `get_number_of_days` call sites, all three wizard `groupby` combinations) **dry-run clean against BigQuery**; ≈$0.014 if every one ran once.
- `make check` (ruff lint + format + `ty`) green — it runs as the pre-commit hook here.
- `pytest tests/apps/wizard`: 12 passed, 4 failed — the same 4 fail identically on unmodified `master` in this environment (`Can't connect to MySQL server on 'localhost'`), so they need a local grapher DB and are unrelated.
- Column formats match on both sides: the GA table's `chart_url` is `'https://ourworldindata.org/grapher/' || slug`, exactly what `get_visualizations_using_data_by_producer` builds with `CONCAT('{GRAPHERS_BASE_URL}', cc.slug)`.

## Note for whoever merges

The two frozen tables are due to be moved to `prod_legacy` on the analytics side ([owid/analytics#985](https://github.com/owid/analytics/issues/985)). **That move has to wait for this PR to merge and deploy** — until then those reads still resolve, and dropping the tables first would turn silent staleness into a hard failure in chart-diff and the wizard.

Context: [owid/analytics#975](https://github.com/owid/analytics/issues/975) (the housekeeper/chart-views audit this fell out of), [#985](https://github.com/owid/analytics/issues/985) (consumer repointing), [#987](https://github.com/owid/analytics/pull/987) (the consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
