### PR TITLE
📊 Force re-upsert of electricity_mix and fossil_fuels MDIMs

### DIFF
--- a/etl/steps/export/multidim/energy/latest/electricity_mix.py
+++ b/etl/steps/export/multidim/energy/latest/electricity_mix.py
@@ -1,5 +1,7 @@
 """Multidim for the electricity mix (source x metric, plus total-only metrics)."""
 
+# Force re-run to re-upsert view-level default entity selections (grapher #6922).
+
 import math
 from copy import deepcopy
 

--- a/etl/steps/export/multidim/energy/latest/fossil_fuels.py
+++ b/etl/steps/export/multidim/energy/latest/fossil_fuels.py
@@ -1,5 +1,7 @@
 """Multidim for fossil fuels (fuel x metric x per capita)."""
 
+# Force re-run to re-upsert view-level default entity selections (grapher #6922).
+
 import math
 from copy import deepcopy
 


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Same as [Force re-upsert of energy_mix MDIM for view-level default selections (#6735)](https://github.com/owid/etl/pull/6735), for the other two energy MDIMs that set view-level `selectedEntityNames`: electricity_mix and fossil_fuels. [owid-grapher #6922](https://github.com/owid/owid-grapher/pull/6922) changed the upsert-time merge logic, so their per-view configs stored in production still pin the selection to the collection-wide default.

Only a comment is added to each step so its checksum changes and production ETL re-runs the export after the merge.

Still pending after this: the covid collections also set view-level `selectedEntityNames` and will need the same nudge (or their next natural re-run).