### PR TITLE
🐛 Fix cache_all passing canonicalized args to the wrapped function

### DIFF
--- a/apps/wizard/utils/__init__.py
+++ b/apps/wizard/utils/__init__.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
+import pandas as pd
 import streamlit as st
 from owid.catalog import Dataset
 from sentry_sdk import capture_exception
@@ -567,6 +568,16 @@ def _canon(x):
     if isinstance(x, np.ndarray):
         # stable, hashable representation for numpy arrays
         return ("__np__", x.dtype.str, x.shape, x.tobytes())
+    if isinstance(x, (pd.DataFrame, pd.Series, pd.Index)):
+        # Content-based key. Falling through to the __dict__ branch below would build a key out of
+        # the internal BlockManager, whose repr contains the object's memory address - so the key
+        # would differ on every call, never hit the cache, and grow the cache without bound.
+        return (
+            "__pandas__",
+            x.__class__.__qualname__,
+            tuple(map(str, getattr(x, "columns", ()))),
+            _canon(pd.util.hash_pandas_object(x, index=True).to_numpy()),
+        )
     # Fallback: try dataclasses/objects with __dict__
     if hasattr(x, "__dict__"):
         return ("__obj__", x.__class__.__qualname__, _canon(vars(x)))
@@ -575,12 +586,12 @@ def _canon(x):
 
 
 def cache_all(f):
-    """A caching decorator that works for unhashable types (lists, dicts)."""
+    """A caching decorator that works for unhashable types (lists, dicts).
 
-    @cache
-    def _cached(key):
-        args_c, kwargs_c = key
-        return f(*args_c, **dict(kwargs_c))
+    The canonical form of the arguments is used as the cache key only; the wrapped function is
+    always called with the original arguments.
+    """
+    results = {}
 
     @wraps(f)
     def wrapper(*args, **kwargs):
@@ -588,7 +599,9 @@ def cache_all(f):
             tuple(_canon(a) for a in args),
             tuple(sorted((k, _canon(v)) for k, v in kwargs.items())),
         )
-        return _cached(key)
+        if key not in results:
+            results[key] = f(*args, **kwargs)
+        return results[key]
 
     return wrapper
 

--- a/tests/apps/wizard/utils/test_wizard_utils.py
+++ b/tests/apps/wizard/utils/test_wizard_utils.py
@@ -1,4 +1,6 @@
-from apps.wizard.utils import as_valid_json
+import pandas as pd
+
+from apps.wizard.utils import as_valid_json, cache_all
 
 
 def test_as_valid_json():
@@ -7,3 +9,35 @@ def test_as_valid_json():
 
     s = '{\n    "time": true\n}'
     assert as_valid_json(s) == {"time": True}
+
+
+def test_cache_all_passes_original_arguments():
+    """The cache key is a canonical (hashable) form of the arguments, but the wrapped function
+    must still receive the originals - not the canonical form."""
+
+    @cache_all
+    def summarize(df, labels):
+        return type(df).__name__, type(labels).__name__, len(df)
+
+    df = pd.DataFrame({"producer": ["a", "a", "b"], "views": [1, 2, 3]})
+
+    assert summarize(df, ["x"]) == ("DataFrame", "list", 3)
+
+
+def test_cache_all_hits_cache_for_equal_dataframes():
+    calls = []
+
+    @cache_all
+    def count(df):
+        calls.append(df)
+        return len(df)
+
+    df = pd.DataFrame({"producer": ["a", "b"], "views": [1, 2]})
+
+    assert count(df) == 2
+    assert count(df.copy()) == 2
+    assert len(calls) == 1
+
+    # A different frame must not reuse the cached result.
+    assert count(pd.DataFrame({"producer": ["a"], "views": [7]})) == 1
+    assert len(calls) == 2


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

`cache_all` built a hashable "canonical" cache key from its arguments and then called the wrapped function with *that key* instead of the original arguments. Anything not already hashable therefore arrived at the function transformed — a `DataFrame` became a tuple — so the wizard's producer-analytics page crashed with `AttributeError: 'tuple' object has no attribute 'groupby'` whenever `st_cache_data` took its non-Streamlit branch. Behaviour change: cached functions now receive what the caller passed.

_Skim — one function, plus a content-based key for pandas objects._

## How it works

`cache_all` backs `st_cache_data` when `Runtime.exists()` is false (bare mode / `AppTest`), so the live wizard never hit this; the [nightly staging build](https://buildkite.com/our-world-in-data/etl-automated-staging-environment/builds/42506) did, in `test_app_producer_analytics`.

Two changes:

- The canonical form is now used **only** as a dict key; the wrapped function is called with the original `*args, **kwargs`. `functools.cache` forced the old shape (its key *is* its argument), so it's replaced with a plain dict — same unbounded-growth characteristics as `functools.cache`.
- `_canon` gets a pandas branch (`DataFrame`/`Series`/`Index`) using `pd.util.hash_pandas_object`. Without it these fall through to the `__dict__` fallback, which walks the internal `BlockManager` and lands on a `repr` containing the object's memory address:

  ```
  ('__obj__', 'DataFrame', (('_attrs', ()), ('_flags', ('__obj__', 'Flags',
    (('_allows_duplicate_labels', True), ('_obj', ('__repr__',
     "<weakref at 0x1091cb2e0; to 'DataFrame' at 0x1011cafd0>"))))), ...
  ```

  So the key differed on every call: the cache never hit, and each miss retained a key holding a full copy of the frame's bytes. Fixing the argument passing alone would have left that in place.

`cache_all` has exactly one caller — verify with `rg -n 'cache_all' apps etl tests lib scripts`.

## Verified

- Reproduced on `master` and confirmed fixed: calling `producer_analytics.producer._process_df` directly (bare mode, so the `cache_all` path) raises the `AttributeError` before, returns the aggregated frame after.
- The two new unit tests fail on `master` (`2 failed, 1 passed`) and pass here — they assert the function receives a `DataFrame`, and that two equal frames hit the cache while a different one does not. They're plain unit tests, so `make unittest` covers this path from now on; the only previous coverage was an integration test.
- **Not verified:** `test_app_producer_analytics` itself. It needs staging DB + BigQuery credentials, and locally the AppTest takes the *Streamlit* branch of `st_cache_data` — which is why it passes on `master` here but fails in CI. The staging build on this PR is the real check.

<details>
<summary>Why the wizard's users never saw this</summary>

`st_cache_data` picks its implementation per call site at decoration time: `st.cache_data` when a Streamlit `Runtime` exists, `cache_all` otherwise. A served wizard page always has a Runtime, so the broken branch was reachable only from bare-mode execution — `AppTest`, or any script importing these modules outside Streamlit. Nothing matching this error appears in Sentry over the last 90 days, consistent with that.
</details>
