### PR TITLE
🐝 sync grapher schema (inapplicableEntityNames)

### DIFF
--- a/etl/collection/model/schema_types.py
+++ b/etl/collection/model/schema_types.py
@@ -303,6 +303,7 @@ class _ViewConfigBase(TypedDict, total=False):
     hideSeriesLabels: bool
     hideTimeline: bool
     hideTotalValueLabel: bool
+    inapplicableEntityNames: list[str]
     includedEntityNames: list[str]
     internalNotes: str
     invertColorScheme: bool

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1802,6 +1802,13 @@
                             "type": "string"
                           }
                         },
+                        "inapplicableEntityNames": {
+                          "type": "array",
+                          "description": "Entities the indicator's data can't apply to by construction, e.g. Mexico for \"Where do Mexican emigrants live?\". On the map, they are excluded from the color scale and rendered in a dedicated pattern.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
                         "peerCountryStrategy": {
                           "type": "string",
                           "description": "Strategy for selecting peer countries for comparison",

--- a/schemas/explorer-schema.json
+++ b/schemas/explorer-schema.json
@@ -401,6 +401,9 @@
                             "includedEntityNames": {
                                 "$ref": "grapher-schema.011.json#/properties/includedEntityNames"
                             },
+                            "inapplicableEntityNames": {
+                                "$ref": "grapher-schema.011.json#/properties/inapplicableEntityNames"
+                            },
                             "entityTypePlural": {
                                 "$ref": "grapher-schema.011.json#/properties/entityTypePlural"
                             },

--- a/schemas/grapher-schema.011.json
+++ b/schemas/grapher-schema.011.json
@@ -254,6 +254,14 @@
         "type": "string"
       }
     },
+    "inapplicableEntityNames": {
+      "type": "array",
+      "description": "Entities the indicator's data can't apply to by construction, e.g. Mexico for\n\"Where do Mexican emigrants live?\". On the map, they are excluded from the\ncolor scale and rendered in a dedicated pattern.\n",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "selectedEntityColors": {
       "type": "object",
       "description": "Colors for selected entities",

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -903,6 +903,9 @@
                             "includedEntityNames": {
                                 "$ref": "grapher-schema.011.json#/properties/includedEntityNames"
                             },
+                            "inapplicableEntityNames": {
+                                "$ref": "grapher-schema.011.json#/properties/inapplicableEntityNames"
+                            },
                             "entityTypePlural": {
                                 "$ref": "grapher-schema.011.json#/properties/entityTypePlural"
                             },


### PR DESCRIPTION
> _Written by Claude Opus 5 — @pabloarosado at the wheel._

Upstream added one property to `grapher-schema.011.json` **in place**, so the vendored copy went stale and `test_vendored_grapher_schema_is_current` has been failing the staging integration build on every branch. Surfaced by [PR #6742](https://github.com/owid/etl/pull/6742), unrelated to it.

## The upstream change

[`owid/owid-grapher@ef501a489`](https://github.com/owid/owid-grapher/commit/ef501a489) — "🔨🤖 move inapplicableEntities to the chart level", merged 2026-08-20. One new property, no version bump (`grapher-schema.latest.json` still resolves to `011`):

```json
"inapplicableEntityNames": {
  "type": "array",
  "description": "Entities the indicator's data can't apply to by construction, e.g. Mexico for\n\"Where do Mexican emigrants live?\". On the map, they are excluded from the\ncolor scale and rendered in a dedicated pattern.\n",
  "default": [],
  "items": { "type": "string" }
}
```

## What each file needed

| File | Change |
|---|---|
| `schemas/grapher-schema.011.json` | Re-vendored (`--refresh`) |
| `schemas/multidim-schema.json`, `schemas/explorer-schema.json` | `$ref` for the new property |
| `schemas/dataset-schema.json` | Mirrored into the embedded `grapher_config` block |
| `etl/collection/model/schema_types.py` | Regenerated |

On the two view schemas: the property moved from the map config to the chart level upstream and is read by `GrapherState`, so a chart config produced by an mdim or explorer view honours it exactly as it honours `includedEntityNames` and `excludedEntityNames`. Both of those already have `$ref`s, and the new one is placed alongside them. Without the `$ref` the regenerated types silently omit the field — the failure mode from [#6196 → #6200](https://github.com/owid/etl/pull/6200) that dropped `dumbbell`.

In `dataset-schema.json` it follows the convention of the neighbouring array properties: no `default`, and the description reflowed onto one line. The deliberate ETL-side deviations in that block are untouched.

## Verification

- `pytest tests/test_schema_types_generation.py tests/test_metadata_schemas.py` — 7 passed.
- `pytest tests -k "collection or schema"` — 203 passed.
- `pytest tests/test_metadata_schemas.py -m integration` — 2 passed, so both `test_vendored_grapher_schema_is_current` and `test_no_newer_grapher_schema_version` are green.
- `make check` clean.

## Still open

The scheduled `sync-grapher-schema` workflow should have opened this PR itself and did not. Its 2026-08-21 07:15 UTC run reported `changed=false` — every step after the check was skipped — even though the upstream commit landed 23 hours earlier, on 2026-08-20 08:36 UTC. Either the schema is published to `files.ourworldindata.org` well after the grapher merge, or the workflow's `curl` read a stale CDN copy. Worth a look by someone who knows the publish path, since the watchdog silently missing a change is the failure mode it exists to prevent. Not addressed here.
