### PR TITLE
🐛🤖 chart-diff: apply the PRODUCTION/STAGING choice in the conflict resolver

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -36,6 +36,18 @@ EXCLUDE_METADATA_CHANGES = [
     "grapher/artificial_intelligence/.*/epoch",
 ]
 
+# Config fields that are environment- or bookkeeping-specific, so a difference in them is not a
+# difference in the chart. Used both when comparing configs and when resolving conflicts, so that
+# the conflict resolver does not ask users to "resolve" e.g. a version number.
+CONFIG_KEYS_IGNORE = (
+    "id",
+    "isPublished",
+    "bakedGrapherURL",
+    "adminBaseUrl",
+    "dataApiUrl",
+    "version",
+)
+
 
 @dataclass
 class ChartDiffScores:
@@ -1155,9 +1167,8 @@ def configs_are_equal(config_1: dict[str, Any], config_2: dict[str, Any], verbos
     assert "isInheritanceEnabled" in config_1, "isInheritanceEnabled must be in config_1"
     assert "isInheritanceEnabled" in config_2, "isInheritanceEnabled must be in config_2"
 
-    exclude_keys = ("id", "isPublished", "bakedGrapherURL", "adminBaseUrl", "dataApiUrl", "version")
-    config_1 = {k: v for k, v in config_1.items() if k not in exclude_keys}
-    config_2 = {k: v for k, v in config_2.items() if k not in exclude_keys}
+    config_1 = {k: v for k, v in config_1.items() if k not in CONFIG_KEYS_IGNORE}
+    config_2 = {k: v for k, v in config_2.items() if k not in CONFIG_KEYS_IGNORE}
 
     # Use pretty print to convert dicts to strings for comparison
     config_1_str = pprint.pformat(config_1, sort_dicts=True)

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -260,16 +260,6 @@ class ChartDiffShow:
             self._refresh_chart_diff()
 
         resolver = ChartDiffConflictResolver(self.diff, self.source_session)
-        col1, col2 = st.columns(2)
-        with col1:
-            st.warning("This is under development! Find below a form with the different fields that present conflicts.")
-        with col2:
-            st.button(
-                key=f"resolve-conflicts-{self.diff.chart_id}",
-                label="⚠️ Mark as resolved: Accept all changes from staging",
-                help="Click to resolve the conflict by accepting all changes from staging. The changes from production will be ignored. This can be useful if you're happy with the changes in staging as they are.",
-                on_click=_mark_as_resolved,
-            )
 
         # If things to compare...
         if resolver.config_compare:
@@ -314,9 +304,32 @@ class ChartDiffShow:
             )
             if undecided:
                 st.caption("Choose an environment for: " + ", ".join(f"`{field}`" for field in undecided) + ".")
+
+            # Recovery path for a failed write: the error message points at this button.
+            if st.session_state.get(f"conflict-write-failed-{self.diff.chart_id}"):
+                st.button(
+                    "Mark as resolved",
+                    key=f"resolve-conflicts-{self.diff.chart_id}",
+                    help="Clear the conflict without writing anything, for when you have already integrated the changes by hand.",
+                    on_click=_mark_as_resolved,
+                )
+
+            st.caption(
+                "This is under development. A field marked *Not present* is missing from that "
+                "environment's config; charts inherit those fields from the indicator's metadata, so "
+                "choosing that side removes the field rather than blanking it."
+            )
         else:
-            st.success(
-                "No conflicts found actually. Unsure why you were prompted with the conflict resolver. Please report."
+            st.info(
+                "Production was edited after this staging server was created, but no config field "
+                "differs between the two. Mark the conflict as resolved to carry on."
+            )
+            st.button(
+                "Mark as resolved",
+                key=f"resolve-conflicts-{self.diff.chart_id}",
+                type="primary",
+                help="Clear the conflict. Neither chart is changed.",
+                on_click=_mark_as_resolved,
             )
 
     def _show_chart_diff_header(self):

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -24,7 +24,11 @@ from apps.chart_sync.admin_api import AdminAPI
 from apps.utils.llms.gpt import OpenAIWrapper, get_cost_and_tokens
 from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff, ChartDiffsLoader
 from apps.wizard.app_pages.chart_diff.citations import st_show_citations
-from apps.wizard.app_pages.chart_diff.conflict_resolver import ChartDiffConflictResolver
+from apps.wizard.app_pages.chart_diff.conflict_resolver import (
+    PRODUCTION,
+    STAGING,
+    ChartDiffConflictResolver,
+)
 from apps.wizard.app_pages.chart_diff.utils import ANALYTICS_NUM_DAYS, SOURCE, TARGET, prettify_date
 from apps.wizard.utils.components import grapher_chart
 from etl.config import OWID_ENV
@@ -273,19 +277,43 @@ class ChartDiffShow:
                 "Find below the chart config fields that do not match. Choose the value you want to keep for each of the fields (or introduce a new one)."
             )
 
+            # Shortcuts to decide every field at once (nothing is preselected otherwise)
+            col1, col2 = st.columns(2)
+            col1.button(
+                "Use staging for all",
+                help="Choose the staging value for every field below. You can still change individual fields afterwards.",
+                key=f"conflict-all-staging-{self.diff.chart_id}",
+                on_click=resolver.choose_env_for_all,
+                args=(STAGING,),
+                width="stretch",
+            )
+            col2.button(
+                "Use production for all",
+                help="Choose the production value for every field below. You can still change individual fields afterwards.",
+                key=f"conflict-all-production-{self.diff.chart_id}",
+                on_click=resolver.choose_env_for_all,
+                args=(PRODUCTION,),
+                width="stretch",
+            )
+
             # Show conflict resolver per field
             ## Provide tools to merge the content of each field
             for field in resolver.config_compare:
-                resolver._show_field_conflict_resolver(field)
+                resolver.show_field_resolver(field)
 
-            # Button to resolve all conflicts
+            # Button to resolve all conflicts. Undecided fields block it: writing an unconfirmed
+            # default is exactly how staging edits used to get silently reverted.
+            undecided = resolver.fields_undecided
             st.button(
                 "Resolve conflicts",
                 help="Click to resolve the conflicts and update the chart config.",
                 key=f"resolve-conflicts-btn-{self.diff.chart_id}",
                 type="primary",
+                disabled=bool(undecided),
                 on_click=lambda r=resolver: _resolve_conflicts(r),
             )
