### PR TITLE
📊 energy: Fix broken link in explainer energy article

### DIFF
--- a/etl/steps/export/multidim/energy/latest/energy_mix.config.yml
+++ b/etl/steps/export/multidim/energy/latest/energy_mix.config.yml
@@ -20,7 +20,7 @@ definitions:
         # where the underlying values are identical under both methods.
         relatedQuestions:
           - text: "Why has our energy data changed?"
-            url: "https://ourworldindata.org/how-primary-energy-is-measured-has-changed-across-our-charts"
+            url: "https://ourworldindata.org/primary-energy-measurement-change"
 dimensions:
   - slug: "source"
     name: "Source"

--- a/etl/steps/export/multidim/energy/latest/energy_mix.py
+++ b/etl/steps/export/multidim/energy/latest/energy_mix.py
@@ -281,7 +281,7 @@ COMMON_VIEW_EXTRAS = {
     "relatedQuestions": [
         {
             "text": "Why has our energy data changed?",
-            "url": "https://ourworldindata.org/how-primary-energy-is-measured-has-changed-across-our-charts",
+            "url": "https://ourworldindata.org/primary-energy-measurement-change",
         }
     ],
 }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @pabloarosado at the wheel._

The "Why has our energy data changed?" related question added in [📊 energy: Update Statistical Review and refactor energy namespace](https://github.com/owid/etl/pull/6393) pointed at `ourworldindata.org/how-primary-energy-is-measured-has-changed-across-our-charts`, which 404s. That string is the explainer's **title** slugified; the article is published at [`ourworldindata.org/primary-energy-measurement-change`](https://ourworldindata.org/primary-energy-measurement-change). The link was written before the article was published, so it was never checked against a live URL.

## What carried the broken link

105 chart configs in total, all of them from that one related question:

| Surface | Count | Fixed by |
|---|---|---|
| `energy-mix` multidim (page config + views) | 80 views | this PR (`energy_mix.config.yml`, `energy_mix.py`) |
| Standalone charts | 25 | admin API on staging (not defined in this repo) |

Nothing else references the bad slug: no narrative charts, no explorers, no DoDs, no article or topic-page links, and no orphaned chart configs from the retired charts. The `electricity-mix` and `fossil-fuels` multidims never carried the related question — it was deliberately scoped to `energy-mix`, since electricity generation and absolute fossil quantities are identical under both methodologies — so they needed no change.

The other OWID links in the energy steps were checked too, and all of them resolve.

## Verification

On `staging-site-data-fix-brokenlink-energyexplainer`, after running the export step and applying the chart edits:

- 0 chart configs and 0 multidim page configs still contain the broken slug.
- 105 chart configs (80 `energy-mix` views + 25 charts) and 1 multidim page config now carry `/primary-energy-measurement-change`, which returns 200.

## Still open

- The 25 chart-config edits live on staging and reach production through chart sync on merge — they are not in this diff.
- A site redirect from the broken slug to the article is already live, so readers hitting an old copy of the link (a cached page, a shared URL) still land on the article.
