### PR TITLE
🐛🤖 Fold the first live Figma run: two-pass export validated, two recipe bugs fixed

### DIFF
--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -97,6 +97,12 @@ What is independent, and today is not batched:
 - **The Step 8c property sweeps** — font sizes, stroke weights, dash patterns, fills, polylines. Those are reads of a single page, so they collapse into *one* `use_figma` returning one JSON. `scripts/verify_templates.js` already does exactly this for ten templates.
 - **The arrow probe's baseline render.** Only the FULL render is shared across arrows: the other three states of the four-render protocol (no-arrow, no-target, both-hidden) each hide *that pair's* nodes, so they are pair-specific and cannot be reused. N arrows cost `3N + 1` screenshots, not `4N` — and not `N + 2`, which under-collects and produces masks containing another pair's target.
 
+**Measured on one template, end to end: 18 Figma calls.** Of those, 3 went on the footer-conversion
+bug now fixed in TEXTS.md and 1 on a wrong guess about the footer's layout, so the same build now
+costs ~14 — against ~21 per template on the previous run and 124–188 for a whole chart before any of
+this. The two-pass export is where the saving is concentrated: it replaces "export, eyeball, re-export"
+with one probe and one solved re-export.
+
 **What is serial for a reason — don't collapse these:**
 
 | Sequence | Why |

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -64,11 +64,32 @@ The chart spans the full content width, left-aligned with the title/subtitle/log
 > you have already unwrapped — delete the text first, after which the bbox *is* the canvas and one
 > rescale lands the height on the template's to `delta 0`.
 
+### The two-pass export, measured end to end
+
+Validated on a live run rather than argued from the model, so the numbers are the claim:
+
+| | pass 1 (model inset) | pass 2 (measured inset) |
+|---|---|---|
+| `imFontSize` | 29 (solved for 13.5px labels) | 29 (carried — the inset is only valid at its own font) |
+| declared, predicted → returned | 849×601 → **849×601** | 869×587 → **868×587** |
+| inset used | 40.6 / 40.6 (symmetric model) | **69.75 / 33.72** (measured) |
+| `xMapShortfall` | **24.47px** | **0.15px** |
+
+Two things worth taking from it. The probe's canvas prediction was *exact* (849×601 to the pixel), so
+a pass-1 miss is never the canvas arithmetic — it is the inset, and only the inset. And the inset read
+**identically** on both imports (69.75/33.72 against declared sizes 20px apart), which is the
+stability the second pass depends on: measured drift 0.00px, against the ~2px the docs claim. One
+`nextPass` command, run as printed, landed the fit with **no correction** — 14px gap top, 13.91
+bottom, right edge 523.96 against a 524 content box.
+
 ### An upload lands on the file's *current* page — which is not your page
 
 `upload_assets` places the import on whatever page the file currently has open, and page context is
-not what your last `use_figma` call set. On a real run that meant SVG imports quietly piling up on the
-file's **Cover** page, in a shared file, until someone noticed.
+not what your last `use_figma` call set. It landed on the file's **Cover** page on three consecutive
+uploads in one run — including immediately after a `use_figma` call that had switched to the working
+page — so treat this as the invariant, not a hazard you might dodge: **every** upload needs the
+reparent below, and the `placedOnNodeId`'s PAGE ancestor is worth logging every time so a wrong
+landing is visible in the tool result rather than discovered later.
 
 So treat the returned `placedOnNodeId` as the only reliable handle: fetch it with
 `getNodeByIdAsync`, `appendChild` it onto the page you meant, and **check the page it came from is

