### PR TITLE
♻️ Publish the suggestion line rather than a list to trim

### DIFF
--- a/scripts/vocabulary/README.md
+++ b/scripts/vocabulary/README.md
@@ -72,7 +72,7 @@ staging server.
 - `--report PATH` - Write an HTML coverage report: per term, what it reveals and what it adds, plus the most-viewed charts nothing covers
 - `--weighting {views,uniform}` - Weight charts by views (default) or count them equally
 - `--views-column {views_7d,views_14d,views_365d}` - Which window to weight by (default `views_365d`; a vocabulary is read for weeks, so the year is steadier than the week)
-- `--max-terms N` - Most terms to publish per topic (default 8; the site shows five and drops some, so a couple of spares keep the line full)
+- `--max-terms N` - Most terms to publish per topic (default 5). The site renders the list as published, so this is the length of the suggestion line and the coverage reported per topic describes exactly what a reader can reach
 - `--min-marginal-share F` - Stop once the next term would reveal less than this share of a topic's views (default 0.01)
 
 ## Chart view data

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -84,12 +84,20 @@ LLM_RETRY_BACKOFF_SECONDS = 4
 # How many topics' record sets to fetch at once.
 SEARCH_CONCURRENCY = 8
 
-# How many terms to publish. The site shows five, then drops any that name a place
-# or repeat the topic's own name, so a couple of spares keep the line full.
-DEFAULT_MAX_TERMS = 8
+# How many terms to publish, which is also how many the site shows: it renders
+# the list as published rather than trimming it, so this is the length of the
+# suggestion line itself.
+#
+# It used to publish eight as spares, on the reasoning that the site would drop
+# some. It drops only place names, and currently drops none of them, so the
+# spares were never shown — which quietly made the coverage reported below a
+# claim about a line no reader sees: eight terms reach a median 92.4% of a
+# topic's views, the five shown reach 87.8%. Publishing what is shown makes the
+# number true.
+DEFAULT_MAX_TERMS = 5
 
 # A term revealing less than this share of a topic's views is not worth one of
-# five slots on a single line. Terms just below it are reported as near misses so
+# the line's few slots. Terms just below it are reported as near misses so
 # the floor can be judged from the output.
 DEFAULT_MIN_MARGINAL_SHARE = 0.01
 
@@ -464,10 +472,6 @@ async def process_topics(
                 "weighting": weighting,
                 "views_column": views_column,
                 "selection": "coverage",
-                # The consumer keys "trust this order" off `refined`; the order is
-                # now measured rather than guessed, so it still holds. See
-                # rankSuggestedKeywords in owid-grapher.
-                "refined": True,
             }
         )
         candidates["keyword_stats"] = [


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

Two things that only existed to serve each other.

**`--max-terms` was 8 because the site showed 5.** The spare three were there in case the site dropped some — it drops only place names, and drops none of the terms currently published (verified: 0 of 728). So they were never shown, and the coverage this command reports was describing a line nobody sees:

| | median coverage of a topic's views |
| --- | --- |
| the 8 terms published | 92.4% |
| the 5 terms shown | **87.8%** |

The default is now 5, so the number describes what a reader can actually reach. The lower figure isn't a regression — it's the figure that was always true.

**`stats.refined` was written `True` unconditionally**, so it never distinguished anything. It was read by owid/owid-grapher#7016 to decide between trusting this order and re-deriving one from the topic's chart list; that branch is now deleted there, so the flag has no reader. Dropped.

Neither change touches the published file until someone reruns the command. Worth doing once this lands, so the vocabulary in the bucket is five terms per topic rather than eight.

<details><summary>Details</summary>

- `DEFAULT_MAX_TERMS` 8 → 5, with the reasoning above in the comment.
- `"refined": True` removed from the per-topic `stats` block. Everything else in `stats` — coverage, chart counts, token usage, weighting — is unchanged, and consumers read the file defensively, so removing a key is safe.
- README's `--max-terms` line updated.

Checked on `gender-ratio`: publishes `sex ratio, female population, life expectancy, infanticide, unemployment` reaching 98.2% of its views, with `drug use +1.0%` now reported as a near miss rather than published unseen. `stats` has no `refined` key.

`make format` and `make lint` (includes `ty check`) clean.

</details>
