### PR TITLE
🐛 Stop withholding a topic's best search term on a coin toss

### DIFF
--- a/scripts/vocabulary/coverage_model.py
+++ b/scripts/vocabulary/coverage_model.py
@@ -83,19 +83,29 @@ def split_into_match_words(text: str) -> list[str]:
     return [word for word in slug.split("-") if word]
 
 
-def record_row_texts(record: dict) -> list[str]:
-    """The texts a row actually displays: its title, subtitle and each producer.
+def record_subject_texts(record: dict) -> list[str]:
+    """What the chart is about: its title and its subtitle.
+
+    The row the site renders also carries the dataset's producers, and its search
+    filter reads them, so typing "UNESCO" does narrow the list. They are left out
+    *here* because this is the measure a suggestion is chosen by, and a producer
+    is not a subject: read with producers, "UNESCO" covered 96% of Literacy and
+    "IHME" most of Malaria, and those won the line on coverage alone. Read from
+    the title and subtitle, Literacy suggests "literacy, numeracy, living
+    languages" instead.
+
+    Measuring less than the site matches is the safe direction: producers only
+    ever *add* rows, so a term that reaches a chart here reaches it there too and
+    no suggestion can turn into a dead end.
 
     Kept as separate strings rather than joined, because the site never satisfies
     a query from words gathered across two of them.
     """
-    texts = [record.get("title") or "", record.get("subtitle") or ""]
-    texts.extend(record.get("datasetProducers") or [])
-    return [text for text in texts if text]
+    return [text for text in (record.get("title"), record.get("subtitle")) if text]
 
 
 def record_matches_term(record: dict, term: str) -> bool:
-    """Whether the block would show this row for this term.
+    """Whether this row is about this term.
 
     Every word of the term must appear in one of the row's own texts, in any
     order, with the last word allowed to match a prefix — see
@@ -105,7 +115,7 @@ def record_matches_term(record: dict, term: str) -> bool:
     if not term_words:
         return True
     leading, last = term_words[:-1], term_words[-1]
-    for text in record_row_texts(record):
+    for text in record_subject_texts(record):
         text_words = split_into_match_words(text)
         if all(word in text_words for word in leading) and any(
             word.startswith(last) for word in text_words
@@ -416,7 +426,7 @@ def offerable_candidates(candidates: list[str], topic_name: str) -> list[str]:
     its text at all: "religious" is not a substring of "Religion" and covers 81%
     of it, while "poverty line" contains the whole of "Poverty" and covers 12%.
     It is answerable from what the term covers, which is what
-    select_terms_by_coverage does with BROAD_TERM_SHARE.
+    select_terms_by_coverage does with SUBSUMING_CHART_SHARE.
     """
     return [candidate for candidate in candidates if not _is_place_name(candidate)]
 
@@ -433,29 +443,31 @@ def _is_place_name(term: str) -> bool:
     return term.strip().lower() in _COMMON_PLACE_WORDS
 
 
-# When one term covers more than this share of a topic — of its views *or* of its
-# charts — it is a blunt instrument: a reader clicking it is shown most of the
-# page they are already on.
+# A term matching this share of a topic's charts narrows nothing: a reader
+# clicking it is shown the page they are already on. "malaria" matches all 20
+# charts on Malaria, "poverty" all but a handful of Poverty's 250 — offering them
+# spends the line's first slot to stand still, and, since everything else is then
+# a subset that adds nothing, the line stops there. Held back, those topics
+# suggest "cases, deaths, children, funding" and "extreme poverty, relative
+# poverty, national poverty lines" instead.
 #
-# Both measures are needed. On Tuberculosis the term "tuberculosis" reaches 50 of
-# the topic's 52 charts but only 47% of its views, because the two most-viewed are
-# about causes of death generally. Judged on views alone it looked specific enough
-# to keep, and taking it made every real term — drug resistance, treatment, BCG —
-# a subset of it that added nothing, so coverage hit 100% with three blunt terms
-# and stopped.
-# Such a term is held back and used only when the sharper terms together cannot
-# reach this same share — the case for a topic whose charts are all named after
-# it, where nothing else reaches them at all.
+# Counted in charts, not views, and set where terms stop narrowing rather than
+# where they start being broad. Both of those were wrong before, and together
+# they made the rule a coin toss:
 #
