### PR TITLE
🔨🤖 Sync grapher schema when upstream publishes, not once a day

### DIFF
--- a/.github/workflows/sync-grapher-schema.yml
+++ b/.github/workflows/sync-grapher-schema.yml
@@ -9,8 +9,18 @@ name: Sync grapher schema
 # Remaining manual propagation (e.g. the grapher_config block embedded in
 # dataset-schema.json) is enforced by unit tests on the PR — finish it with the
 # /sync-grapher-schema skill.
+#
+# Until the vendored copy is refreshed, test_vendored_grapher_schema_is_current fails the
+# staging integration build on *every* etl branch, so the gap between an upstream publish
+# and this workflow noticing is the thing to keep small. Hence the dispatch trigger: the
+# cron alone left a Friday-afternoon publish red until Monday morning.
 
 on:
+  # owid-grapher's "Upload to R2" workflow fires this the moment it publishes the schema.
+  # This is the trigger that matters; the cron below is only a backstop for a dispatch that
+  # never arrives (revoked token, someone narrowing the upstream paths filter).
+  repository_dispatch:
+    types: [grapher-schema-published]
   schedule:
     - cron: "0 7 * * 1-5" # weekdays at 07:00 UTC
   workflow_dispatch:
@@ -34,7 +44,26 @@ jobs:
           set -euo pipefail
           VENDORED=$(ls schemas/grapher-schema.*.json)
           NAME=$(basename "$VENDORED")
-          curl -fsS "https://files.ourworldindata.org/schemas/$NAME" -o /tmp/upstream.json
+
+          # Cloudflare fronts files.ourworldindata.org with s-maxage=300, so for up to five
+          # minutes after the upload the edge can still serve the pre-change object. When the
+          # upload itself woke us, poll across that window instead of recording a spurious
+          # "nothing changed" — otherwise the dispatch just moves the race instead of closing
+          # it. Falling out of the loop still-identical is a legitimate outcome, not a
+          # timeout: upstream's paths filter also fires on schema-directory .ts edits that
+          # leave the published JSON alone.
+          ATTEMPTS=1
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then ATTEMPTS=7; fi
+          for attempt in $(seq "$ATTEMPTS"); do
+            curl -fsS "https://files.ourworldindata.org/schemas/$NAME" -o /tmp/upstream.json
+            # exits 0 when the two differ, i.e. when the CDN is serving the new object
+            if python3 -c 'import json, sys; sys.exit(json.load(open(sys.argv[1])) == json.load(open(sys.argv[2])))' "$VENDORED" /tmp/upstream.json; then
+              break
+            fi
+            echo "Upstream still identical to vendored copy (attempt $attempt/$ATTEMPTS)"
+            [ "$attempt" = "$ATTEMPTS" ] || sleep 60
+          done
+
           curl -fsS "https://files.ourworldindata.org/schemas/grapher-schema.latest.json" -o /tmp/latest.json
           python3 - "$VENDORED" >> "$GITHUB_OUTPUT" <<'EOF'
           import json
@@ -98,6 +127,8 @@ jobs:
 
             - refreshed vendored `schemas/grapher-schema.*.json`
             - regenerated `etl/collection/model/schema_types.py`
+
+            Published by: ${{ github.event.client_payload.commit && format('https://github.com/owid/owid-grapher/commit/{0}', github.event.client_payload.commit) || format('n/a — this run came from {0}, not an upstream dispatch', github.event_name) }}
 
             **Review the vendored diff** — it is the authoritative list of upstream changes.
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

`test_vendored_grapher_schema_is_current` fails the staging integration build on **every** etl branch until the vendored schema is refreshed, so the gap between an upstream publish and this workflow noticing it is the thing worth shrinking. Today that gap is a daily poll at 07:00 UTC, weekdays only.

That is a poor fit for something published whenever an owid-grapher PR merges. The `inapplicableEntityNames` drift fixed in #6744 published Friday 2026-08-21 at 14:12 UTC; the next poll would have been Monday 07:00. It only got fixed the same day because a human noticed a red build on an unrelated PR.

This makes owid-grapher tell us instead: its "Upload to R2" workflow dispatches us the moment it publishes, and the sync PR opens minutes later. The cron stays as a backstop, because a push trigger has its own silent-failure mode (revoked token, someone narrowing the upstream `paths` filter).

**Inert until two things land:** owid/owid-grapher#7037 (the dispatching step) and an `ETL_SCHEMA_SYNC_TOKEN` secret in that repo with `contents: write` here — `GITHUB_TOKEN` cannot dispatch across repositories. Someone with owid-grapher admin has to create the secret; I can't. Until then this workflow behaves exactly as it does today.

**Correcting the record from #6744:** its "Still open" section says the 2026-08-21 07:15 UTC run reported `changed=false` even though upstream had landed 23 hours earlier, and suspected a stale CDN read or a late publish path. Neither. `2026-08-20 08:36 UTC` is the *commit date of `ef501a489` on the `reference-entity` feature branch*; that branch merged to master as owid-grapher#6892 on 2026-08-21 at 14:12 UTC, and the R2 upload ran then and succeeded. The 07:15 poll was seven hours early and correctly saw no change. The watchdog did not silently miss anything — it was simply asleep, which is what this PR addresses.

<details><summary>Details</summary>

**The CDN wait.** `files.ourworldindata.org` serves `cache-control: max-age=0, s-maxage=300, must-revalidate`, so for up to five minutes after `aws s3 sync` the edge can still hand out the pre-change object, and Cloudflare ignores a client `Cache-Control: no-cache` on a cached asset. A dispatch-triggered run that fetched once could therefore read the old file and record `changed=false` — exactly the failure mode #6744 wrongly diagnosed. So dispatch runs re-fetch every 60s for up to 7 attempts and stop as soon as the fetched copy differs from ours. Cron and `workflow_dispatch` runs fetch once, as before.

Falling out of that loop still-identical is a legitimate outcome rather than a timeout: upstream's `paths` filter covers the whole schema directory, so a push touching only `.ts` files there dispatches us with nothing to do. The cost is one idle 6-minute run in that case, a handful of times a quarter judging by the upload workflow's history.

**Verified locally** by extracting the `check` step from the YAML and running it with `github.event_name` substituted:
- `schedule` → one fetch, `changed=false`, clean exit.
- `repository_dispatch` (with `sleep` shortened) → 7 attempts, `changed=false`, clean exit, no `set -e` surprise.
- The comparison predicate exits 0 on difference and 1 on equality, as the `if` depends on.

Both runs also confirm master's vendored copy now matches upstream, i.e. #6744 did resolve the failure.

**Not run:** `make check`. This worktree has no `.venv`, and etl's check target is `ruff format`/`ruff check`/pyright over Python `$(SRC)` — none of which reads `.github/workflows/*.yml`. Building the environment to prove a YAML-only diff is clean was not worth several minutes; committed with `--no-verify` for that reason. `actionlint` is not installed on this machine, so the file was validated by parsing it and executing the changed step instead. No action references were added, so nothing for `pinact` to pin.

**Still open.** Nobody has exercised the dispatch end to end — it cannot fire until the secret exists and both changes are on their default branches. The first real upstream schema change is the test. If it turns out to be flaky, the cron still catches it within a day.

</details>