+            if undecided:
+                st.caption("Choose an environment for: " + ", ".join(f"`{field}`" for field in undecided) + ".")
         else:
             st.success(
                 "No conflicts found actually. Unsure why you were prompted with the conflict resolver. Please report."
@@ -790,9 +818,27 @@ class ChartDiffShow:
                 case gm.ChartStatus.PENDING.value:
                     st.toast(f"**Resetting** state for chart {self.diff.chart_id}.", icon=":material/restart_alt:")
 
+    def _show_conflict_resolver_message(self) -> None:
+        """Show the outcome of a conflict resolution.
+
+        `resolve_conflicts` runs as a callback and the popover it lives in is gone by the time the
+        conflict is resolved, so the message is deferred to session state and drawn here instead.
+        """
+        message = st.session_state.pop(f"conflict-resolver-msg-{self.diff.chart_id}", None)
+        if message is None:
+            return
+        kind, text = message
+        if kind == "success":
+            st.success(text)
+        else:
+            st.error(text)
+
     @st.fragment
     def show(self):
         """Show chart diff."""
+        # Outcome of a conflict resolution (shown even if the diff itself is gone afterwards)
+        self._show_conflict_resolver_message()
+
         # Chart diff no longer exists (e.g. after a refresh found no differences)
         if st.session_state.pop(f"chart-diff-gone-{self.diff.chart_id}", False):
             st.info(

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -305,6 +305,9 @@ class ChartDiffShow:
             if undecided:
                 st.caption("Choose an environment for: " + ", ".join(f"`{field}`" for field in undecided) + ".")
 
+            # Why the last attempt wrote nothing, if it wrote nothing.
+            resolver.show_error()
+
             # Recovery path for a failed write: the error message points at this button.
             if st.session_state.get(f"conflict-write-failed-{self.diff.chart_id}"):
                 st.button(
@@ -837,26 +840,23 @@ class ChartDiffShow:
                 case gm.ChartStatus.PENDING.value:
                     st.toast(f"**Resetting** state for chart {self.diff.chart_id}.", icon=":material/restart_alt:")
 
-    def _show_conflict_resolver_message(self) -> None:
+    def _show_conflict_resolver_toast(self) -> None:
         """Show the outcome of a conflict resolution.
 
-        `resolve_conflicts` runs as a callback and the popover it lives in is gone by the time the
-        conflict is resolved, so the message is deferred to session state and drawn here instead.
+        As a toast: it floats, so it pushes no content down, and the outcome of a resolve is not
+        something to keep on screen. `resolve_conflicts` runs as a callback, and the popover it lives
+        in is gone by the time the conflict is resolved, so the message is deferred to session state
+        and drawn here instead (drawing it from the callback duplicates it).
         """
-        message = st.session_state.pop(f"conflict-resolver-msg-{self.diff.chart_id}", None)
-        if message is None:
-            return
-        kind, text = message
-        if kind == "success":
-            st.success(text)
-        else:
-            st.error(text)
+        message = st.session_state.pop(f"conflict-toast-{self.diff.chart_id}", None)
+        if message is not None:
+            st.toast(message, icon=":material/merge:")
 
     @st.fragment
     def show(self):
         """Show chart diff."""
         # Outcome of a conflict resolution (shown even if the diff itself is gone afterwards)
-        self._show_conflict_resolver_message()
+        self._show_conflict_resolver_toast()
 
         # Chart diff no longer exists (e.g. after a refresh found no differences)
         if st.session_state.pop(f"chart-diff-gone-{self.diff.chart_id}", False):

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -772,7 +772,13 @@ class ChartDiffShow:
         If a conflict is detected (i.e. edits in production), a conflict resolver is shown.
         """
         if self.diff.in_conflict:
-            with st.popover("⚠️ Resolve conflict"):
+            # A popover rather than a dialog on purpose: its content is rendered eagerly, so a
+            # half-made decision survives an accidental click outside, and interacting with a widget
+            # cannot close it. `st.dialog` needs a session-state flag to survive widget interaction at
+            # all, and, with no dismissal callback in Streamlit, a dismissed dialog would reopen on the
+            # next fragment rerun. `width="stretch"` gives the panel the width the side-by-side value
+            # comparison needs, which was the one real advantage a modal had.
+            with st.popover("⚠️ Resolve conflict", width="stretch"):
                 self._show_conflict_resolver()
 
         if self.diff.error:

--- a/apps/wizard/app_pages/chart_diff/conflict_resolver.py
+++ b/apps/wizard/app_pages/chart_diff/conflict_resolver.py
@@ -68,12 +68,21 @@ def parse_field_text(field_key: str, text: str, rendered_value: Any) -> Any:
     except json.JSONDecodeError:
         pass
 
+    # Values shown as JSON come back as JSON, but a user may paste a Python repr (single quotes,
+    # True/None), which json.loads rejects.
     try:
-        # Values shown as JSON come back as JSON, but a user may paste a Python repr (single quotes,
-        # True/None), which json.loads rejects.
-        return json.loads(json.dumps(ast.literal_eval(text)))
-    except (ValueError, SyntaxError) as e:
+        value = ast.literal_eval(text)
+    except Exception as e:
+        # literal_eval raises a whole family of errors on input that is not a literal (ValueError,
+        # SyntaxError, TypeError, MemoryError, RecursionError). They all mean the same thing here.
         raise FieldParseError(field_key, str(e)) from e
+
+    try:
+        # Not every Python literal is a value a chart config can hold: a set has no JSON form, and
+        # neither does an out-of-range float.
+        return json.loads(json.dumps(value, allow_nan=False))
+    except (TypeError, ValueError) as e:
+        raise FieldParseError(field_key, f"{type(value).__name__} is not a valid JSON value") from e
 
 
 def resolve_field_value(field_key: str, text: str, rendered_text: str, rendered_value: Any) -> Any:
@@ -231,12 +240,28 @@ class ChartDiffConflictResolver:
         rendered_value = None if choice is None else field[f"raw{choice}"]
         rendered_text = "" if choice is None else field[f"text{choice}"]
 
-        # Re-seed the editor whenever the chosen environment changes (and on first render).
-        if st.session_state.get(applied_key) != choice:
+        # `rendered_key` holds the text the editor was last seeded with. It is what tells an untouched
+        # editor apart from a hand-edited one, both here and in `_resolutions`, so it is written only
+        # when the editor is actually seeded.
+        seeded_text = st.session_state.get(rendered_key)
+        hand_edited = (seeded_text is not None) and (st.session_state.get(editor_key) != seeded_text)
+        value_changed = rendered_text != seeded_text
+
+        # Seed the editor when the chosen environment changes (and on first render), and also when
+        # the chosen environment's own value changes under us: the diff can be refreshed while the
+        # resolver is open, and an editor still showing the old text would write it back over the
+        # newer edit -- which is the bug this whole resolver was fixed for, one level down.
+        if (st.session_state.get(applied_key) != choice) or (value_changed and not hand_edited):
             st.session_state[editor_key] = rendered_text
-            st.session_state[applied_key] = choice
-        # Remember what the editor was seeded with, to tell later whether the user edited it.
-        st.session_state[rendered_key] = rendered_text
+            st.session_state[rendered_key] = rendered_text
+        st.session_state[applied_key] = choice
+
+        # A hand edit is never thrown away silently; say that it is now based on an outdated value.
+        if hand_edited and value_changed and (choice is not None):
+            st.warning(
+                f"The {ENVIRONMENT_IDS[choice]} value changed while you were editing this field. Your "
+                "edit is kept — pick an environment again to start from the new value."
+            )
 
         if choice is None:
             placeholder = "Choose PRODUCTION or STAGING above."

--- a/apps/wizard/app_pages/chart_diff/conflict_resolver.py
+++ b/apps/wizard/app_pages/chart_diff/conflict_resolver.py
@@ -146,6 +146,19 @@ def compare_chart_configs(c1: dict[str, Any], c2: dict[str, Any]) -> list[dict[s
     return diff_list
 
 
+def show_field_value(value: Any) -> None:
+    """Render one side's value of a conflicted field.
+
+    A field that is not in that environment's config gets a short marker rather than a `None`: the
+    chart inherits such fields from the indicator's metadata, and the difference between "absent" and
+    "blank" matters when resolving (see `build_resolved_config`).
+    """
+    if value is None:
+        st.warning("Not present", icon=":material/block:")
+    else:
+        st.write(value)
+
+
 class ChartDiffConflictResolver:
     """Resolve conflicts between charts.
 
@@ -195,21 +208,16 @@ class ChartDiffConflictResolver:
             # Choose option
             choice = self._choose_env(field)
 
-            # Show the fields values
-            msg_none = "The field might be `None` because it is not present in the config, but inherited automatically from the indicator's metadata."
+            # Show the field's value on each side
             col1, col2 = st.columns(2)
             with col1:
                 with st.container(border=True):
                     st.markdown("**Production**")
-                    st.write(field["raw1"])
-                    if field["raw1"] is None:
-                        st.warning(msg_none)
+                    show_field_value(field["raw1"])
             with col2:
                 with st.container(border=True):
                     st.markdown("**Staging**")
-                    st.write(field["raw2"])
-                    if field["raw2"] is None:
-                        st.warning(msg_none)
+                    show_field_value(field["raw2"])
 
             # Merge editor
             self._show_merge_editor(field, choice)
@@ -359,16 +367,28 @@ class ChartDiffConflictResolver:
             # Consolidate changes
             config = build_resolved_config(self.diff.source_chart.config, resolutions)
 
-            # `validate_chart_config_and_set_defaults` drops isInheritanceEnabled (it lives in the
-            # charts table, not in the config schema), but AdminAPI.update_chart needs it to set the
-            # inheritance flag -- without re-attaching it, resolving that field does nothing.
-            is_inheritance_enabled = config.get("isInheritanceEnabled")
-
-            # Verify config
-            try:
-                config_new = validate_chart_config_and_set_defaults(
-                    config, schema=get_schema_from_url(config["$schema"])
+            # Choosing staging for every field leaves the chart exactly as it is. Say so and mark the
+            # conflict resolved, rather than pushing an identical config: that would add a chart
+            # revision and bump updatedAt, which invalidates an existing approval of this diff.
+            if config == build_resolved_config(self.diff.source_chart.config, {}):
+                self.diff.set_conflict_to_resolved(self.session)
+                st.session_state.pop(f"conflict-write-failed-{self.diff.chart_id}", None)
+                st.session_state[message_key] = (
+                    "success",
+                    f"Chart {self.diff.chart_id} left as it is on staging, conflict marked as resolved:\n\n{summary}",
                 )
+                return
+
+            # Verify the config, but send the config we built: the return value of this function has
+            # every schema default filled in (38 extra top-level fields on a typical chart, from
+            # `hasMapTab` to `map.region`), which would write values the chart never had as explicit
+            # overrides -- they stop following the indicator's metadata and show up as differences
+            # against production for ever after. Removing them again afterwards is not the answer
+            # either: `validate_chart_config_and_remove_defaults` reverts genuine overrides that
+            # happen to equal a schema default (#5911). Resolving a conflict should change the
+            # conflicted fields and nothing else.
+            try:
+                validate_chart_config_and_set_defaults(config, schema=get_schema_from_url(config["$schema"]))
             except Exception as e:
                 log.error(e)
                 st.session_state[message_key] = (
@@ -377,28 +397,28 @@ class ChartDiffConflictResolver:
                 )
                 return
 
-            if is_inheritance_enabled is not None:
-                config_new["isInheritanceEnabled"] = is_inheritance_enabled
-
             # User who last edited the chart
             user_id = self.diff.source_chart.lastEditedByUserId
 
             api = AdminAPI(SOURCE)
             try:
-                # Push new chart to staging
+                # Push new chart to staging. isInheritanceEnabled stays in the payload on purpose:
+                # update_chart pops it and turns it into the ?inheritance= parameter.
                 api.update_chart(
                     chart_id=self.diff.chart_id,
-                    chart_config=config_new,
+                    chart_config=config,
                     user_id=user_id,
                 )
             except HTTPError as e:
                 log.error(e)
+                st.session_state[f"conflict-write-failed-{self.diff.chart_id}"] = True
                 st.session_state[message_key] = (
                     "error",
-                    f"An error occurred while updating the chart in staging. Please report this to #proj-new-data-workflow. If you are in a rush, you can manually integrate the changes in production [here]({SOURCE.chart_admin_site(self.diff.chart_id)}), and then click on the 'Mark as resolved' button in the conflict resolver. \n\n {e}",
+                    f"An error occurred while updating the chart in staging. Please report this to #proj-new-data-workflow. If you are in a rush, you can manually integrate the changes in production [here]({SOURCE.chart_admin_site(self.diff.chart_id)}), and then click on the 'Mark as resolved' button below. \n\n {e}",
                 )
             else:
                 # Set conflict as resolved
+                st.session_state.pop(f"conflict-write-failed-{self.diff.chart_id}", None)
                 self.diff.set_conflict_to_resolved(self.session)
                 # Signal user that everything went well, and with which value each field ended up
                 st.session_state[message_key] = (

--- a/apps/wizard/app_pages/chart_diff/conflict_resolver.py
+++ b/apps/wizard/app_pages/chart_diff/conflict_resolver.py
@@ -99,11 +99,17 @@ def resolve_field_value(field_key: str, text: str, rendered_text: str, rendered_
 
 
 def build_resolved_config(source_config: dict[str, Any], resolutions: dict[str, Any]) -> dict[str, Any]:
-    """Apply the resolution of each conflicted field on top of the staging config."""
+    """Apply the resolution of each conflicted field on top of the staging config.
+
+    A resolution of `None` means the field should not be set at all: either the chosen environment
+    does not have it, or the editor was emptied. An empty string is a different thing -- a chart can
+    hold `subtitle: ""` on purpose, and dropping the key instead would let the indicator's metadata be
+    inherited in its place, which is not what the user picked.
+    """
     config = deepcopy(source_config)
 
     for field_key, value in resolutions.items():
-        if (value is None) or (value == ""):
+        if value is None:
             config.pop(field_key, None)
         else:
             config[field_key] = value
@@ -267,6 +273,10 @@ class ChartDiffConflictResolver:
             placeholder = "Choose PRODUCTION or STAGING above."
         elif rendered_value is None:
             placeholder = f"This field is not present in {ENVIRONMENT_IDS[choice]}!"
+        elif rendered_value == "":
+            # Distinguish "explicitly blank" from "not set": emptying the editor removes the field,
+            # which is not the same chart (an unset field can be inherited from the indicator).
+            placeholder = f"Empty in {ENVIRONMENT_IDS[choice]} — saved as empty, not removed."
         else:
             placeholder = ""
 
@@ -300,8 +310,13 @@ class ChartDiffConflictResolver:
             field_key = field["key"]
             choice = st.session_state[self._radio_key(field_key)]
             origin = ENVIRONMENT_IDS[choice]
-            edited = resolutions[field_key] != field[f"raw{choice}"]
-            lines.append(f"- `{field_key}`: {origin}{' (edited)' if edited else ''}")
+            if resolutions[field_key] is None:
+                note = " (field removed)"
+            elif resolutions[field_key] != field[f"raw{choice}"]:
+                note = " (edited)"
+            else:
+                note = ""
+            lines.append(f"- `{field_key}`: {origin}{note}")
         return "\n".join(lines)
 
     def resolve_conflicts(self, rerun: bool = False):

--- a/apps/wizard/app_pages/chart_diff/conflict_resolver.py
+++ b/apps/wizard/app_pages/chart_diff/conflict_resolver.py
@@ -1,6 +1,7 @@
+import ast
 import json
 from copy import deepcopy
-from typing import cast
+from typing import Any
 
 import streamlit as st
 import structlog
@@ -8,24 +9,136 @@ from requests.exceptions import HTTPError
 from sqlalchemy.orm import Session
 
 from apps.chart_sync.admin_api import AdminAPI
-from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff
+from apps.wizard.app_pages.chart_diff.chart_diff import CONFIG_KEYS_IGNORE, ChartDiff
 from apps.wizard.app_pages.chart_diff.utils import SOURCE
-from apps.wizard.utils import as_list, as_valid_json
 from etl.files import get_schema_from_url
 from etl.indicator_upgrade.schema import validate_chart_config_and_set_defaults
 
 log = structlog.get_logger()
 
+PRODUCTION = 1
+STAGING = 2
 ENVIRONMENT_IDS = {
-    1: "PRODUCTION",
-    2: "STAGING",
+    PRODUCTION: "PRODUCTION",
+    STAGING: "STAGING",
 }
+
+# Fields the admin API sets itself, so they are never sent back to it.
+KEYS_NOT_SENT = (
+    "bakedGrapherURL",
+    "adminBaseUrl",
+    "dataApiUrl",
+)
+
+
+class FieldParseError(Exception):
+    """The text typed into a field's editor could not be read back into a config value."""
+
+    def __init__(self, field_key: str, message: str):
+        self.field_key = field_key
+        super().__init__(message)
+
+
+def as_text(value: Any) -> str:
+    """Render a config value as text to edit.
+
+    Strings are shown raw (a title stays a title, without quotes around it); everything else as JSON,
+    which is what `parse_field_text` reads back.
+    """
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, indent=2)
+
+
+def parse_field_text(field_key: str, text: str, rendered_value: Any) -> Any:
+    """Read the text of a field's editor back into a config value.
+
+    `rendered_value` is the value the editor was seeded with, and its type decides how `text` is read.
+    That matters: a string field must stay a string even when its content happens to look like
+    something else (a note of "2024" is the string "2024", not the number 2024).
+
+    Raises `FieldParseError` rather than silently falling back to the raw string, so that a malformed
+    edit cannot write a string into a field that expects a list.
+    """
+    if isinstance(rendered_value, str):
+        return text
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    try:
+        # Values shown as JSON come back as JSON, but a user may paste a Python repr (single quotes,
+        # True/None), which json.loads rejects.
+        return json.loads(json.dumps(ast.literal_eval(text)))
+    except (ValueError, SyntaxError) as e:
+        raise FieldParseError(field_key, str(e)) from e
+
+
+def resolve_field_value(field_key: str, text: str, rendered_text: str, rendered_value: Any) -> Any:
+    """Value a conflicted field should take, given the content of its editor.
+
+    An untouched editor keeps the chosen side's value exactly as it is, without a text round-trip, so
+    types survive (a list stays a list). An emptied editor means "this field should not be set".
+    """
+    if text == rendered_text:
+        return rendered_value
+    if text.strip() == "":
+        return None
+    return parse_field_text(field_key, text, rendered_value)
+
+
+def build_resolved_config(source_config: dict[str, Any], resolutions: dict[str, Any]) -> dict[str, Any]:
+    """Apply the resolution of each conflicted field on top of the staging config."""
+    config = deepcopy(source_config)
+
+    for field_key, value in resolutions.items():
+        if (value is None) or (value == ""):
+            config.pop(field_key, None)
+        else:
+            config[field_key] = value
+
+    for key in KEYS_NOT_SENT:
+        config.pop(key, None)
+
+    return config
+
+
+def compare_chart_configs(c1: dict[str, Any], c2: dict[str, Any]) -> list[dict[str, Any]]:
+    """Compare chart configs c1 (production) and c2 (staging).
+
+    Returns one entry per differing field, with both the raw value on each side (`raw1`/`raw2`, used
+    to write the config) and its text rendering (`text1`/`text2`, used to fill the editor).
+    """
+    diff_list = []
+    for key in sorted(set(c1.keys()).union(c2.keys())):
+        if key in CONFIG_KEYS_IGNORE:
+            continue
+        value1 = c1.get(key)
+        value2 = c2.get(key)
+        if value1 != value2:
+            diff_list.append(
+                {
+                    "key": key,
+                    "raw1": value1,
+                    "raw2": value2,
+                    "text1": "" if value1 is None else as_text(value1),
+                    "text2": "" if value2 is None else as_text(value2),
+                }
+            )
+
+    return diff_list
 
 
 class ChartDiffConflictResolver:
     """Resolve conflicts between charts.
 
     Provides UI.
+
+    All of the resolver's state lives in `st.session_state`: this object is re-created on every
+    Streamlit rerun, and `resolve_conflicts` runs as a widget callback (i.e. before the rerun that
+    would re-create it), so anything stored on `self` between renders would be stale.
     """
 
     def __init__(self, diff: ChartDiff, session: Session):
@@ -38,10 +151,28 @@ class ChartDiffConflictResolver:
             self.diff.target_chart.config,  # ty: ignore
             self.diff.source_chart.config,
         )
-        # Resolved values. key -> value, where key is conflicted field and value is the resolution.
-        self.value_resolved = {}
 
-    def _show_field_conflict_resolver(self, field):
+    def _radio_key(self, field_key: str) -> str:
+        return f"conflict-radio-{field_key}-{self.diff.chart_id}"
+
+    def _editor_key(self, field_key: str) -> str:
+        return f"conflict-editor-{field_key}-{self.diff.chart_id}"
+
+    @property
+    def fields_undecided(self) -> list[str]:
+        """Conflicted fields for which no environment has been chosen yet."""
+        return [f["key"] for f in self.config_compare if st.session_state.get(self._radio_key(f["key"])) is None]
+
+    def choose_env_for_all(self, choice: int) -> None:
+        """Pick the same environment for every conflicted field.
+
+        Runs as a button callback, i.e. before the radios are instantiated in the following rerun,
+        which is what makes writing their session state legal.
+        """
+        for field in self.config_compare:
+            st.session_state[self._radio_key(field["key"])] = choice
+
+    def show_field_resolver(self, field: dict[str, Any]) -> None:
         with st.container(border=True):
             # Title & layout
             st.markdown(f"##### {field['key']}")
@@ -53,79 +184,161 @@ class ChartDiffConflictResolver:
             msg_none = "The field might be `None` because it is not present in the config, but inherited automatically from the indicator's metadata."
             col1, col2 = st.columns(2)
             with col1:
-                # with st.expander("PRODUCTION", expanded=True):
                 with st.container(border=True):
                     st.markdown("**Production**")
-                    st.write(field["value1"])
-                    if field["value1"] is None:
+                    st.write(field["raw1"])
+                    if field["raw1"] is None:
                         st.warning(msg_none)
             with col2:
-                # with st.expander("STAGING", expanded=True):
                 with st.container(border=True):
                     st.markdown("**Staging**")
-                    st.write(field["value2"])
-                    if field["value2"] is None:
+                    st.write(field["raw2"])
+                    if field["raw2"] is None:
                         st.warning(msg_none)
 
             # Merge editor
             self._show_merge_editor(field, choice)
 
-    def _choose_env(self, field) -> int:
+    def _choose_env(self, field) -> int | None:
         """Choose environment to keep the value from.
 
-        The user can edit the value later on.
+        The user can edit the value later on. No environment is preselected: a default would get
+        written without the user ever confirming it.
         """
         # Show option radio buttons
-        value = st.radio(
+        return st.radio(
             "Choose config from...",
-            options=[1, 2],
+            options=[PRODUCTION, STAGING],
+            index=None,
             captions=["Insert production config", "Insert staging config"],
             format_func=lambda x: ENVIRONMENT_IDS[x],
-            key=f"conflict-radio-{field['key']}-{self.diff.chart_id}",
+            key=self._radio_key(field["key"]),
             horizontal=True,
             label_visibility="collapsed",
         )
 
-        return cast(int, value)
+    def _show_merge_editor(self, field, choice: int | None) -> None:
+        """Edit the content of the field.
 
-    def _show_merge_editor(self, field, choice):
-        """Edit the content of the field."""
-        is_none = field[f"value{choice}"] is None
-        self.value_resolved[field["key"]] = st.text_area(
+        The editor's value is driven through session state rather than through `value=`: a keyed
+        widget ignores `value=` from its second render onwards, which is why the editor used to keep
+        whatever it was born with no matter which environment was picked.
+        """
+        editor_key = self._editor_key(field["key"])
+        applied_key = f"{editor_key}-applied-choice"
+        rendered_key = f"{editor_key}-rendered"
+
+        rendered_value = None if choice is None else field[f"raw{choice}"]
+        rendered_text = "" if choice is None else field[f"text{choice}"]
+
+        # Re-seed the editor whenever the chosen environment changes (and on first render).
+        if st.session_state.get(applied_key) != choice:
+            st.session_state[editor_key] = rendered_text
+            st.session_state[applied_key] = choice
+        # Remember what the editor was seeded with, to tell later whether the user edited it.
+        st.session_state[rendered_key] = rendered_text
+
+        if choice is None:
+            placeholder = "Choose PRODUCTION or STAGING above."
+        elif rendered_value is None:
+            placeholder = f"This field is not present in {ENVIRONMENT_IDS[choice]}!"
+        else:
+            placeholder = ""
+
+        st.text_area(
             label="Edit config",
-            value="" if is_none else str(field[f"value{choice}"]),
-            placeholder=f"This field is not present in {ENVIRONMENT_IDS[choice]}!" if is_none else "",
-            help="Edit the final config here. When cliking on 'Resolve conflicts', this value will be used to update the chart config.",
-            disabled=is_none,
-            key=f"conflict-editor-{field['key']}-{self.diff.chart_id}",
+            placeholder=placeholder,
+            help="Edit the final config here. When clicking on 'Resolve conflicts', this value will be used to update the chart config.",
+            disabled=(choice is None) or (rendered_value is None),
+            key=editor_key,
         )
 
+    def _resolutions(self) -> dict[str, Any]:
+        """Value each conflicted field should take, read from the widgets."""
+        resolutions = {}
+        for field in self.config_compare:
+            field_key = field["key"]
+            choice = st.session_state[self._radio_key(field_key)]
+            editor_key = self._editor_key(field_key)
+            resolutions[field_key] = resolve_field_value(
+                field_key,
+                text=st.session_state.get(editor_key, ""),
+                rendered_text=st.session_state.get(f"{editor_key}-rendered", ""),
+                rendered_value=field[f"raw{choice}"],
+            )
+        return resolutions
+
+    def _summary(self, resolutions: dict[str, Any]) -> str:
+        """One line per field saying where its value came from."""
+        lines = []
+        for field in self.config_compare:
+            field_key = field["key"]
+            choice = st.session_state[self._radio_key(field_key)]
+            origin = ENVIRONMENT_IDS[choice]
+            edited = resolutions[field_key] != field[f"raw{choice}"]
+            lines.append(f"- `{field_key}`: {origin}{' (edited)' if edited else ''}")
+        return "\n".join(lines)
+
     def resolve_conflicts(self, rerun: bool = False):
-        """Gather all resolved conflicts and update chart config in staging."""
+        """Gather all resolved conflicts and update chart config in staging.
+
+        Runs as a button callback, so messages are deferred to session state instead of being drawn
+        here (drawing elements from a callback inside a fragment duplicates them).
+        """
+        message_key = f"conflict-resolver-msg-{self.diff.chart_id}"
+
+        undecided = self.fields_undecided
+        if undecided:
+            st.session_state[message_key] = (
+                "error",
+                "Nothing was written: no environment chosen yet for " + ", ".join(f"`{f}`" for f in undecided) + ".",
+            )
+            return
+
+        try:
+            resolutions = self._resolutions()
+        except FieldParseError as e:
+            st.session_state[message_key] = (
+                "error",
+                f"Nothing was written: could not read the value typed for `{e.field_key}` ({e}). "
+                "It must be valid JSON, matching the type of the field.",
+            )
+            return
+
+        summary = self._summary(resolutions)
+        log.info(
+            "chart_diff.resolve_conflicts",
+            chart_id=self.diff.chart_id,
+            resolutions={
+                field["key"]: ENVIRONMENT_IDS[st.session_state[self._radio_key(field["key"])]]
+                for field in self.config_compare
+            },
+        )
+
         with st.spinner("Updating chart on staging..."):
             # Consolidate changes
-            config = deepcopy(self.diff.source_chart.config)
-            for field_key, field_resolution in self.value_resolved.items():
-                if (self.value_resolved[field_key] is None) or (self.value_resolved[field_key] == ""):
-                    config.pop(field_key, None)
-                else:
-                    # st.write(field_key)
-                    config_field = as_valid_json(field_resolution)
-                    config_field = as_list(config_field)
-                    config[field_key] = config_field
-                    # st.write(f"{field_key}: {type(config[field_key]).__name__}")
+            config = build_resolved_config(self.diff.source_chart.config, resolutions)
 
-            # # Get rid of special fields
-            fields_remove = [
-                "bakedGrapherURL",
-                "adminBaseUrl",
-                "dataApiUrl",
-            ]
-            for field in fields_remove:
-                config.pop(field, None)
+            # `validate_chart_config_and_set_defaults` drops isInheritanceEnabled (it lives in the
+            # charts table, not in the config schema), but AdminAPI.update_chart needs it to set the
+            # inheritance flag -- without re-attaching it, resolving that field does nothing.
+            is_inheritance_enabled = config.get("isInheritanceEnabled")
 
             # Verify config
-            config_new = validate_chart_config_and_set_defaults(config, schema=get_schema_from_url(config["$schema"]))
+            try:
+                config_new = validate_chart_config_and_set_defaults(
+                    config, schema=get_schema_from_url(config["$schema"])
+                )
+            except Exception as e:
+                log.error(e)
+                st.session_state[message_key] = (
+                    "error",
+                    f"Nothing was written: the resolved config is not valid. \n\n {e}",
+                )
+                return
+
+            if is_inheritance_enabled is not None:
+                config_new["isInheritanceEnabled"] = is_inheritance_enabled
 
             # User who last edited the chart
             user_id = self.diff.source_chart.lastEditedByUserId
@@ -140,46 +353,17 @@ class ChartDiffConflictResolver:
                 )
             except HTTPError as e:
                 log.error(e)
-                st.error(
-                    f"An error occurred while updating the chart in staging. Please report this to #proj-new-data-workflow. If you are in a rush, you can manually integrate the changes in production [here]({SOURCE.chart_admin_site(self.diff.chart_id)}), and then click on the 'Mark as resolved' button in the conflict resolver. \n\n {e}"
+                st.session_state[message_key] = (
+                    "error",
+                    f"An error occurred while updating the chart in staging. Please report this to #proj-new-data-workflow. If you are in a rush, you can manually integrate the changes in production [here]({SOURCE.chart_admin_site(self.diff.chart_id)}), and then click on the 'Mark as resolved' button in the conflict resolver. \n\n {e}",
                 )
             else:
                 # Set conflict as resolved
                 self.diff.set_conflict_to_resolved(self.session)
-                # Signal user that everything went well
-                # st.success(
-                #     "Conflicts have been resolved. The chart in staging has been updated. You can close this window."
-                # )
+                # Signal user that everything went well, and with which value each field ended up
+                st.session_state[message_key] = (
+                    "success",
+                    f"Chart {self.diff.chart_id} updated on staging:\n\n{summary}",
+                )
         if rerun:
             st.rerun()
-
-
-def compare_chart_configs(c1, c2):
-    """Compare to chart configs c1 and c2."""
-    keys = set(c1.keys()).union(c2.keys())
-    diff_list = []
-    KEYS_IGNORE = {
-        "bakedGrapherURL",
-        "adminBaseUrl",
-        "dataApiUrl",
-        # "version",
-    }
-    for key in keys:
-        if key in KEYS_IGNORE:
-            continue
-        value1 = c1.get(key)
-        value2 = c2.get(key)
-        if value1 != value2:
-            if isinstance(value1, dict):
-                value1 = json.dumps(value1, indent=4)
-            if isinstance(value2, dict):
-                value2 = json.dumps(value2, indent=4)
-            diff_list.append(
-                {
-                    "key": key,
-                    "value1": value1,
-                    "value2": value2,
-                }
-            )
-
-    return diff_list

--- a/apps/wizard/app_pages/chart_diff/conflict_resolver.py
+++ b/apps/wizard/app_pages/chart_diff/conflict_resolver.py
@@ -1,5 +1,6 @@
 import ast
 import json
+from collections import Counter
 from copy import deepcopy
 from typing import Any
 
@@ -180,6 +181,27 @@ class ChartDiffConflictResolver:
             self.diff.source_chart.config,
         )
 
+    @property
+    def toast_key(self) -> str:
+        """Outcome of a resolve, shown once as a toast. Toasts float, so they push no content down."""
+        return f"conflict-toast-{self.diff.chart_id}"
+
+    @property
+    def error_key(self) -> str:
+        """Why a resolve wrote nothing. Stays next to the form until the next attempt."""
+        return f"conflict-error-{self.diff.chart_id}"
+
+    def _fail(self, message: str) -> None:
+        """Record that nothing was written, both next to the form and as a toast."""
+        st.session_state[self.error_key] = message
+        st.session_state[self.toast_key] = f"Chart {self.diff.chart_id}: nothing was written"
+
+    def show_error(self) -> None:
+        """Show why the last attempt wrote nothing, if it did not."""
+        message = st.session_state.get(self.error_key)
+        if message is not None:
+            st.error(message)
+
     def _radio_key(self, field_key: str) -> str:
         return f"conflict-radio-{field_key}-{self.diff.chart_id}"
 
@@ -311,21 +333,34 @@ class ChartDiffConflictResolver:
             )
         return resolutions
 
-    def _summary(self, resolutions: dict[str, Any]) -> str:
-        """One line per field saying where its value came from."""
-        lines = []
+    def _decisions(self, resolutions: dict[str, Any]) -> dict[str, str]:
+        """Where each field's value came from. For the log, not for the screen."""
+        decisions = {}
         for field in self.config_compare:
             field_key = field["key"]
             choice = st.session_state[self._radio_key(field_key)]
             origin = ENVIRONMENT_IDS[choice]
             if resolutions[field_key] is None:
-                note = " (field removed)"
+                origin += " (removed)"
             elif resolutions[field_key] != field[f"raw{choice}"]:
-                note = " (edited)"
-            else:
-                note = ""
-            lines.append(f"- `{field_key}`: {origin}{note}")
-        return "\n".join(lines)
+                origin += " (edited)"
+            decisions[field_key] = origin
+        return decisions
+
+    def _summary_line(self, resolutions: dict[str, Any]) -> str:
+        """One line fit for a toast: a per-field list runs to dozens of lines on a real conflict."""
+        counts = Counter(
+            ENVIRONMENT_IDS[st.session_state[self._radio_key(field["key"])]] for field in self.config_compare
+        )
+        parts = []
+        for choice in (STAGING, PRODUCTION):
+            env = ENVIRONMENT_IDS[choice]
+            if counts[env]:
+                parts.append(f"{counts[env]} from {env.lower()}")
+        removed = sum(1 for value in resolutions.values() if value is None)
+        if removed:
+            parts.append(f"{removed} removed")
+        return ", ".join(parts)
 
     def resolve_conflicts(self, rerun: bool = False):
         """Gather all resolved conflicts and update chart config in staging.
@@ -333,34 +368,30 @@ class ChartDiffConflictResolver:
         Runs as a button callback, so messages are deferred to session state instead of being drawn
         here (drawing elements from a callback inside a fragment duplicates them).
         """
-        message_key = f"conflict-resolver-msg-{self.diff.chart_id}"
+        # Every attempt starts from a clean slate, so a stale error never lingers next to the form.
+        st.session_state.pop(self.error_key, None)
 
         undecided = self.fields_undecided
         if undecided:
-            st.session_state[message_key] = (
-                "error",
-                "Nothing was written: no environment chosen yet for " + ", ".join(f"`{f}`" for f in undecided) + ".",
+            self._fail(
+                "Nothing was written: no environment chosen yet for " + ", ".join(f"`{f}`" for f in undecided) + "."
             )
             return
 
         try:
             resolutions = self._resolutions()
         except FieldParseError as e:
-            st.session_state[message_key] = (
-                "error",
+            self._fail(
                 f"Nothing was written: could not read the value typed for `{e.field_key}` ({e}). "
-                "It must be valid JSON, matching the type of the field.",
+                "It must be valid JSON, matching the type of the field."
             )
             return
 
-        summary = self._summary(resolutions)
+        summary = self._summary_line(resolutions)
         log.info(
             "chart_diff.resolve_conflicts",
             chart_id=self.diff.chart_id,
-            resolutions={
-                field["key"]: ENVIRONMENT_IDS[st.session_state[self._radio_key(field["key"])]]
-                for field in self.config_compare
-            },
+            decisions=self._decisions(resolutions),
         )
 
         with st.spinner("Updating chart on staging..."):
@@ -373,9 +404,8 @@ class ChartDiffConflictResolver:
             if config == build_resolved_config(self.diff.source_chart.config, {}):
                 self.diff.set_conflict_to_resolved(self.session)
                 st.session_state.pop(f"conflict-write-failed-{self.diff.chart_id}", None)
-                st.session_state[message_key] = (
-                    "success",
-                    f"Chart {self.diff.chart_id} left as it is on staging, conflict marked as resolved:\n\n{summary}",
+                st.session_state[self.toast_key] = (
+                    f"Chart {self.diff.chart_id} left as it is on staging, conflict resolved ({summary})"
                 )
                 return
 
@@ -391,10 +421,7 @@ class ChartDiffConflictResolver:
                 validate_chart_config_and_set_defaults(config, schema=get_schema_from_url(config["$schema"]))
             except Exception as e:
                 log.error(e)
-                st.session_state[message_key] = (
-                    "error",
-                    f"Nothing was written: the resolved config is not valid. \n\n {e}",
-                )
+                self._fail(f"Nothing was written: the resolved config is not valid. \n\n {e}")
                 return
 
             # User who last edited the chart
@@ -412,18 +439,14 @@ class ChartDiffConflictResolver:
             except HTTPError as e:
                 log.error(e)
                 st.session_state[f"conflict-write-failed-{self.diff.chart_id}"] = True
-                st.session_state[message_key] = (
-                    "error",
-                    f"An error occurred while updating the chart in staging. Please report this to #proj-new-data-workflow. If you are in a rush, you can manually integrate the changes in production [here]({SOURCE.chart_admin_site(self.diff.chart_id)}), and then click on the 'Mark as resolved' button below. \n\n {e}",
+                self._fail(
+                    f"An error occurred while updating the chart in staging. Please report this to #proj-new-data-workflow. If you are in a rush, you can manually integrate the changes in production [here]({SOURCE.chart_admin_site(self.diff.chart_id)}), and then click on the 'Mark as resolved' button below. \n\n {e}"
                 )
             else:
                 # Set conflict as resolved
                 st.session_state.pop(f"conflict-write-failed-{self.diff.chart_id}", None)
                 self.diff.set_conflict_to_resolved(self.session)
-                # Signal user that everything went well, and with which value each field ended up
-                st.session_state[message_key] = (
-                    "success",
-                    f"Chart {self.diff.chart_id} updated on staging:\n\n{summary}",
-                )
+                # Signal user that everything went well, and where the values came from
+                st.session_state[self.toast_key] = f"Chart {self.diff.chart_id} updated on staging ({summary})"
         if rerun:
             st.rerun()

--- a/apps/wizard/utils/__init__.py
+++ b/apps/wizard/utils/__init__.py
@@ -545,16 +545,6 @@ def as_valid_json(s):
             return s
 
 
-def as_list(s):
-    """Return `s` as a list if applicable."""
-    if isinstance(s, str):
-        try:
-            return ast.literal_eval(s)
-        except (ValueError, SyntaxError):
-            return s
-    return s
-
-
 @cache
 def is_running_in_streamlit():
     """Check if running in Streamlit."""

--- a/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
@@ -313,3 +313,92 @@ def test_resolving_a_malformed_edit_writes_nothing(fake_admin_api):
     assert fake_admin_api.calls == []
     assert at.text[0].value.startswith("error: Nothing was written")
     assert "selectedEntityNames" in at.text[0].value
+
+
+def _refreshable_app():
+    """Same as `_resolve_app`, but the staging value changes when `refreshed` is set.
+
+    Simulates the diff being refreshed (or the chart being edited again) while the resolver is open.
+    """
+    import streamlit as st
+
+    import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
+
+    staging_title = "New staging title" if st.session_state.get("refreshed") else "Staging title"
+
+    class _Chart:
+        def __init__(self, config):
+            self.config = config
+            self.lastEditedByUserId = 13
+
+    class _Diff:
+        chart_id = 42
+
+        def __init__(self):
+            self.target_chart = _Chart({"$schema": "s", "title": "Production title"})
+            self.source_chart = _Chart({"$schema": "s", "title": staging_title})
+
+        def set_conflict_to_resolved(self, session):
+            pass
+
+    resolver = cr.ChartDiffConflictResolver(_Diff(), session=None)  # ty: ignore
+    for field in resolver.config_compare:
+        resolver.show_field_resolver(field)
+    st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
+
+    message = st.session_state.get("conflict-resolver-msg-42")
+    if message is not None:
+        st.text(f"{message[0]}: {message[1]}")
+
+
+def test_editor_follows_a_value_that_changed_under_it(fake_admin_api):
+    """An untouched editor must not keep showing -- and writing back -- a superseded value."""
+    at = AppTest.from_function(_refreshable_app, default_timeout=30).run()
+    at = at.radio[0].set_value(2).run()
+    assert at.text_area[0].value == "Staging title"
+
+    # The staging chart gets edited again and the diff is refreshed.
+    at.session_state["refreshed"] = True
+    at = at.run()
+    assert at.text_area[0].value == "New staging title"
+    assert at.warning == []
+
+    at = at.button[0].click().run()
+    assert fake_admin_api.calls[0]["config"]["title"] == "New staging title"
+
+
+def test_a_hand_edit_survives_a_value_that_changed_under_it(fake_admin_api):
+    """A hand edit is never thrown away silently -- it is kept, and the user is told why it matters."""
+    at = AppTest.from_function(_refreshable_app, default_timeout=30).run()
+    at = at.radio[0].set_value(2).run()
+    at = at.text_area[0].set_value("Hand-written title").run()
+
+    at.session_state["refreshed"] = True
+    at = at.run()
+    assert at.text_area[0].value == "Hand-written title"
+    assert "changed while you were editing" in at.warning[0].value
+
+    at = at.button[0].click().run()
+    assert fake_admin_api.calls[0]["config"]["title"] == "Hand-written title"
+
+    # Re-picking an environment starts from the new value, as the warning says.
+    at = at.radio[0].set_value(1).run()
+    at = at.radio[0].set_value(2).run()
+    assert at.text_area[0].value == "New staging title"
+
+
+def test_a_literal_json_cannot_hold_is_a_field_error(fake_admin_api):
+    """`{1, 2}` is a valid Python literal but not a JSON value: report it, never crash the callback."""
+    with pytest.raises(FieldParseError):
+        parse_field_text("selectedEntityNames", "{1, 2}", ["Kenya"])
+
+    at = AppTest.from_function(_resolve_app, default_timeout=30).run()
+    at = at.radio[0].set_value(2).run()
+    at = at.radio[1].set_value(2).run()
+    at = at.radio[2].set_value(2).run()
+    at = at.text_area[1].set_value("{1, 2}").run()
+    at = at.button[0].click().run()
+
+    assert at.exception == []
+    assert fake_admin_api.calls == []
+    assert at.text[0].value.startswith("error: Nothing was written")

--- a/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
@@ -324,7 +324,7 @@ def _refreshable_app():
 
     import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
 
-    staging_title = "New staging title" if st.session_state.get("refreshed") else "Staging title"
+    production_title = "New production title" if st.session_state.get("refreshed") else "Production title"
 
     class _Chart:
         def __init__(self, config):
@@ -335,8 +335,8 @@ def _refreshable_app():
         chart_id = 42
 
         def __init__(self):
-            self.target_chart = _Chart({"$schema": "s", "title": "Production title"})
-            self.source_chart = _Chart({"$schema": "s", "title": staging_title})
+            self.target_chart = _Chart({"$schema": "s", "title": production_title})
+            self.source_chart = _Chart({"$schema": "s", "title": "Staging title"})
 
         def set_conflict_to_resolved(self, session):
             pass
@@ -354,23 +354,23 @@ def _refreshable_app():
 def test_editor_follows_a_value_that_changed_under_it(fake_admin_api):
     """An untouched editor must not keep showing -- and writing back -- a superseded value."""
     at = AppTest.from_function(_refreshable_app, default_timeout=30).run()
-    at = at.radio[0].set_value(2).run()
-    assert at.text_area[0].value == "Staging title"
+    at = at.radio[0].set_value(1).run()
+    assert at.text_area[0].value == "Production title"
 
-    # The staging chart gets edited again and the diff is refreshed.
+    # The production chart gets edited again and the diff is refreshed.
     at.session_state["refreshed"] = True
     at = at.run()
-    assert at.text_area[0].value == "New staging title"
+    assert at.text_area[0].value == "New production title"
     assert at.warning == []
 
     at = at.button[0].click().run()
-    assert fake_admin_api.calls[0]["config"]["title"] == "New staging title"
+    assert fake_admin_api.calls[0]["config"]["title"] == "New production title"
 
 
 def test_a_hand_edit_survives_a_value_that_changed_under_it(fake_admin_api):
     """A hand edit is never thrown away silently -- it is kept, and the user is told why it matters."""
     at = AppTest.from_function(_refreshable_app, default_timeout=30).run()
-    at = at.radio[0].set_value(2).run()
+    at = at.radio[0].set_value(1).run()
     at = at.text_area[0].set_value("Hand-written title").run()
 
     at.session_state["refreshed"] = True
@@ -382,9 +382,9 @@ def test_a_hand_edit_survives_a_value_that_changed_under_it(fake_admin_api):
     assert fake_admin_api.calls[0]["config"]["title"] == "Hand-written title"
 
     # Re-picking an environment starts from the new value, as the warning says.
-    at = at.radio[0].set_value(1).run()
     at = at.radio[0].set_value(2).run()
-    assert at.text_area[0].value == "New staging title"
+    at = at.radio[0].set_value(1).run()
+    assert at.text_area[0].value == "New production title"
 
 
 def test_a_literal_json_cannot_hold_is_a_field_error(fake_admin_api):
@@ -466,3 +466,85 @@ def test_emptying_the_editor_removes_the_field_and_says_so(fake_admin_api):
 
     assert "note" not in fake_admin_api.calls[0]["config"]
     assert "(field removed)" in at.text[0].value
+
+
+def test_choosing_staging_everywhere_writes_nothing(fake_admin_api):
+    """That is the chart staging already has, so it needs no revision, only the conflict cleared."""
+    at = AppTest.from_function(_resolve_app, default_timeout=30).run()
+    at = at.radio[0].set_value(2).run()
+    at = at.radio[1].set_value(2).run()
+    at = at.radio[2].set_value(2).run()
+    at = at.button[0].click().run()
+
+    assert fake_admin_api.calls == []
+    assert at.text[0].value.startswith("success: Chart 42 left as it is on staging")
+
+
+def _realistic_app():
+    """A conflict on a config that validates against the real grapher schema. Self-contained."""
+    import streamlit as st
+
+    import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
+
+    base = {
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
+        "dimensions": [{"property": "y", "variableId": 1000}],
+        "subtitle": "A subtitle",
+    }
+
+    class _Chart:
+        def __init__(self, config):
+            self.config = config
+            self.lastEditedByUserId = 13
+
+    class _Diff:
+        chart_id = 42
+
+        def __init__(self):
+            self.target_chart = _Chart({**base, "title": "Production title"})
+            self.source_chart = _Chart({**base, "title": "Staging title"})
+
+        def set_conflict_to_resolved(self, session):
+            pass
+
+    resolver = cr.ChartDiffConflictResolver(_Diff(), session=None)  # ty: ignore
+    for field in resolver.config_compare:
+        resolver.show_field_resolver(field)
+    st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
+
+    message = st.session_state.get("conflict-resolver-msg-42")
+    if message is not None:
+        st.text(f"{message[0]}: {message[1]}")
+
+
+@pytest.fixture
+def fake_admin_api_real_schema(monkeypatch):
+    """Like `fake_admin_api`, but validating against the grapher schema vendored in the repo."""
+    import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
+    from etl.files import read_json_schema
+    from etl.paths import SCHEMAS_DIR
+
+    schema = read_json_schema(SCHEMAS_DIR / "grapher-schema.011.json")
+    FakeAdminAPI.calls = []
+    monkeypatch.setattr(cr, "AdminAPI", FakeAdminAPI)
+    monkeypatch.setattr(cr, "get_schema_from_url", lambda url: schema)
+    return FakeAdminAPI
+
+
+def test_resolving_does_not_fill_the_config_with_schema_defaults(fake_admin_api_real_schema):
+    """Resolving a conflict changes the conflicted fields and nothing else.
+
+    Validation used to double as a transformation: it filled in every schema default, which wrote
+    ~38 top-level fields the chart never had (`hasMapTab`, `chartTypes`, `minTime`, `map.region`, ...)
+    as explicit chart-level values, so they stopped following the indicator's metadata and showed up
+    as differences against production.
+    """
+    at = AppTest.from_function(_realistic_app, default_timeout=30).run()
+    at = at.radio[0].set_value(1).run()  # title <- production
+    at = at.button[0].click().run()
+
+    assert at.exception == []
+    config = fake_admin_api_real_schema.calls[0]["config"]
+    assert config["title"] == "Production title"
+    # Exactly the fields the chart had, no more.
+    assert set(config) == {"$schema", "dimensions", "subtitle", "title"}

--- a/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
@@ -402,3 +402,67 @@ def test_a_literal_json_cannot_hold_is_a_field_error(fake_admin_api):
     assert at.exception == []
     assert fake_admin_api.calls == []
     assert at.text[0].value.startswith("error: Nothing was written")
+
+
+def test_build_resolved_config_keeps_an_explicit_empty_string():
+    """`subtitle: ""` is a chart with a blank subtitle; dropping the key inherits one instead."""
+    config = build_resolved_config({"subtitle": "Staging subtitle"}, {"subtitle": ""})
+    assert config["subtitle"] == ""
+
+    # An emptied editor still means "do not set this field".
+    assert "subtitle" not in build_resolved_config({"subtitle": "Staging subtitle"}, {"subtitle": None})
+
+
+def _empty_string_app():
+    """One conflict where production's value is an explicit empty string. Must be self-contained."""
+    import streamlit as st
+
+    import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
+
+    class _Chart:
+        def __init__(self, config):
+            self.config = config
+            self.lastEditedByUserId = 13
+
+    class _Diff:
+        chart_id = 42
+
+        def __init__(self):
+            self.target_chart = _Chart({"$schema": "s", "note": ""})
+            self.source_chart = _Chart({"$schema": "s", "note": "Staging note"})
+
+        def set_conflict_to_resolved(self, session):
+            pass
+
+    resolver = cr.ChartDiffConflictResolver(_Diff(), session=None)  # ty: ignore
+    for field in resolver.config_compare:
+        resolver.show_field_resolver(field)
+    st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
+
+    message = st.session_state.get("conflict-resolver-msg-42")
+    if message is not None:
+        st.text(f"{message[0]}: {message[1]}")
+
+
+def test_choosing_an_empty_string_writes_it_rather_than_removing_the_field(fake_admin_api):
+    at = AppTest.from_function(_empty_string_app, default_timeout=30).run()
+
+    at = at.radio[0].set_value(1).run()  # note <- production, which has it set to ""
+    assert at.text_area[0].value == ""
+    assert not at.text_area[0].disabled
+    # The editor looks the same as an unset field, so it says which of the two this is.
+    assert "not removed" in at.text_area[0].placeholder
+
+    at = at.button[0].click().run()
+    assert fake_admin_api.calls[0]["config"]["note"] == ""
+
+
+def test_emptying_the_editor_removes_the_field_and_says_so(fake_admin_api):
+    at = AppTest.from_function(_empty_string_app, default_timeout=30).run()
+
+    at = at.radio[0].set_value(2).run()  # note <- staging ("Staging note")
+    at = at.text_area[0].set_value("").run()
+    at = at.button[0].click().run()
+
+    assert "note" not in fake_admin_api.calls[0]["config"]
+    assert "(field removed)" in at.text[0].value

--- a/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
@@ -1,0 +1,315 @@
+"""Tests for the chart-diff conflict resolver (issue #6736).
+
+The bug these guard against: the PRODUCTION/STAGING radio had no effect, because the editor was a
+keyed Streamlit widget created with `value=` -- which is ignored from the second render onwards -- so
+whatever the editor was born with (production's value) was what got written to the staging chart.
+"""
+
+import json
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from apps.wizard.app_pages.chart_diff.conflict_resolver import (
+    FieldParseError,
+    build_resolved_config,
+    compare_chart_configs,
+    parse_field_text,
+    resolve_field_value,
+)
+
+PROD_CONFIG = {
+    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
+    "id": 42,
+    "version": 7,
+    "isPublished": True,
+    "title": "Production title",
+    "note": "2024",
+    "selectedEntityNames": ["World"],
+    "map": {"time": 2020},
+}
+STAGING_CONFIG = {
+    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
+    "id": 42,
+    "version": 9,
+    "isPublished": True,
+    "title": "Staging title",
+    "note": "2024",
+    "selectedEntityNames": ["Kenya", "Peru"],
+    "subtitle": "Only on staging",
+}
+
+
+def test_compare_chart_configs_ignores_bookkeeping_fields():
+    """`version` differs on essentially every real conflict, and is not a conflict to resolve."""
+    fields = {field["key"] for field in compare_chart_configs(PROD_CONFIG, STAGING_CONFIG)}
+    assert fields == {"title", "selectedEntityNames", "map", "subtitle"}
+
+
+def test_compare_chart_configs_keeps_raw_values_and_is_sorted():
+    fields = compare_chart_configs(PROD_CONFIG, STAGING_CONFIG)
+
+    # Sorted, so the UI (and these tests) see a stable order.
+    assert [field["key"] for field in fields] == ["map", "selectedEntityNames", "subtitle", "title"]
+
+    by_key = {field["key"]: field for field in fields}
+    # Raw values are kept as objects, not pre-stringified: that is what lets an untouched field be
+    # written back with its type intact.
+    assert by_key["selectedEntityNames"]["raw2"] == ["Kenya", "Peru"]
+    assert by_key["map"]["raw1"] == {"time": 2020}
+    assert by_key["map"]["raw2"] is None
+    assert by_key["map"]["text2"] == ""
+    # Strings are shown raw, everything else as JSON.
+    assert by_key["title"]["text1"] == "Production title"
+    assert by_key["selectedEntityNames"]["text2"] == json.dumps(["Kenya", "Peru"], indent=2)
+
+
+def test_resolve_field_value_untouched_editor_keeps_the_object():
+    value = ["Kenya", "Peru"]
+    rendered = json.dumps(value, indent=2)
+    assert resolve_field_value("selectedEntityNames", rendered, rendered, value) is value
+
+
+def test_resolve_field_value_emptied_editor_drops_the_field():
+    assert resolve_field_value("subtitle", "", "Only on staging", "Only on staging") is None
+
+
+def test_resolve_field_value_edited_list():
+    assert resolve_field_value("selectedEntityNames", '["Chad"]', '["Kenya"]', ["Kenya"]) == ["Chad"]
+
+
+def test_parse_field_text_does_not_retype_strings():
+    """A note of "2024" is the string "2024" -- the old code turned it into the number 2024."""
+    assert parse_field_text("note", "2024", "2023") == "2024"
+    assert parse_field_text("note", "null", "text") == "null"
+    assert parse_field_text("note", "1,2", "text") == "1,2"
+
+
+def test_parse_field_text_accepts_python_reprs():
+    assert parse_field_text("selectedEntityNames", "['Chad', 'Peru']", ["Kenya"]) == ["Chad", "Peru"]
+
+
+def test_parse_field_text_raises_on_malformed_structured_value():
+    """A broken edit must not be written to the chart as a raw string."""
+    with pytest.raises(FieldParseError) as excinfo:
+        parse_field_text("selectedEntityNames", '["Chad", ', ["Kenya"])
+    assert excinfo.value.field_key == "selectedEntityNames"
+
+
+def test_build_resolved_config():
+    config = build_resolved_config(
+        {**STAGING_CONFIG, "dataApiUrl": "https://api.staging"},
+        {
+            "title": "Production title",  # keep production's
+            "selectedEntityNames": ["Kenya", "Peru"],  # keep staging's
+            "subtitle": None,  # absent in production -> drop it
+        },
+    )
+
+    assert config["title"] == "Production title"
+    assert config["selectedEntityNames"] == ["Kenya", "Peru"]
+    assert "subtitle" not in config
+    # Environment-specific fields are never sent back to the admin API.
+    assert "dataApiUrl" not in config
+    # Untouched fields come through from staging.
+    assert config["version"] == 9
+
+
+def test_build_resolved_config_does_not_mutate_the_source():
+    source = {"title": "Staging title", "selectedEntityNames": ["Kenya"]}
+    build_resolved_config(source, {"title": "Production title", "selectedEntityNames": None})
+    assert source == {"title": "Staging title", "selectedEntityNames": ["Kenya"]}
+
+
+def _resolver_app():
+    """Render the field resolvers for one conflict. Must be self-contained (AppTest runs its source)."""
+    import streamlit as st
+
+    from apps.wizard.app_pages.chart_diff.conflict_resolver import ChartDiffConflictResolver
+
+    class _Chart:
+        def __init__(self, config):
+            self.config = config
+            self.lastEditedByUserId = 1
+
+    class _Diff:
+        chart_id = 42
+
+        def __init__(self):
+            self.target_chart = _Chart(
+                {
+                    "$schema": "s",
+                    "title": "Production title",
+                    "selectedEntityNames": ["World"],
+                }
+            )
+            self.source_chart = _Chart(
+                {
+                    "$schema": "s",
+                    "title": "Staging title",
+                    "selectedEntityNames": ["Kenya", "Peru"],
+                }
+            )
+
+    resolver = ChartDiffConflictResolver(_Diff(), session=None)  # ty: ignore
+    for field in resolver.config_compare:
+        resolver.show_field_resolver(field)
+    st.text("undecided: [" + ", ".join(resolver.fields_undecided) + "]")
+
+
+def test_editor_follows_the_radio():
+    """The regression test for #6736: today's code returns production's value whatever is clicked."""
+    at = AppTest.from_function(_resolver_app, default_timeout=30).run()
+
+    # Fields are sorted: selectedEntityNames, title.
+    assert len(at.radio) == 2
+    assert len(at.text_area) == 2
+
+    # Nothing is preselected, so nothing can be written by accident.
+    assert [radio.value for radio in at.radio] == [None, None]
+    assert [text_area.value for text_area in at.text_area] == ["", ""]
+    assert all(text_area.disabled for text_area in at.text_area)
+    assert at.text[0].value == "undecided: [selectedEntityNames, title]"
+
+    # Choosing STAGING fills the editor with staging's value...
+    at = at.radio[1].set_value(2).run()
+    assert at.text_area[1].value == "Staging title"
+    assert not at.text_area[1].disabled
+
+    # ...and switching to PRODUCTION follows.
+    at = at.radio[1].set_value(1).run()
+    assert at.text_area[1].value == "Production title"
+
+    # Structured values are shown as JSON.
+    at = at.radio[0].set_value(2).run()
+    assert at.text_area[0].value == json.dumps(["Kenya", "Peru"], indent=2)
+    assert at.text[0].value == "undecided: []"
+
+
+def test_editor_keeps_a_hand_edit_until_the_choice_changes():
+    at = AppTest.from_function(_resolver_app, default_timeout=30).run()
+    at = at.radio[1].set_value(2).run()
+
+    at = at.text_area[1].set_value("Hand-written title").run()
+    assert at.text_area[1].value == "Hand-written title"
+
+    # Re-picking the same environment does not wipe the edit...
+    at = at.radio[1].set_value(2).run()
+    assert at.text_area[1].value == "Hand-written title"
+
+    # ...but choosing the other one does, since that is an explicit request for its value.
+    at = at.radio[1].set_value(1).run()
+    assert at.text_area[1].value == "Production title"
+
+
+class FakeAdminAPI:
+    """Captures what would be pushed to the staging chart."""
+
+    calls: list[dict] = []
+
+    def __init__(self, owid_env):
+        pass
+
+    def update_chart(self, chart_id, chart_config, user_id=None):
+        FakeAdminAPI.calls.append({"chart_id": chart_id, "config": chart_config, "user_id": user_id})
+        return {"success": True}
+
+
+def _resolve_app():
+    """Full flow for one conflict, up to the call to the admin API. Must be self-contained."""
+    import streamlit as st
+
+    import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
+
+    class _Chart:
+        def __init__(self, config):
+            self.config = config
+            self.lastEditedByUserId = 13
+
+    class _Diff:
+        chart_id = 42
+
+        def __init__(self):
+            self.target_chart = _Chart(
+                {
+                    "$schema": "s",
+                    "title": "Production title",
+                    "selectedEntityNames": ["World"],
+                    "isInheritanceEnabled": True,
+                }
+            )
+            self.source_chart = _Chart(
+                {
+                    "$schema": "s",
+                    "title": "Staging title",
+                    "selectedEntityNames": ["Kenya", "Peru"],
+                    "isInheritanceEnabled": False,
+                }
+            )
+
+        def set_conflict_to_resolved(self, session):
+            pass
+
+    resolver = cr.ChartDiffConflictResolver(_Diff(), session=None)  # ty: ignore
+    for field in resolver.config_compare:
+        resolver.show_field_resolver(field)
+    st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
+
+    message = st.session_state.get("conflict-resolver-msg-42")
+    if message is not None:
+        st.text(f"{message[0]}: {message[1]}")
+
+
+@pytest.fixture
+def fake_admin_api(monkeypatch):
+    import apps.wizard.app_pages.chart_diff.conflict_resolver as cr
+
+    FakeAdminAPI.calls = []
+    monkeypatch.setattr(cr, "AdminAPI", FakeAdminAPI)
+    # Keep schema validation offline: the real one downloads the grapher schema.
+    monkeypatch.setattr(cr, "get_schema_from_url", lambda url: {"type": "object"})
+    return FakeAdminAPI
+
+
+def test_resolving_writes_the_chosen_side(fake_admin_api):
+    """End to end for #6736: what reaches the admin API is what was picked, per field."""
+    at = AppTest.from_function(_resolve_app, default_timeout=30).run()
+
+    # Fields, sorted: isInheritanceEnabled, selectedEntityNames, title.
+    assert [radio.value for radio in at.radio] == [None, None, None]
+    # Nothing can be resolved until every field has been decided.
+    assert at.button[0].disabled
+
+    at = at.radio[0].set_value(1).run()  # isInheritanceEnabled <- production
+    at = at.radio[1].set_value(2).run()  # selectedEntityNames <- staging
+    at = at.radio[2].set_value(1).run()  # title <- production
+    assert not at.button[0].disabled
+
+    at = at.button[0].click().run()
+
+    assert len(fake_admin_api.calls) == 1
+    call = fake_admin_api.calls[0]
+    assert call["chart_id"] == 42
+    assert call["user_id"] == 13
+    # The staging-side entity selection survives -- the whole point of the issue.
+    assert call["config"]["selectedEntityNames"] == ["Kenya", "Peru"]
+    assert call["config"]["title"] == "Production title"
+    # isInheritanceEnabled is re-attached after schema validation strips it, so choosing a side for it
+    # actually reaches the admin API.
+    assert call["config"]["isInheritanceEnabled"] is True
+    assert at.text[0].value.startswith("success: Chart 42 updated on staging")
+
+
+def test_resolving_a_malformed_edit_writes_nothing(fake_admin_api):
+    at = AppTest.from_function(_resolve_app, default_timeout=30).run()
+    at = at.radio[0].set_value(2).run()
+    at = at.radio[1].set_value(2).run()
+    at = at.radio[2].set_value(2).run()
+
+    # Break the JSON of a list field.
+    at = at.text_area[1].set_value('["Kenya", ').run()
+    at = at.button[0].click().run()
+
+    assert fake_admin_api.calls == []
+    assert at.text[0].value.startswith("error: Nothing was written")
+    assert "selectedEntityNames" in at.text[0].value

--- a/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py
@@ -255,9 +255,12 @@ def _resolve_app():
         resolver.show_field_resolver(field)
     st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
 
-    message = st.session_state.get("conflict-resolver-msg-42")
-    if message is not None:
-        st.text(f"{message[0]}: {message[1]}")
+    toast = st.session_state.get("conflict-toast-42")
+    error = st.session_state.get("conflict-error-42")
+    if error is not None:
+        st.text(f"error: {error}")
+    elif toast is not None:
+        st.text(f"success: {toast}")
 
 
 @pytest.fixture
@@ -297,7 +300,7 @@ def test_resolving_writes_the_chosen_side(fake_admin_api):
     # isInheritanceEnabled is re-attached after schema validation strips it, so choosing a side for it
     # actually reaches the admin API.
     assert call["config"]["isInheritanceEnabled"] is True
-    assert at.text[0].value.startswith("success: Chart 42 updated on staging")
+    assert at.text[0].value == "success: Chart 42 updated on staging (1 from staging, 2 from production)"
 
 
 def test_resolving_a_malformed_edit_writes_nothing(fake_admin_api):
@@ -346,9 +349,12 @@ def _refreshable_app():
         resolver.show_field_resolver(field)
     st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
 
-    message = st.session_state.get("conflict-resolver-msg-42")
-    if message is not None:
-        st.text(f"{message[0]}: {message[1]}")
+    toast = st.session_state.get("conflict-toast-42")
+    error = st.session_state.get("conflict-error-42")
+    if error is not None:
+        st.text(f"error: {error}")
+    elif toast is not None:
+        st.text(f"success: {toast}")
 
 
 def test_editor_follows_a_value_that_changed_under_it(fake_admin_api):
@@ -439,9 +445,12 @@ def _empty_string_app():
         resolver.show_field_resolver(field)
     st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
 
-    message = st.session_state.get("conflict-resolver-msg-42")
-    if message is not None:
-        st.text(f"{message[0]}: {message[1]}")
+    toast = st.session_state.get("conflict-toast-42")
+    error = st.session_state.get("conflict-error-42")
+    if error is not None:
+        st.text(f"error: {error}")
+    elif toast is not None:
+        st.text(f"success: {toast}")
 
 
 def test_choosing_an_empty_string_writes_it_rather_than_removing_the_field(fake_admin_api):
@@ -465,7 +474,7 @@ def test_emptying_the_editor_removes_the_field_and_says_so(fake_admin_api):
     at = at.button[0].click().run()
 
     assert "note" not in fake_admin_api.calls[0]["config"]
-    assert "(field removed)" in at.text[0].value
+    assert "1 removed" in at.text[0].value
 
 
 def test_choosing_staging_everywhere_writes_nothing(fake_admin_api):
@@ -512,9 +521,12 @@ def _realistic_app():
         resolver.show_field_resolver(field)
     st.button("Resolve conflicts", disabled=bool(resolver.fields_undecided), on_click=resolver.resolve_conflicts)
 
-    message = st.session_state.get("conflict-resolver-msg-42")
-    if message is not None:
-        st.text(f"{message[0]}: {message[1]}")
+    toast = st.session_state.get("conflict-toast-42")
+    error = st.session_state.get("conflict-error-42")
+    if error is not None:
+        st.text(f"error: {error}")
+    elif toast is not None:
+        st.text(f"success: {toast}")
 
 
 @pytest.fixture


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

Closes #6736.

The editor next to each PRODUCTION/STAGING radio was a keyed Streamlit widget created with `value=`, which is ignored from the second render onwards. So it kept whatever it was born with — production's value, since the radio defaulted to option 1 — and `resolve_conflicts` wrote that into the staging chart, reverting the staging-side work without saying so.

What changed in `conflict_resolver.py`:

- The editor is driven through `st.session_state` and re-seeded whenever the chosen environment changes.
- Resolutions are read from the widgets **at click time**. They used to be collected while rendering, and callbacks run before the rerun, so an edit typed without blurring the box first was dropped.
- No environment is preselected (`index=None`), "Resolve conflicts" is disabled until every field is decided, and there are "Use staging for all" / "Use production for all" shortcuts. The existing "Mark as resolved: accept all changes from staging" button is untouched.
- No more type guessing on save. An untouched field keeps its value as-is (a list stays a list), a string field stays a string (a note of `2024` was becoming the number 2024), and a malformed edit aborts the resolve with a message instead of writing a string into a list field.
- `isInheritanceEnabled` is re-attached after schema validation, which strips it — resolving that field used to be a silent no-op.
- `version`/`id`/`isPublished` are no longer offered as conflicts: the resolver now shares `configs_are_equal`'s ignore list (`CONFIG_KEYS_IGNORE`), so `version`, which differs on essentially every conflict, stops showing up.
- A resolve now reports which side each field took, and logs it.

Verification: 14 new tests in `tests/apps/wizard/app_pages/chart_diff/test_conflict_resolver.py`, no DB and no network — unit tests for the parsing/merging, an `AppTest` that flips the radio and asserts the editor follows, and two end-to-end ones through the click path asserting what reaches the admin API. `make check` and `make unittest` are clean. Not covered: the browser flow against a live staging server with a real conflict.

Worth knowing: charts where the per-field "Resolve conflicts" button was used may have had their staging edits reverted to production's values — an indicator remap is the case that hurts, since the chart ends up pointing at a variable the update retired. The "Mark as resolved" button never wrote a config, so it was never affected.