-# Used for both halves on purpose, so there is one number rather than two: "a
-# term covering more than half the topic is blunt, and a blunt one is worth it
-# only if the rest cannot reach half". Both halves are reported per topic, so the
-# number can be judged from output rather than taste.
-#
-# It buys a great deal. Allowed everywhere, blunt terms lift median coverage from
-# 90% to 98% but collapse fifteen topics to a single chip — Poverty's 250 charts
-# reduced to "poverty". Held back entirely, thirty topics under-cover badly.
-BROAD_TERM_SHARE = 0.5
+# - It read views, so the *same* term on the same charts changed category as
+#   traffic moved. "sex ratio" matches 6 of Gender Ratio's 15 charts and sat at
+#   53% of its views — just over the old bar — so it was withheld, and the topic
+#   suggested six terms reaching half of it while five charts named "Sex ratio …"
+#   had nothing pointing at them. A week earlier the same code had suggested it
+#   first and reached 99%. A chart count only moves when charts are published, so
+#   the decision now holds still.
+# - The bar was half the topic, which is where useful terms live, not useless
+#   ones: a term matching six charts in fifteen is the most narrowing thing on
+#   offer. Anywhere in 80–95% the outcome is near enough identical (median
+#   coverage 94.3%, 95.0%, 95.7%), because almost nothing real sits there — which
+#   is the point of putting the bar there.
+SUBSUMING_CHART_SHARE = 0.9
 
 
 def select_terms_by_coverage(
@@ -480,6 +492,11 @@ def select_terms_by_coverage(
     "sex-selective abortion" and "excess female mortality", three terms and two
     charts. And a term the block would show nothing for covers nothing, so it
     can't be taken at all.
+
+    The one thing withheld from the competition is a term that matches nearly
+    every chart, because it narrows nothing (SUBSUMING_CHART_SHARE). Coverage is
+    otherwise the only criterion: a term revealing most of a topic is taken if it
+    reveals the most, which is what the line is supposed to open with.
     """
     candidates = offerable_candidates(candidates, universe.topic_name)
     matches = {term: match_identities(universe, term) for term in candidates}
@@ -491,26 +508,25 @@ def select_terms_by_coverage(
         return sum(weight_of.get(identity, 0.0) for identity in identities)
 
     self_named = match_identities(universe, universe.topic_name)
-    # Blunt terms — ones that alone reveal most of the topic — are set aside and
-    # only brought back if the rest cannot do the job. See BROAD_TERM_SHARE.
-    blunt = {
+    # Terms that match nearly every chart narrow nothing, so they are not offered
+    # — see SUBSUMING_CHART_SHARE. Everything else competes on coverage as usual,
+    # however much of the topic it happens to reveal.
+    narrowing = [
         term
-        for term, identities in matches.items()
-        if (total_weight and weight(identities) / total_weight > BROAD_TERM_SHARE)
-        or (total_count and len(identities) / total_count > BROAD_TERM_SHARE)
-    }
-    sharp = [term for term in candidates if term not in blunt]
+        for term in candidates
+        if not (
+            total_count and len(matches[term]) / total_count > SUBSUMING_CHART_SHARE
+        )
+    ]
 
     selection = _greedy(
-        universe, sharp, matches, weight, max_terms, min_marginal_share
+        universe, narrowing, matches, weight, max_terms, min_marginal_share
     )
-    if (
-        blunt
-        and total_weight
-        and selection.covered_weight / total_weight <= BROAD_TERM_SHARE
-    ):
-        # The sharp terms can't reach half the topic, so its charts really are
-        # only findable by the name they share with it.
+    if not selection.selected:
+        # Every candidate matches the whole topic. That happens on a topic whose
+        # charts are all named after it — Energy Mix, whose ten charts are all
+        # about the energy mix — where a term that narrows nothing is still better
+        # than no suggestion at all.
         selection = _greedy(
             universe, candidates, matches, weight, max_terms, min_marginal_share
         )

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -233,12 +233,13 @@ What makes this list good is that each term takes the reader somewhere *differen
 
 Do not worry about whether a term is too broad, or too close to the topic's own
 name. That is measured afterwards against the chart list, far more reliably than
-either of us can guess: a term that turns out to reveal most of the topic is set
-aside unless nothing narrower reaches those charts. So offer the obvious central
-terms — "child mortality" on Child & Infant Mortality, "religious" on Religion,
-"female population" on Gender Ratio — including the topic's own name and the bare
-root of it. Withholding them is how a topic ends up with no way to reach the very
-charts it exists for; offering one that turns out too blunt costs nothing.
+either of us can guess: the only term dropped for breadth is one matching nearly
+every chart above, which would narrow nothing. Anything short of that competes on
+what it reveals. So offer the obvious central terms — "child mortality" on Child &
+Infant Mortality, "religious" on Religion, "sex ratio" and "female population" on
+Gender Ratio — including the topic's own name and the bare root of it. Withholding
+them is how a topic ends up with no way to reach the very charts it exists for;
+offering one that turns out too broad costs nothing.
 
 Give a generous list — only a handful are ever shown, and they are picked from
 yours by measuring how much of the chart list above each one actually brings up.


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

The vocabulary published yesterday suggests this on Gender Ratio:

> female population, life expectancy, missing women, birth order, unemployment, drug use

Six terms reaching half the topic, while five charts named "Sex ratio …" — the other half of its traffic — have nothing pointing at them. The model had proposed `sex ratio`; selection threw it away. A run hours earlier, on the same code, had offered it first and reached 99%.

## Why

The rule that holds back over-broad terms had two faults which together made it a coin toss.

**It read view counts.** A term covering more than half a topic's *views* was withheld unless the remaining terms couldn't reach half either. `sex ratio` matches 6 of Gender Ratio's 15 charts and sat at 53% of its views; the terms left over reached 50.1%. A tenth of a percentage point the wrong side of the bar, and the topic lost its best term. Nothing about the charts had changed between the two runs — traffic had moved. The test now counts charts, which only move when charts are published.

**The bar was in the wrong place.** Half a topic is where the *most useful* term sits, not the most useless. What actually makes a term not worth offering is that it narrows nothing — `malaria` matches all 20 charts on Malaria, so clicking it shows you the page you are already on. The bar is now 90% of a topic's charts. Anywhere in 80–95% gives near-identical results (median coverage 94.3%, 95.0%, 95.7%), because almost nothing real sits there; that flatness is the point of moving it.

## A second thing this turned up

Coverage was measured over the dataset-producer field as well as the title and subtitle, so producer names looked like excellent subject terms. `UNESCO` covered 96% of Literacy and led its line; `IHME` led Malaria's. Coverage now reads what a chart is *about*.

This measures less than the site matches — its search filter does read producers, so typing "UNESCO" still narrows the list. That is the safe direction: producers only ever add rows, so a term reaching a chart here reaches it there too, and no suggestion can become a dead end.

## What it does to the output

All 125 topics, against the same chart data and analytics as the vocabulary now published:

| | before | after |
| --- | --- | --- |
| median coverage of a topic's views | 83.3% | **93.2%** |
| topics below 35% | 1 | **0** |
| topics offering one term or none | 8 | **2** |
| terms published | 733 | 730 |

75 topics change their opening term.

| Topic | Before | After |
| --- | --- | --- |
| Gender Ratio | female population, life expectancy, missing women, … | **sex ratio**, female population, life expectancy, … |
| Cancer | cancer | cervical cancer, lung cancer, age-standardized, stomach cancer, … |
| Tuberculosis | deaths, tuberculosis, vaccination | deaths, cases, HIV, vaccination, incidence, treatment |
| Literacy | **UNESCO**, numeracy, living languages | literacy, illiterate, age, languages |
| Malaria | age, cases, children, funding | deaths, cases, children, GDP per capita, funding |
| Energy Mix | energy supply | primary energy, fossil fuels |

**Coverage falls where it was being earned dishonestly.** Cancer now reports 47.9% against the old 96.3% — because the old line was the single term `cancer`, which matches every chart on the topic. The report says as much itself: *the topic's own name alone reaches 96% of these views, which no suggestion can narrow*. A lower number against eight usable suggestions is the better outcome, but the number does go down, and anyone reading the report should know why.

## Nothing is published by this

The vocabulary in the bucket is unchanged; regenerating it is a separate manual run. Worth doing once this lands, since the file currently live is the one with the Gender Ratio line above. Nothing on ourworldindata.org reads it until owid/owid-grapher#7016 ships.

<details><summary>Details</summary>

### Changed

- **`coverage_model.py`**
    - `record_row_texts` → `record_subject_texts`: title and subtitle, no producers. `record_matches_term` unchanged otherwise, so the word-boundary/prefix semantics still mirror `textContainsAllQueryWords`.
    - `BROAD_TERM_SHARE = 0.5` → `SUBSUMING_CHART_SHARE = 0.9`, and the test drops its view-weight clause.
    - `select_terms_by_coverage`: the two-pass "set blunt terms aside, bring them back if the sharp ones can't reach half" is gone. One pass over the terms that narrow something; the fallback over *all* candidates now fires only when nothing narrows the topic at all (Energy Mix's ten charts are all about the energy mix), where a term that narrows nothing still beats no suggestion.
- **`vocabulary.py`** — the prompt paragraph telling the model not to worry about breadth described the old rule; it now describes the new one, and names `sex ratio` among the central terms worth offering.

### How this was measured

Rather than re-paying for the model per experiment, one pass cached each topic's weighted universe and its raw candidate list, and the selection variants were then compared offline over that fixed input. Two caches were built, from two different analytics snapshots, because the bug is a sensitivity to exactly that:

| | current rule | this PR |
| --- | --- | --- |
| Gender Ratio, snapshot A | 99.3% — opens `sex ratio` | 99.3% — opens `sex ratio` |
| Gender Ratio, snapshot B | 50.1% — no `sex ratio` | 99.3% — opens `sex ratio` |

Variants that were tried and rejected, both measured over both snapshots:

- **Drop the breadth rule entirely.** Median coverage 96.6%, but Malaria collapses to `malaria`, Polio to `polio`, and Influenza's 88 records to `influenza A, flu`. The rule earns its place; only its threshold was wrong.
- **Build both lines and prefer the one with more terms.** Never loses terms, but loses coverage catastrophically where the narrow line is long and useless — Life Expectancy would publish six terms reaching 17.8% in place of four reaching 91%. Coverage has to dominate; term count can't.

### Verified

`make format`, `make lint` (includes `ty check`) clean. The CLI was run over all 125 topics for the numbers above, and on `gender-ratio`, `malaria` and `cancer` individually to confirm the offline harness and the real pipeline agree.

</details>