--- a/.claude/skills/create-figma-chart/reference/GOTCHAS.md
+++ b/.claude/skills/create-figma-chart/reference/GOTCHAS.md
@@ -133,10 +133,13 @@ not in the type file, for that reason — the worked examples stay in `reference
     Vertical fits at **1.30x**, an upscale, so the same multiplier *thickens*: its line arrived at 2.61
     and its halo at 3.91 and both had to come **down** to 2/3. So the rule is not "restore what the
     rescale thinned" but "set every stroke after the scale, whichever way the scale went".
-  - **The reference tells you the rescale changed it. It does not tell you the target.** `imType=square`
-    ships 4/5 and `uncaptioned` ships 2/3 — and the house weight is **3 with a 4px halo**, i.e. neither
-    of them. Use the comparison to *notice*, then set the house value, keeping the halo one px above
-    the line.
+  - **The reference tells you the rescale changed it. It does not tell you the target.** The two export
+    routes ship different weights, and neither is a reliable stand-in for the house value — measured on
+    one chart, `imType=square` came back **line 3 / outline 4** and `imType=uncaptioned` **line 1.5 /
+    outline 2.5**, before any fit. So the square route happens to arrive at the house weight and the
+    uncaptioned route at 40% of it: read the fitted frame and set **3 with a 4px halo** explicitly.
+    Use the comparison to *notice*, never to source the number — and note that a square reference will
+    agree with the house value and so cannot tell you whether the repair ran.
   - **3/4 holds across the static and IG templates regardless of frame width.** I set the 850-wide
     Static Vertical to 2/3 on a rule I invented — "a wider plot wants a relatively thinner line" — and
     on a 1095-tall frame it read thin. Don't derive a weight from the frame size; 3/4 is the value.

--- a/.claude/skills/create-figma-chart/reference/TEXTS.md
+++ b/.claude/skills/create-figma-chart/reference/TEXTS.md
@@ -33,16 +33,39 @@ Replace the lorem-ipsum text nodes in the cloned template. Source everything fro
   const BOTTOM = footer.y + footer.height;       // read off the clone, before anything moves
   source.textAutoResize = "WIDTH_AND_HEIGHT";    // one line, its natural width
   footer.layoutMode = "VERTICAL";                // the actual operation — not a y assignment
+  footer.primaryAxisSizingMode = "AUTO";         // REQUIRED — see below; without it the row overflows
   footer.itemSpacing = 4;                        // the row pitch both shipped two-row footers use
   footer.counterAxisAlignItems = "MIN";          // left-align, so CC BY sits under the source
-  footer.y = BOTTOM - footer.height;             // re-pin the designed bottom edge after it grows
+  // Re-pin in a LATER call, or from the rows' own extent — footer.height is stale in this one:
+  footer.y = BOTTOM - Math.max(...footer.children.map((c) => c.y + c.height));
   ```
 
