### PR TITLE
✨ Show site-screenshots status in owidbot's comment

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -15,6 +15,9 @@ SVG_TESTER_SUITES = ("graphers", "grapher-views", "mdims", "thumbnails")
 # Written by devTools/svgTester/verify-graphs.ts, one per suite
 VERIFY_RESULTS_FILENAME = "verify-results.json"
 
+# Written by templates/lxc-manager/site-screenshots in owid/ops, next to the repos
+SCREENSHOTS_STATUS_FILENAME = "site-screenshots-status.json"
+
 # Mirrors SVG_TESTER_HEARTBEAT_STALE_MS in owid-grapher
 HEARTBEAT_STALE_SECONDS = 90
 
@@ -26,6 +29,7 @@ def run(branch: str, head_sha: str | None = None) -> str:
     container_name = get_container_name(branch)
 
     svgs_repo = BASE_DIR.parent / "owid-grapher-svgs"
+    screenshots_status = read_screenshots_status(BASE_DIR.parent / SCREENSHOTS_STATUS_FILENAME)
 
     results_by_suite = {suite: resolve_running(svgs_repo / suite) for suite in SVG_TESTER_SUITES}
 
@@ -54,7 +58,7 @@ def run(branch: str, head_sha: str | None = None) -> str:
     )
 
     body = f"""
-- **Site-screenshots:** https://github.com/owid/site-screenshots/compare/{branch}
+- **Site-screenshots:** {make_screenshots_line(screenshots_status, branch=branch, head_sha=head_sha)}
 - **SVG tester:** {make_report_url(container_name)}
 
 <details open>
@@ -75,6 +79,48 @@ def run(branch: str, head_sha: str | None = None) -> str:
     """.strip()
 
     return body
+
+
+def read_screenshots_status(path: Path) -> dict | None:
+    """Parsed site-screenshots-status.json, None when the file does not exist."""
+    if not path.exists():
+        return None
+
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("owidbot.site_screenshots.unreadable_status", path=str(path), error=str(e))
+        return {"status": "unreadable"}
+
+
+def make_screenshots_line(status: dict | None, branch: str, head_sha: str | None) -> str:
+    """The Site-screenshots line: the compare link, plus how the run that produced it went.
+
+    Worth stating because a failed run is invisible otherwise. The buildkite step soft
+    fails, and a run that fails commits nothing, so the compare link keeps showing the
+    previous run's diff - which reads exactly like a run that found no changes.
+
+    There is one status file for all branches, because every branch's screenshots are
+    taken in the same working copy on lxc-manager-1. A run of another branch that landed
+    in between therefore says nothing about ours, and is reported as not-yet-reported.
+    """
+    compare_url = f"https://github.com/owid/site-screenshots/compare/{branch}"
+
+    if status is None:
+        return compare_url
+
+    if status.get("status") == "unreadable":
+        return f"⚠️ status file unreadable: {compare_url}"
+
+    is_ours = status.get("branch") == branch and (not head_sha or status.get("grapherCommit") == head_sha)
+    if not is_ours:
+        pending = f"`{head_sha[:7]}`" if head_sha else "this commit"
+        return f"⏳ the run for {pending} hasn't reported yet: {compare_url}"
+
+    if status.get("status") == "ok":
+        return f"✅ {compare_url}"
+
+    return f"❌ the run failed, so {compare_url} is still the previous run's"
 
 
 def read_verify_results(suite_dir: Path) -> dict | None:

