### PR TITLE
📊 Force re-upsert of energy_mix MDIM for view-level default selections

### DIFF
--- a/etl/steps/export/multidim/energy/latest/energy_mix.py
+++ b/etl/steps/export/multidim/energy/latest/energy_mix.py
@@ -1,5 +1,7 @@
 """Multidim for the energy mix (source x metric), based on Total Energy Supply."""
 
+# Force re-run to re-upsert view-level default entity selections (grapher #6922).
+
 import math
 from copy import deepcopy
 


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

[Let a multi-dim view define its own default entity selection (owid-grapher #6922)](https://github.com/owid/owid-grapher/pull/6922) changed how `upsertMultiDim` merges a view's own `selectedEntityNames` with the collection-wide default selection. That logic runs at upsert time, so the energy-mix MDIM's per-view configs stored in production were written with the old behavior and still pin the selection to World.

This PR only adds a comment to the export step so its checksum changes and production ETL re-runs it after the merge, re-upserting the views with the corrected default selections.

Other MDIM steps also set view-level `selectedEntityNames` (electricity_mix, fossil_fuels, covid) and will need the same nudge eventually; this PR deliberately covers only energy_mix.