-  The frame hugs its own height on the new axis, so there is no `resize` to do — and re-read `footer.height` afterwards rather than assuming 36, since it now falls out of the rows.
+  **`primaryAxisSizingMode = "AUTO"` is not optional, and leaving it out fails silently.** On a
+  VERTICAL auto-layout the *primary* axis is the vertical one, so height is governed by
+  `primaryAxisSizingMode` — not `counterAxisSizingMode`, and not `layoutSizingHorizontal`. DI's
+  `Frame 37` ships **`FIXED`** (measured 2026-08-20, alongside `layoutSizingVertical: "FIXED"`), so
+  turning the axis alone leaves the box at its one-row **16px** while the second row renders *below*
+  it: CC BY sits at `y: 20, h: 16` inside a frame whose `height` still reads 16. Nothing errors, both
+  rows draw, and every geometry read — `footer.height`, the band bottom, the gap — is wrong by 20px
+  in the direction that makes the chart look fine and the footer overhang the artboard.
+
+  **And `footer.height` does not settle inside the call that changed `layoutMode`.** Re-pinning with
+  `BOTTOM - footer.height` in that same call therefore subtracts the *old* height and moves the footer
+  nowhere. Pin from `Math.max(...children.map(c => c.y + c.height))`, which is live, or split the
+  re-pin into the next call. Verified on this template: content extent 36, `footer.y` 488, bottom
+  landing exactly on the clone's 524.
 
   **Take `BOTTOM` from the clone rather than typing it.** It is 524 in a 540-wide template, and the footer edge differs in every template (Step 7's table) — hardcoding the square template's value lifts the footer off the bottom everywhere else. Then re-fit the chart into what's left (Step 7). Only if the source is too long even for a full line — beyond the template's content width — wrap it with `textAutoResize = "HEIGHT"` at a width that breaks after the organization's name, and top-align CC BY with its first line. Either way CC BY is **left-aligned** once it has its own row — it only sits at x=468 while it shares the source's line.
 
   **The `source.y = -20` variant only works on a footer whose children are NOT flowed.** It leaves the footer's own geometry untouched — nothing else in the template shifts — and the band's real bottom becomes `footer.y + source.y`, which is the number to feed Step 7. But it is a `y` assignment, so auto-layout discards it on every current template: check `layoutPositioning` on the child first (`"ABSOLUTE"` means it will hold, `"AUTO"` means it won't). It is recorded here because the file's own older finished pages use it, from when those footers were absolute.
+
+  **Diagnose the overrun by measuring the source's own width, not by reasoning about the layout.**
+  DI's `Frame 37` is already `primaryAxisAlignItems: "SPACE_BETWEEN"` and already FIXED at 508, which
+  makes its `itemSpacing: 220` inert — so "the fixed spacing is pushing CC BY off" is a plausible
+  story that costs a wasted write to disprove. Read `source.width`: on this run it was **535** against
+  the 508 content box, i.e. the line genuinely does not fit, and CC BY's `x: 535` was just the source's
+  own right edge. The arithmetic that decides the fix is then one division — 508/535 needs a **0.949**
+  factor, so 14px must drop to 13 (13.5 leaves it at 516, still over).
 
   **And know when *not* to spend the second row.** A source that overruns CC BY by only a few pixels is not worth 20px of chart: the full FAO name at the Source style's 14px measured 473px against CC BY starting at x=468 — a 2px overlap — and the finished page's answer was to set that one line to **13px** and keep the footer one row deep. Weigh the two costs explicitly (one off-ladder size on the least important text, versus a fifth of the gap budget and a re-export) and record whichever you pick.
 - **Note:** only in templates that carry a Note line, and only if the chart has one worth keeping. **DI images normally carry no note at all** — drop it, or, when it's genuinely load-bearing for understanding the chart, fold it into the subtitle as a bolded second line (only if the subtitle isn't already crowded).

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -38,13 +38,21 @@ Why the model is only a probe: the `1.4 * imFontSize` figure is symmetric, and t
 Measured on an `imType=uncaptioned` line chart that reserves a right margin for a direct entity
 label:
 
-    imFontSize 30 -> insetX 64.1, insetY 29.0   (model predicts 42.0 / 42.0)
-    imFontSize 21 -> insetX 70.6, insetY 40.8   (model predicts 29.4 / 29.4)
+    imFontSize 30 -> insetX 64.1, insetY 29.0   (model predicts 42.0 / 42.0)   democracy index
+    imFontSize 21 -> insetX 70.6, insetY 40.8   (model predicts 29.4 / 29.4)   democracy index
+    imFontSize 29 -> insetX 69.8, insetY 33.7   (model predicts 40.6 / 40.6)   CO2 per capita
 
 The model is right for the charts it was measured on — the recorded examples come out ~44/46 at
 imFontSize 32 — and wrong by 2x on the horizontal axis for this class. Note also that insetY got
-*larger* as the font got *smaller*: the inset is not a simple function of imFontSize, so don't try to
-fit one from a couple of runs. Measure it. And the measured inset pins the font — pass 2 keeps the
+*larger* as the font got *smaller*, and that the third row above sits at a *higher* insetX than the
+first despite a lower font: the inset is a property of the CHART (how much right margin its direct
+labels reserve, how wide its axis ticks are), not a function of imFontSize. Don't try to fit one from
+a few runs. Measure it.
+
+What IS stable — and is the whole reason pass 2 works — is the inset at a FIXED imFontSize across the
+aspect change pass 2 makes. Measured live on the CO2 chart: pass 1 declared 849x601 and pass 2
+declared 868x587, and the inset read 69.75/33.72 on both, i.e. **0.00px of drift**. The x-map leftover
+went from 24.47px on the probe to 0.15px on the measured pass — sub-pixel, no correction needed. And the measured inset pins the font — pass 2 keeps the
 imFontSize the inset was measured at rather than re-bisecting for a label target, because changing
 the font invalidates the measurement.
 
@@ -220,6 +228,10 @@ def self_test() -> int:
     for label_, bw, bh, ix, iy, dw, dh in [
         ("square", 508.0, 409.0, 64.08, 29.04, 837.0, 609.0),
         ("desktop", 818.0, 521.0, 70.60, 40.80, 921.0, 554.0),
+        # Measured end to end on a live run: probe at imFontSize 29 declared 849x601 and inked
+        # 779.25x567.28 (inset 69.75/33.72); the pass-2 solve below predicted 869x587 and grapher
+        # returned 868x587, landing the x-map leftover at 0.15px.
+        ("co2 DI", 508.0, 380.0, 69.75, 33.72, 868.0, 587.0),
     ]:
         a = target_aspect(bw, bh, DEFAULT_GAP)
         w, h = solve_canvas(a, ix, iy)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

First end-to-end run of `solve_export.py` and `measure_fit.js` **inside Figma** — the test the previous six PRs could not perform, since `measure_fit.js` only executes through `use_figma`. Chart: `co-emissions-per-capita?country=USA~CHN`, DI template, on a disposable test page.

Both scripts worked on the first try. The run validated the design they encode and found two real bugs in the docs around them.

## The two-pass export lands

| | pass 1 (model inset) | pass 2 (measured inset) |
|---|---|---|
| declared, predicted → returned | 849×601 → **849×601** | 869×587 → **868×587** |
| inset used | 40.6 / 40.6 (symmetric model) | **69.75 / 33.72** (measured) |
| `xMapShortfall` | **24.47 px** | **0.15 px** |

The `nextPass` command `measure_fit.js` printed, run verbatim, landed the fit with **no correction**: 14px / 13.91px gaps, right edge 523.96 against a 524 content box.

Two findings worth more than the headline:

- **The probe's canvas prediction was exact to the pixel** (849×601). So a pass-1 miss is never the canvas arithmetic — it is the inset, and only the inset.
- **The inset read identically on both imports** — 69.75 / 33.72 across declared sizes 20px apart. Measured drift **0.00px**, against the ~2px the docs claimed. That stability is the whole basis of the second pass, and it now has a live measurement instead of an argument.

Recorded in `FITTING.md` as a table, and added to `solve_export.py --self-test` as a third measured-inset case so it guards against regression.

## Two recipe bugs, both silent

**`TEXTS.md` said a VERTICAL footer hugs its own height. It does not.** DI's `Frame 37` ships `primaryAxisSizingMode: FIXED`, so turning the axis leaves the box at its one-row 16px while the second row renders *below* it — CC BY at `y: 20, h: 16` inside a frame whose `height` still reads 16. The band, the gap and the footer's own bottom edge are then all wrong by 20px, nothing errors, and both rows draw. Fixed, with the required `primaryAxisSizingMode = "AUTO"` in the recipe.

**`footer.height` is stale inside the call that changes `layoutMode`.** The recipe's `footer.y = BOTTOM - footer.height` therefore subtracts the *old* height and moves the footer nowhere. Now pins from the rows' own extent, which is live.

## Corrections to recorded facts

- **The inset is a property of the chart, not of `imFontSize`.** A third measurement (F=29 → 69.8/33.7) sits *above* the F=30 one (64.1/29.0), so the docstring no longer implies a font relationship — it says measure it, and why.
- **Stroke weights per export route, measured:** `imType=square` ships line 3 / outline 4, `uncaptioned` ships 1.5 / 2.5. The previous "square 4/5, uncaptioned 2/3" was wrong, and the correction matters: a square reference *agrees* with the house 3/4 and so cannot confirm the repair ran.
- **The upload-lands-on-Cover gotcha is an invariant, not a hazard.** Three consecutive uploads landed on Cover, one immediately after a `use_figma` call that had switched pages. Every upload needs the reparent.
- **Diagnose a footer overrun by measuring `source.width`.** DI's footer is already `SPACE_BETWEEN` with `itemSpacing: 220` inert, so "the fixed spacing pushes CC BY off" is a plausible story that costs a wasted write to disprove. The source was genuinely 535 wide against a 508 box.

## Checks confirmed to fail when they should

Three defects were planted on the test frame and the Step 8c sweep caught all three: a series line left at 1.5 instead of the house 3, a label under the 12px floor, and ink pushed past the 524 content edge. The first attempt at the margin defect did *not* fire — because the nudge left the label at 500.96, still inside the box. That was an inadequate plant, not a blind spot; re-planted at 536 the check fired with the overrun named. Worth recording as the reason a "check the checks" pass needs its own verification.

The sweep also caught what the fit itself broke, unprompted: 11 furniture nodes left at **0.64px** and dashes at **[2.54, 2.54]** by `rescale()`. Repaired conditionally — every weight reset to 1px, but only nodes that *already* had a dash re-dashed, so the zero line and tick marks kept their empty pattern.

## Round trips

**18 Figma calls for one template**, of which 3 went on the footer bug now fixed and 1 on the wrong footer guess — so the same build now costs ~14, against ~21 per template on the previous run and 124–188 for a whole chart before any of this work.