--- a/tests/apps/test_owidbot_grapher.py
+++ b/tests/apps/test_owidbot_grapher.py
@@ -1,0 +1,69 @@
+import json
+
+from apps.owidbot.grapher import make_screenshots_line, read_screenshots_status
+
+BRANCH = "some-branch"
+SHA = "0123456789abcdef0123456789abcdef01234567"
+COMPARE_URL = f"https://github.com/owid/site-screenshots/compare/{BRANCH}"
+
+
+def _status(**overrides) -> dict:
+    return {
+        "status": "ok",
+        "branch": BRANCH,
+        "grapherCommit": SHA,
+        "finishedAt": "2026-08-21T08:00:00+00:00",
+    } | overrides
+
+
+def test_no_status_file_leaves_the_link_alone():
+    # An ops host that predates the status file, or a run that hasn't happened
+    assert make_screenshots_line(None, branch=BRANCH, head_sha=SHA) == COMPARE_URL
+
+
+def test_successful_run_is_marked():
+    assert make_screenshots_line(_status(), branch=BRANCH, head_sha=SHA) == f"✅ {COMPARE_URL}"
+
+
+def test_failed_run_says_the_link_is_stale():
+    line = make_screenshots_line(_status(status="failed"), branch=BRANCH, head_sha=SHA)
+    assert line.startswith("❌")
+    assert "previous run" in line
+
+
+def test_status_from_another_branch_is_not_ours():
+    # One status file serves every branch: they share the working copy on lxc-manager-1
+    line = make_screenshots_line(_status(branch="other-branch"), branch=BRANCH, head_sha=SHA)
+    assert line.startswith("⏳")
+
+
+def test_status_from_an_earlier_commit_is_not_ours():
+    line = make_screenshots_line(_status(grapherCommit="f" * 40), branch=BRANCH, head_sha=SHA)
+    assert line.startswith("⏳")
+    assert SHA[:7] in line
+
+
+def test_missing_head_sha_falls_back_to_the_branch():
+    # The first owidbot run of a build has no head_sha to compare against
+    assert make_screenshots_line(_status(), branch=BRANCH, head_sha=None) == f"✅ {COMPARE_URL}"
+
+
+def test_unreadable_status_is_its_own_state(tmp_path):
+    path = tmp_path / "site-screenshots-status.json"
+    path.write_text("{ truncated mid-write")
+    status = read_screenshots_status(path)
+    assert status == {"status": "unreadable"}
+    assert make_screenshots_line(status, branch=BRANCH, head_sha=SHA).startswith("⚠️")
+
+
+def test_absent_file_reads_as_none(tmp_path):
+    assert read_screenshots_status(tmp_path / "site-screenshots-status.json") is None
+
+
+def test_status_written_by_the_ops_script_parses(tmp_path):
+    # The shape templates/lxc-manager/site-screenshots writes
+    path = tmp_path / "site-screenshots-status.json"
+    path.write_text(
+        json.dumps({"status": "ok", "branch": BRANCH, "grapherCommit": SHA, "finishedAt": "2026-08-21T08:00:00+00:00"})
+    )
+    assert make_screenshots_line(read_screenshots_status(path), branch=BRANCH, head_sha=SHA) == f"✅ {COMPARE_URL}"


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

owidbot's Site-screenshots line is a bare compare link, and a failed screenshot run is invisible in it. The buildkite step soft fails (owid/ops#639), and a run that fails commits nothing — so the link keeps showing the *previous* run's diff, which reads exactly like a run that found no changes. Yesterday six nginx `502 Bad Gateway` images were committed as one branch's screenshots, so the run now fails instead (owid/site-screenshots#8); this is the half that says so.

*Skim — one line in the comment, two small helpers, tests for the branches.*

## How it works

`bin/site-screenshots` on lxc-manager-1 writes `/home/owid/site-screenshots-status.json`, next to the repos. owidbot reads it the same way it already reads the SVG tester's `verify-results.json`, so this is a file read — **no Buildkite API, no token, and no waiting added to owidbot**, which was the concern worth checking before building it.

```
- **Site-screenshots:** ✅ https://github.com/owid/site-screenshots/compare/<branch>
- **Site-screenshots:** ❌ the run failed, so <link> is still the previous run's
- **Site-screenshots:** ⏳ the run for `abc1234` hasn't reported yet: <link>
```

Absent file → the bare link exactly as today, so this is inert until owid/ops#639 lands and `init.sh` syncs the script.

The non-obvious part: **one status file serves every branch**, because every branch's screenshots are taken in the same working copy on lxc-manager-1. A run of another branch can land between ours and owidbot's read, so branch *and* commit are both checked and anything else reports as not-yet-reported rather than as ours. `head_sha` is absent on the first owidbot run of a build, and there the branch match alone decides.

## Verified

`tests/apps/test_owidbot_grapher.py` covers the branches, including the two that would otherwise mislead — another branch's status and an earlier commit's status both reporting as not-yet-reported — plus a truncated file reading as its own state rather than as absent. `make check` clean.

Not verified end to end: that needs owid/ops#639 on the host. The first real exercise is the next build after both land.
