### PR TITLE
Retract the batching claim and close the colour-audit handoff

### DIFF
--- a/.claude/skills/create-figma-chart/reference/BENCHMARK.md
+++ b/.claude/skills/create-figma-chart/reference/BENCHMARK.md
@@ -63,7 +63,7 @@ session transcript rather than estimated:
 | ├ approval, asked 13:26:35 → granted 13:26:51 | 16 s *(the checkpoint, by design)* |
 | └ stall, 13:29:16 → 13:30:33 | 77 s *(a defect — see below)* |
 | Figma calls | 30 (28 in the build proper) |
-| messages issuing them | 28 — **nothing was batched** |
+| messages issuing them | 28 — one call each, correctly (see the batching warning below) |
 
 **Two corrections this measurement forced, both against things assumed rather than checked:**
 
@@ -86,18 +86,39 @@ issuing assistant message id**, never by timestamp proximity:
 
 | | why |
 |---|---|
-| Figma calls by tool, and the total | against the 120–190 this skill's budget assumes |
-| messages containing >1 Figma call, and peak in-flight | whether the batch manifest was actually followed |
-
-**On the first run that last row read zero.** 28 calls, 28 messages, peak in-flight **1** — the
-batch manifest was in the skill, and the run followed none of it. That is the single largest
-finding the benchmark has produced, because batching is measured at **~4.0×** and is this branch's
-central claim. The manifest is not self-executing; SKILL.md already records two of five earlier
-sessions batching nothing at all, and the official benchmark is now the sixth data point and the
-worst. **Report this row first** — a run that never batched has not tested the thing being sold.
+| Figma calls by tool, and the total | against the **~14–18 per template** a build should cost |
 | turns, and median gap between them | the term that dominates `turns × (turn + call)` |
+| messages containing >1 Figma call, and peak in-flight | but read the warning below before scoring it |
 | screenshots that were *looked at* vs measured by script | the thing `measure_pixels.py` exists to reduce |
 | re-work: calls spent on a mistake, and what it was | the honest denominator — a fast wrong build is not fast |
+
+### Do not score batching on a single-chart build. It has nothing to batch.
+
+The first run came back **28 calls in 28 messages, peak in-flight 1**, and that was first written up
+here as the benchmark's largest finding — the manifest ignored, the ~4.0× left on the table. **That
+was wrong, and the mistake is worth more than the claim was.** Reading the calls back, 22 of the 28
+were `use_figma` writes to the DI page, and SKILL.md's own rule is that **writes batch only across
+different pages**, since a script may switch pages once and two writes at one page race. A build is
+one page. The three `upload_assets` are the two-pass export solve, serial by the documented
+`measure band → export embed → fit` chain; the two screenshots were four minutes apart on different
+states. **Nothing in that run was batchable.** Zero was the correct number, not a failure.
+
+The manifest's rows are surveys and checks — the Step 5 page enumeration, the Step 8c check pair,
+the Step 9 delivery renders, the palette harvest — and this build had one Step 8c call and two
+renders. So the ~4.0× is real and belongs to *read-heavy* passes; it was never available to the
+build spine.
+
+The general lesson, which is why this stays written down: **a zero is not a finding until you have
+checked that a non-zero was possible.** Measuring the number was right, and reading a verdict into
+it without asking whether the thing was even available is the same error as a check reporting PASS
+on input it could not measure. Score this row only against calls the manifest actually names.
+
+**What the number does say, once batching is off the table.** 28 calls against the ~14–18 a
+template should cost, and 30.8 min / 28 ≈ **66 s per call** where the call itself is ~4.4 s — so
+**~60 s of each is model turn**. The lever on a build is therefore *fewer, fatter* calls, not
+parallel ones: the plugin allows ~10 logical operations per call, and four of the 28 were pure
+diagnosis and rework (`Diagnose why the annotation text did not grow`, two position fixes, a
+re-bold after a style collapse). Turns dominate; that is what `turns × (turn + call)` already says.
 
 ## What this cannot tell you
 

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -6,14 +6,14 @@
 Every one of these caught a real defect on this skill's first run, and none of them is visible by looking at the frame. Run them as a pass, and report the numbers rather than "looks fine".
 
 > **⚠️ `verify_page.js` does not fit in a `use_figma` call as it ships.** The `code` argument caps at
-> **50,000 characters** and the file is **~103,000**, so the instruction below is not executable
+> **50,000 characters** and the file is **~112,000**, so the instruction below is not executable
 > verbatim — a run that pastes it is rejected. Emit it stripped instead:
 >
 > **Run it in slices — that is the supported path, and the only one.** Stripping the comments used to
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **55,257 stripped**. So
+> exists to catch. It has since grown past the cap outright: **58,824 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -25,13 +25,13 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 59% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 54% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 49% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 65% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 66% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 61% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 56% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 72% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (36,965) then
-> `--rows geometry,annotations` (37,647, **75% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (40,532) then
+> `--rows geometry,annotations` (41,214, **82% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there
@@ -77,6 +77,19 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > on the test fixture, it returned a one-entry palette consisting of a text label's fill. `outline__*`
 > strokes are excluded too: that is the white halo under a line, shared by every series.
 >
+> **A legend is furniture, and its swatches are not categories.** grapher draws the legend *inside*
+> the chart group and *outside* the map — a map page reads `chart > numeric-color-legend > {lines,
+> swatches, labels, swatch-hit-areas}` as a **sibling** of `map` — so every filled swatch reached the
+> palette as an ordinary chart-side mark. An ordinary choropleth then reported **two** palettes: the
+> map under `--maps` and its own legend under `--separated`, with a `--suggest` rerun ready to
+> recommend restyling the legend rather than the categories. On a line chart the harm landed on
+> `--names` instead: a numeric legend's bins are unnamed rects, so one swatch in a colour of its own
+> put an import default into the palette and dropped the flag for the whole run. A legend repeats the
+> categories' colours and adds none of its own, so the swatches are excluded, **counted** in the row,
+> and any colour appearing *only* in the legend — an empty bin — is named rather than quietly lost.
+> They keep their boxes for `annotation-overlap`, where an annotation dropped over the legend still
+> covers something the reader needs, and are reported there as "a legend swatch".
+>
 > The mode flag is chosen from what the palette was sourced from, and it is not cosmetic — it also
 > selects which palette a `--suggest` rerun searches. A line or slope palette gets **`--line`**
 > (`--separated` plus the Line and Slope Chart variants, the darker set for thin marks on white);
@@ -101,6 +114,14 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >   nearest `<kind>__<Entity>` **ancestor**, because grapher puts the name on the group and the paint
 >   on its leaves: a `datapoints__<Entity>` marker is a filled leaf called `Ellipse 12`.
 >
+> **A frame that paints no pixels returns one row, not a sheet of them.** Figma switches a node off
+> two independent ways — `visible: false` and opacity — and both are **inherited**, while the walk
+> starts at the frame's *children*, whose own `visible: true` says nothing about whether they render.
+> So a hidden frame, or one under a hidden section, used to certify thirty rows of verdicts about a
+> deliverable nobody can see. Either switch now returns a single `frame-not-rendered` **FAIL** naming
+> which switch is off and where, and the verdict reads `NOT CHECKED` — never "no mechanical row
+> failed". Unhide or reset the frame *and every group and section above it*, then re-run.
+>
 > A `SKIPPED` row is a declared gap in coverage, never a pass — which
 > is the whole reason to read the list rather than the verdict.
 >
@@ -118,7 +139,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > its text — and it separates the one API limitation that is *not* a defect (a bolded `Data source:`
 > prefix cannot be both bold and style-bound through the plugin API, so it reports as `halfBound`; see
 > [TEXTS.md](TEXTS.md)) from real drift. Its harness is
-> [`scripts/test_diff_against_template.js`](../scripts/test_diff_against_template.js) (**49**
+> [`scripts/test_diff_against_template.js`](../scripts/test_diff_against_template.js) (**75**
 > assertions), which found four defects in the script that review had not: a header that lost a row
 > reported as matching, five fingerprinted footer properties never actually compared, and a
 > `TypeError` that killed the whole diff when a row changed type. A fifth, from review: the text
@@ -127,7 +148,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > Validated by planting defects and confirming each row **fails**, twice over: 11 planted in Figma and
 > 11 caught, then a stubbed-figma harness ([`scripts/test_verify_page.js`](../scripts/test_verify_page.js),
-> `node` it after any edit) covering **137** assertions including the rows that are awkward to plant on a
+> `node` it after any edit) covering **262** assertions including the rows that are awkward to plant on a
 > real page. **A check that cannot fail is worse than no check**, so when you extend this script,
 > extend both passes with it.
 >

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -13,7 +13,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **58,824 stripped**. So
+> exists to catch. It has since grown past the cap outright: **58,726 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -30,8 +30,8 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > | `geometry` | box-alignment, gap, margins, off-palette | 56% |
 > | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 72% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (40,532) then
-> `--rows geometry,annotations` (41,214, **82% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (40,437) then
+> `--rows geometry,annotations` (41,116, **82% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there
@@ -122,6 +122,12 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > which switch is off and where, and the verdict reads `NOT CHECKED` — never "no mechanical row
 > failed". Unhide or reset the frame *and every group and section above it*, then re-run.
 >
+> **Non-rendering means exactly zero, never a floor.** A node or paint at 0.005 does reach the canvas,
+> and a cutoff dropped its whole subtree from *every* row — an 8px label at 0.005 left `text-floor`
+> reporting that all of its ranges cleared the floor. Anything positive is **translucent**: held out of
+> the palette, named there so the shortfall is visible, and still judged by every row that is about
+> geometry rather than colour.
+>
 > A `SKIPPED` row is a declared gap in coverage, never a pass — which
 > is the whole reason to read the list rather than the verdict.
 >
@@ -148,7 +154,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > Validated by planting defects and confirming each row **fails**, twice over: 11 planted in Figma and
 > 11 caught, then a stubbed-figma harness ([`scripts/test_verify_page.js`](../scripts/test_verify_page.js),
-> `node` it after any edit) covering **262** assertions including the rows that are awkward to plant on a
+> `node` it after any edit) covering **264** assertions including the rows that are awkward to plant on a
 > real page. **A check that cannot fail is worse than no check**, so when you extend this script,
 > extend both passes with it.
 >

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -55,7 +55,20 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > (`/adversarial-data-review`), entity completeness (needs the *effective* selection from outside
 > Figma), the arrow row (it needs rendered pixels), `leader-on-map` (a **vector** ray-cast against
 > the country's rings — pixels are only its fallback), and the page count (a page-level fact, where
-> the script is handed frames). A `SKIPPED` row is a declared gap in coverage, never a pass — which
+> the script is handed frames).
+>
+> **`colour-vision` and `grayscale-seams` hand back a runnable command, not just an owner.** The
+> script cannot run `color_audit.py` — a Figma plugin sandbox has no shell — but it already holds
+> every plot fill, so it emits the invocation with the palette filled in, the interpreter spelled
+> out and `--names` attached when the node names allow it. Paste and run it; both rows are one run
+> of one script. Two things it cannot decide for you: it assumes `--separated` (nothing shares an
+> edge — true for lines, maps and plain or grouped bars), so on a **stacked or segmented** chart
+> drop that flag and reorder the colours into stack order first, because the seam check reads
+> adjacency off the order you give it. And `--names` is dropped wholesale, with the reason stated,
+> if any fill node is unnamed or carries a comma — a comma would split into two entries and
+> misalign every label after it.
+>
+> A `SKIPPED` row is a declared gap in coverage, never a pass — which
 > is the whole reason to read the list rather than the verdict.
 >
 > **[`scripts/diff_against_template.js`](../scripts/diff_against_template.js) is the other half of the

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -36,6 +36,12 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there
 > together; `--check` fails if their groups no longer cover the file exactly once.
+> Read its **`floor`** column beside that percentage: `sent` is what today's two calls cost and can
+> always be bought down by re-splitting, while `floor` is the preamble plus the single largest row
+> group — the smallest any call can be, whatever the split. `verify_page.js` reads **85% sent against
+> a 75% floor**, so re-splitting still buys real room; when the floor itself passes the cap, slicing is
+> exhausted and the only move left is splitting the script into separate files with their own
+> preambles. `--check` fails on that and warns past 85%.
 > **Run all four** — each reports its own rows and nothing else, so a group you skip is a group
 > nobody checked.
 > `diff_against_template.js` (~12,000 stripped) needs none of this.

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -13,7 +13,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **51,904 stripped**. So
+> exists to catch. It has since grown past the cap outright: **53,765 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -25,13 +25,13 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 53% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 47% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 43% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 58% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 56% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 51% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 46% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 62% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (33,865) then
-> `--rows geometry,annotations` (34,294, **69% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (35,473) then
+> `--rows geometry,annotations` (36,155, **72% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -6,14 +6,14 @@
 Every one of these caught a real defect on this skill's first run, and none of them is visible by looking at the frame. Run them as a pass, and report the numbers rather than "looks fine".
 
 > **⚠️ `verify_page.js` does not fit in a `use_figma` call as it ships.** The `code` argument caps at
-> **50,000 characters** and the file is **~102,000**, so the instruction below is not executable
+> **50,000 characters** and the file is **~103,000**, so the instruction below is not executable
 > verbatim — a run that pastes it is rejected. Emit it stripped instead:
 >
 > **Run it in slices — that is the supported path, and the only one.** Stripping the comments used to
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **54,827 stripped**. So
+> exists to catch. It has since grown past the cap outright: **55,257 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -25,13 +25,13 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 58% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 53% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 48% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 64% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 59% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 54% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 49% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 65% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (36,535) then
-> `--rows geometry,annotations` (37,217, **74% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (36,965) then
+> `--rows geometry,annotations` (37,647, **75% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -6,14 +6,14 @@
 Every one of these caught a real defect on this skill's first run, and none of them is visible by looking at the frame. Run them as a pass, and report the numbers rather than "looks fine".
 
 > **⚠️ `verify_page.js` does not fit in a `use_figma` call as it ships.** The `code` argument caps at
-> **50,000 characters** and the file is **~116,000**, so the instruction below is not executable
+> **50,000 characters** and the file is **~117,000**, so the instruction below is not executable
 > verbatim — a run that pastes it is rejected. Emit it stripped instead:
 >
 > **Run it in slices — that is the supported path, and the only one.** Stripping the comments used to
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **60,227 stripped**. So
+> exists to catch. It has since grown past the cap outright: **60,937 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -28,18 +28,18 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 69% of cap |
 > | `series` | series-weight, furniture-weight, furniture-dash | 64% |
 > | `geometry` | box-alignment, gap, margins, off-palette | 59% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 75% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 76% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (41,938) then
-> `--rows geometry,annotations` (42,617, **85% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (41,960) then
+> `--rows geometry,annotations` (43,327, **87% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there
 > together; `--check` fails if their groups no longer cover the file exactly once.
 > Read its **`floor`** column beside that percentage: `sent` is what today's two calls cost and can
 > always be bought down by re-splitting, while `floor` is the preamble plus the single largest row
-> group — the smallest any call can be, whatever the split. `verify_page.js` reads **85% sent against
-> a 75% floor**, so re-splitting still buys real room; when the floor itself passes the cap, slicing is
+> group — the smallest any call can be, whatever the split. `verify_page.js` reads **87% sent against
+> a 76% floor**, so re-splitting still buys real room; when the floor itself passes the cap, slicing is
 > exhausted and the only move left is splitting the script into separate files with their own
 > preambles. `--check` fails on that and warns past 85%.
 > **Run all four** — each reports its own rows and nothing else, so a group you skip is a group
@@ -140,6 +140,13 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > which switch is off and where, and the verdict reads `NOT CHECKED` — never "no mechanical row
 > failed". Unhide or reset the frame *and every group and section above it*, then re-run.
 >
+> **A translucent knockout is not certified.** An annotation's knockout works by painting the frame's
+> colour *over* what it crosses, so one at 0.005 masks nothing while still passing the weight,
+> alignment and colour checks — a clean `ok` on a crossing the reader can see straight through. Zero
+> is already "no knockout"; anything between is reported **REVIEW** with its effective opacity (paint
+> × node) named, because at 0.98 it masks fine and at 0.05 it does not, and which side of that a frame
+> is on depends on what sits behind the annotation.
+>
 > **Non-rendering means exactly zero, never a floor.** A node or paint at 0.005 does reach the canvas,
 > and a cutoff dropped its whole subtree from *every* row — an 8px label at 0.005 left `text-floor`
 > reporting that all of its ranges cleared the floor. Anything positive is **translucent**: held out of
@@ -172,7 +179,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > Validated by planting defects and confirming each row **fails**, twice over: 11 planted in Figma and
 > 11 caught, then a stubbed-figma harness ([`scripts/test_verify_page.js`](../scripts/test_verify_page.js),
-> `node` it after any edit) covering **272** assertions including the rows that are awkward to plant on a
+> `node` it after any edit) covering **276** assertions including the rows that are awkward to plant on a
 > real page. **A check that cannot fail is worse than no check**, so when you extend this script,
 > extend both passes with it.
 >

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -58,15 +58,34 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > the script is handed frames).
 >
 > **`colour-vision` and `grayscale-seams` hand back a runnable command, not just an owner.** The
-> script cannot run `color_audit.py` — a Figma plugin sandbox has no shell — but it already holds
-> every plot fill, so it emits the invocation with the palette filled in, the interpreter spelled
-> out and `--names` attached when the node names allow it. Paste and run it; both rows are one run
-> of one script. Two things it cannot decide for you: it assumes `--separated` (nothing shares an
-> edge — true for lines, maps and plain or grouped bars), so on a **stacked or segmented** chart
-> drop that flag and reorder the colours into stack order first, because the seam check reads
-> adjacency off the order you give it. And `--names` is dropped wholesale, with the reason stated,
-> if any fill node is unnamed or carries a comma — a comma would split into two entries and
-> misalign every label after it.
+> script cannot run `color_audit.py` — a Figma plugin sandbox has no shell — but the palette is
+> already on the canvas, so it emits the invocation with the palette filled in, the interpreter
+> spelled out and `--names` attached when the node names allow it. Paste and run it; both rows are
+> one run of one script.
+>
+> The palette is taken from **identified data marks and line/slope series strokes**, never from the
+> script's `fills` inventory. That inventory holds every solid paint on an area node in the plot and
+> a TEXT node has one, while a line chart's series colour is a **stroke** and is not in it at all —
+> so sourcing from it audits axis and legend labels as categories while omitting the data. Measured
+> on the test fixture, it returned a one-entry palette consisting of a text label's fill. `outline__*`
+> strokes are excluded too: that is the white halo under a line, shared by every series.
+>
+> Four things it will not decide for you:
+> - It assumes `--separated` (nothing shares an edge — true for lines, maps and plain or grouped
+>   bars), so on a **stacked or segmented** chart drop that flag and reorder the colours into stack
+>   order first, because the seam check reads adjacency off the order you give it.
+> - On a **map** the command covers a *categorical* choropleth only. `--maps` selects the Categorical
+>   Maps palette and the ΔE 20 gate is a categorical test, so a **sequential ramp** — ordered by
+>   construction, and set in grapher — fails it by design, and `--suggest` would then offer an
+>   unordered palette in place of a correct ramp. Nothing in the plugin can tell the two apart from
+>   the fills, so judge a ramp by lightness order instead of running this.
+> - `--names` is dropped wholesale, with the reason stated, if any mark is unnamed, carries a comma
+>   (it would split into two entries and misalign every label after it), or carries an apostrophe
+>   (it would end the single-quoted shell argument mid-name).
+> - The palette is deduplicated by **colour**, so two categories painted the same colour reach the
+>   audit as one entry and it cannot report the clash. The row names them instead, ungraded — a
+>   highlight treatment greys every unhighlighted series on purpose, and a choropleth bin is one
+>   colour by definition (map shapes are left out of the note entirely).
 >
 > A `SKIPPED` row is a declared gap in coverage, never a pass — which
 > is the whole reason to read the list rather than the verdict.

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -70,10 +70,15 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > on the test fixture, it returned a one-entry palette consisting of a text label's fill. `outline__*`
 > strokes are excluded too: that is the white halo under a line, shared by every series.
 >
+> The mode flag is chosen from what the palette was sourced from, and it is not cosmetic — it also
+> selects which palette a `--suggest` rerun searches. A line or slope palette gets **`--line`**
+> (`--separated` plus the Line and Slope Chart variants, the darker set for thin marks on white);
+> a map gets `--maps`; anything else gets `--separated`. All three mean "nothing shares an edge".
+>
 > Four things it will not decide for you:
-> - It assumes `--separated` (nothing shares an edge — true for lines, maps and plain or grouped
->   bars), so on a **stacked or segmented** chart drop that flag and reorder the colours into stack
->   order first, because the seam check reads adjacency off the order you give it.
+> - On a **stacked or segmented** chart drop the mode flag and reorder the colours into stack order
+>   first, because the seam check reads adjacency off the order you give it. That is the only chart
+>   where seams exist, so it is the only case where the emitted flag is wrong.
 > - On a **map** the command covers a *categorical* choropleth only. `--maps` selects the Categorical
 >   Maps palette and the ΔE 20 gate is a categorical test, so a **sequential ramp** — ordered by
 >   construction, and set in grapher — fails it by design, and `--suggest` would then offer an
@@ -85,7 +90,9 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > - The palette is deduplicated by **colour**, so two categories painted the same colour reach the
 >   audit as one entry and it cannot report the clash. The row names them instead, ungraded — a
 >   highlight treatment greys every unhighlighted series on purpose, and a choropleth bin is one
->   colour by definition (map shapes are left out of the note entirely).
+>   colour by definition (map shapes are left out of the note entirely). The category comes from the
+>   nearest `<kind>__<Entity>` **ancestor**, because grapher puts the name on the group and the paint
+>   on its leaves: a `datapoints__<Entity>` marker is a filled leaf called `Ellipse 12`.
 >
 > A `SKIPPED` row is a declared gap in coverage, never a pass — which
 > is the whole reason to read the list rather than the verdict.

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -13,7 +13,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **52,206 stripped**. So
+> exists to catch. It has since grown past the cap outright: **51,904 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -25,15 +25,19 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 54% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 48% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 44% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 59% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 53% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 47% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 43% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 58% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (34,167) then
-> `--rows geometry,annotations` (34,596, **69% of cap** — the figure `inline_script.py --check`
-> reports, since that larger call is the biggest thing anyone actually sends). **Run all four** —
-> each reports its own rows and nothing else, so a group you skip is a group nobody checked.
+> Groups combine, so the whole pass is two calls: `--rows type,series` (33,865) then
+> `--rows geometry,annotations` (34,294, **69% of cap** — the figure `inline_script.py --check`
+> reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
+> than the smallest split it could find for itself — an optimiser would go on reporting a
+> comfortable number by picking a split nobody is told to send. Change the pair here and there
+> together; `--check` fails if their groups no longer cover the file exactly once.
+> **Run all four** — each reports its own rows and nothing else, so a group you skip is a group
+> nobody checked.
 > `diff_against_template.js` (~12,000 stripped) needs none of this.
 >
 > **Do NOT substitute a hand-rolled subset. It is worse than skipping the pass, and this is

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -406,8 +406,16 @@ mock, and both changes make a row *less* red on purpose. Read them before treati
 
 ## A skip with a false reason is the failure mode, not a wrong number
 
-Worth stating on its own, because it has now bitten in three different rows. When `CONFIG.chartName`
-finds nothing — the documented case where a designer has **ungrouped** the chart — the plot has to be
+**First, the common case is not the one this section assumed.** `chartName` defaults to `chart`, and a
+read of the live file found the real convention is **`chart__<slug>`** — a `static_viz` import lands as
+`chart__agriculture-share`. An exact-only match resolved nothing on every one of those pages, fell
+through to the ungrouped branch, walked the right node anyway, and reported *"the chart group looks
+ungrouped"* about a frame whose chart group is present and correctly named. The answer was right and
+the explanation was wrong, which is the worse of the two: it sends the next reader to fix a
+non-problem. The resolver now takes an exact match first, then `<chartName>__<slug>`.
+
+The rest of this section is the genuinely ungrouped case. It has bitten in three different rows. When
+`CONFIG.chartName` finds nothing — a designer has **ungrouped** the chart — the plot has to be
 resolved from the frame's children, and doing that from a list of container names was line-chart-shaped:
 it knew the axis, grid and lines groups and missed a map's `map`, a bar's `bars`, a scatter's point
 container and a slope's `slopes`. Those children were then walked as *not* in the plot, which does not

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -6,14 +6,14 @@
 Every one of these caught a real defect on this skill's first run, and none of them is visible by looking at the frame. Run them as a pass, and report the numbers rather than "looks fine".
 
 > **⚠️ `verify_page.js` does not fit in a `use_figma` call as it ships.** The `code` argument caps at
-> **50,000 characters** and the file is **~112,000**, so the instruction below is not executable
+> **50,000 characters** and the file is **~116,000**, so the instruction below is not executable
 > verbatim — a run that pastes it is rejected. Emit it stripped instead:
 >
 > **Run it in slices — that is the supported path, and the only one.** Stripping the comments used to
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **58,726 stripped**. So
+> exists to catch. It has since grown past the cap outright: **60,227 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -25,13 +25,13 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 66% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 61% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 56% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 72% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 69% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 64% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 59% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 75% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (40,437) then
-> `--rows geometry,annotations` (41,116, **82% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (41,938) then
+> `--rows geometry,annotations` (42,617, **85% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there
@@ -95,6 +95,18 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > (`--separated` plus the Line and Slope Chart variants, the darker set for thin marks on white);
 > a map gets `--maps`; anything else gets `--separated`. All three mean "nothing shares an edge".
 >
+> **A palette of one colour gets no command at all.** Both rows compare *pairs*, so a single colour
+> has nothing to compare — but `color_audit.py` does not say so: handed one hex it prints an empty pair
+> list and `overall: min dE inf`, and exits 0, which reads exactly like a clean audit.
+> [GUIDELINES.md](../GUIDELINES.md) already rules on this ("one categorical color against neutral grays
+> has no pair to check, and reporting no failures from a two-color audit reads as coverage you don't
+> have"), so the row withholds the command, names the colour, and hands over the two checks that *are*
+> live: that colour's contrast against the background, and whether it still separates from the grays in
+> grayscale. The clash note survives the withholding — two categories painted one colour **are** a
+> one-colour palette, and that is the severest collision there is. A declared `highlightTreatment` gets
+> the same warning attached to its command rather than the command withheld, because which entries are
+> muting grays is a judgement this script cannot make.
+>
 > Four things it will not decide for you:
 > - On a **stacked or segmented** chart drop the mode flag and reorder the colours into stack order
 >   first, because the seam check reads adjacency off the order you give it. That is the only chart
@@ -154,7 +166,7 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > Validated by planting defects and confirming each row **fails**, twice over: 11 planted in Figma and
 > 11 caught, then a stubbed-figma harness ([`scripts/test_verify_page.js`](../scripts/test_verify_page.js),
-> `node` it after any edit) covering **264** assertions including the rows that are awkward to plant on a
+> `node` it after any edit) covering **272** assertions including the rows that are awkward to plant on a
 > real page. **A check that cannot fail is worse than no check**, so when you extend this script,
 > extend both passes with it.
 >

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -406,13 +406,29 @@ mock, and both changes make a row *less* red on purpose. Read them before treati
 
 ## A skip with a false reason is the failure mode, not a wrong number
 
-**First, the common case is not the one this section assumed.** `chartName` defaults to `chart`, and a
-read of the live file found the real convention is **`chart__<slug>`** — a `static_viz` import lands as
-`chart__agriculture-share`. An exact-only match resolved nothing on every one of those pages, fell
-through to the ungrouped branch, walked the right node anyway, and reported *"the chart group looks
-ungrouped"* about a frame whose chart group is present and correctly named. The answer was right and
-the explanation was wrong, which is the worse of the two: it sends the next reader to fix a
-non-problem. The resolver now takes an exact match first, then `<chartName>__<slug>`.
+**First, the common case is not the one this section assumed.** `chartName` defaults to `chart`, and
+counting the live file found **three** names in use, not one: `chart` (a grapher import),
+`chart__agriculture-share` (a `static_viz` import) and `chart-desktop` / `chart-mobile` (a two-format
+page). An exact-only match resolved nothing on two of the three, fell through to the ungrouped branch,
+walked the right node anyway, and reported *"the chart group looks ungrouped"* about a frame whose
+chart group is present and correctly named. The answer was right and the explanation was wrong, which
+is the worse of the two: it sends the next reader to fix a non-problem. The resolver now takes an
+exact match first, then a `__` or `-` suffix, and names what it matched.
+
+**And there are two `<kind>__<name>` conventions, which is what made the palette labels wrong.**
+
+| Source | Names | Is the second token a category? |
+|---|---|---|
+| Grapher's SVG export | `line__<Entity>`, `outline__<Entity>`, `datapoints__<Entity>` | **yes** — one per series, in selection order |
+| A `static_viz` matplotlib step | `bars__<slug>`, `diagram__median`, `{slug}__{part}` | **no** — a dataset slug or a part name, repeated across marks |
+
+`CATEGORY_ANY` matches `<word>__<rest>` and cannot tell them apart, so on a `static_viz` bar chart every
+bar resolved to the same "category" and `--names` labelled three distinct colours
+`agriculture-share,agriculture-share,agriculture-share`. That is why `--names` is now gated on the names
+being **distinct across the palette** and not import defaults (`Vector`, `Rectangle 12`): the grapher
+case passes that gate and keeps its labels, the `static_viz` case fails it and the flag is dropped with
+the reason. Do not "fix" this by widening `CATEGORY_ANY` — the two conventions are genuinely ambiguous
+at the name level, and distinctness is the property `--names` actually promises.
 
 The rest of this section is the genuinely ungrouped case. It has bitten in three different rows. When
 `CONFIG.chartName` finds nothing — a designer has **ungrouped** the chart — the plot has to be

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -6,16 +6,17 @@
 Every one of these caught a real defect on this skill's first run, and none of them is visible by looking at the frame. Run them as a pass, and report the numbers rather than "looks fine".
 
 > **⚠️ `verify_page.js` does not fit in a `use_figma` call as it ships.** The `code` argument caps at
-> **50,000 characters** and the file is **~84,000**, so the instruction below is not executable
+> **50,000 characters** and the file is **~94,000**, so the instruction below is not executable
 > verbatim — a run that pastes it is rejected. Emit it stripped instead:
 >
-> **Run it in slices — that is the supported path, and the only one.** Stripping the comments does
-> get it to ~48,000 characters, which parses (the helper is context-aware, so URLs, regex literals
-> and template strings survive). But 48,000 is **97% of the cap**, and all of it has to be relayed
-> verbatim, where a one-character corruption yields a *wrong verdict* rather than an error — the
-> exact failure this gate exists to catch. So `inline_script.py verify_page.js` with no `--rows`
-> now **refuses and exits 1**, naming the size and pointing here; `--whole` overrides it if you
-> genuinely mean to. The rows are grouped, each slice carries the shared preamble and runs alone:
+> **Run it in slices — that is the supported path, and the only one.** Stripping the comments used to
+> get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
+> strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
+> one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
+> exists to catch. It has since grown past the cap outright: **52,206 stripped**. So
+> `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
+> pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
+> script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
 >
 > ```bash
 > .venv/bin/python .claude/skills/create-figma-chart/scripts/inline_script.py verify_page.js --list-rows
@@ -24,13 +25,15 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 46% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 40% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 36% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 51% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 54% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 48% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 44% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 59% |
 >
-> Groups combine (`--rows type,series`), so the whole pass is two calls. **Run all four** — each
-> reports its own rows and nothing else, so a group you skip is a group nobody checked.
+> Groups combine, so the whole pass is two calls: `--rows type,series` (34,167) then
+> `--rows geometry,annotations` (34,596, **69% of cap** — the figure `inline_script.py --check`
+> reports, since that larger call is the biggest thing anyone actually sends). **Run all four** —
+> each reports its own rows and nothing else, so a group you skip is a group nobody checked.
 > `diff_against_template.js` (~12,000 stripped) needs none of this.
 >
 > **Do NOT substitute a hand-rolled subset. It is worse than skipping the pass, and this is

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -6,14 +6,14 @@
 Every one of these caught a real defect on this skill's first run, and none of them is visible by looking at the frame. Run them as a pass, and report the numbers rather than "looks fine".
 
 > **⚠️ `verify_page.js` does not fit in a `use_figma` call as it ships.** The `code` argument caps at
-> **50,000 characters** and the file is **~94,000**, so the instruction below is not executable
+> **50,000 characters** and the file is **~102,000**, so the instruction below is not executable
 > verbatim — a run that pastes it is rejected. Emit it stripped instead:
 >
 > **Run it in slices — that is the supported path, and the only one.** Stripping the comments used to
 > get it *just* under the cap (the helper is context-aware, so URLs, regex literals and template
 > strings survive), and even then it sat at 97%, all of which has to be relayed verbatim — where a
 > one-character corruption yields a *wrong verdict* rather than an error, the exact failure this gate
-> exists to catch. It has since grown past the cap outright: **53,765 stripped**. So
+> exists to catch. It has since grown past the cap outright: **54,827 stripped**. So
 > `inline_script.py verify_page.js` with no `--rows` **refuses and exits 1**, naming the size and
 > pointing here, and `--whole` no longer overrides that — the cap is now a hard floor for this
 > script, not a judgement call. The rows are grouped, each slice carries the shared preamble:
@@ -25,13 +25,13 @@ Every one of these caught a real defect on this skill's first run, and none of t
 >
 > | group | rows | size |
 > |---|---|---|
-> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 56% of cap |
-> | `series` | series-weight, furniture-weight, furniture-dash | 51% |
-> | `geometry` | box-alignment, gap, margins, off-palette | 46% |
-> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 62% |
+> | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 58% of cap |
+> | `series` | series-weight, furniture-weight, furniture-dash | 53% |
+> | `geometry` | box-alignment, gap, margins, off-palette | 48% |
+> | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 64% |
 >
-> Groups combine, so the whole pass is two calls: `--rows type,series` (35,473) then
-> `--rows geometry,annotations` (36,155, **72% of cap** — the figure `inline_script.py --check`
+> Groups combine, so the whole pass is two calls: `--rows type,series` (36,535) then
+> `--rows geometry,annotations` (37,217, **74% of cap** — the figure `inline_script.py --check`
 > reports: it measures **these two calls**, declared as `DOCUMENTED_CALLS` in the script, rather
 > than the smallest split it could find for itself — an optimiser would go on reporting a
 > comfortable number by picking a split nobody is told to send. Change the pair here and there

--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -419,7 +419,7 @@ exact match first, then a `__` or `-` suffix, and names what it matched.
 
 | Source | Names | Is the second token a category? |
 |---|---|---|
-| Grapher's SVG export | `line__<Entity>`, `outline__<Entity>`, `datapoints__<Entity>` | **yes** — one per series, in selection order |
+| Grapher's SVG export | `line__<Entity>`, `outline__<Entity>`, `label__<Entity>` | **yes** — one per series, in selection order |
 | A `static_viz` matplotlib step | `bars__<slug>`, `diagram__median`, `{slug}__{part}` | **no** — a dataset slug or a part name, repeated across marks |
 
 `CATEGORY_ANY` matches `<word>__<rest>` and cannot tell them apart, so on a `static_viz` bar chart every
@@ -429,6 +429,23 @@ being **distinct across the palette** and not import defaults (`Vector`, `Rectan
 case passes that gate and keeps its labels, the `static_viz` case fails it and the flag is dropped with
 the reason. Do not "fix" this by widening `CATEGORY_ANY` — the two conventions are genuinely ambiguous
 at the name level, and distinctness is the property `--names` actually promises.
+
+**The grapher half is confirmed against a live export**, not inferred. `child-mortality.svg?imType=uncaptioned`
+carries 7 `line__<Entity>`, 7 `outline__<Entity>` and 7 `label__<Entity>` ids — Ghana, India, Brazil,
+France, Sweden, United-Kingdom, United-States — with 7 distinct stroke colours, so the row emits
+`--names 'Ghana,India,…' --line` and the audit runs. You can check this without Figma at all:
+
+```bash
+# the naming and the palette, straight from grapher
+curl -s "https://ourworldindata.org/grapher/<slug>.svg?imType=uncaptioned" | grep -o 'id="line__[^"]*"'
+```
+
+Two things that run did **not** prove, so don't cite it for them. Its labels carry the same colours as
+its lines, so a palette wrongly sourced from text fills would produce the *same* hexes and look
+correct — only a chart whose labels differ from its marks tests that. And it is grapher's automatic
+7-series assignment, which GUIDELINES replaces with the highlight treatment anyway; the audit failing
+it (France/UK at **ΔE 0.0** under tritanopia, India/UK at **1.00:1** in grayscale) is the row working,
+not a defect in a shipped page.
 
 The rest of this section is the genuinely ungrouped case. It has bitten in three different rows. When
 `CONFIG.chartName` finds nothing — a designer has **ungrouped** the chart — the plot has to be

--- a/.claude/skills/create-figma-chart/reference/GOTCHAS.md
+++ b/.claude/skills/create-figma-chart/reference/GOTCHAS.md
@@ -130,6 +130,14 @@
   failure as batching the four-render arrow protocol. Bulk-render surveys and delivery renders of
   finished frames; keep every post-write probe on `get_screenshot`. It also returns no
   `original_width`/`original_height`, so the size-only survey still wants `get_screenshot`.
+  **Checked 2026-08-24: ETL carries no such token** — no `FIGMA_API_KEY` in its env files — so this
+  is blocked on someone provisioning one, not on anybody's time. Don't write the wrapper first: an
+  untested client for an API you cannot call is a thing that reports success it has not earned.
+  And weigh it against what it would actually buy now. Its niche is a *cloud* session doing bulk
+  reads, since a local one has the desktop server for that; and `measure_pixels.py` removed the
+  reason most probes rendered at all, which was for a model to look at them. So the case for it is
+  narrower than when it was first written down: raise it if cloud screenshot volume becomes the
+  measured bottleneck on a real run, and not before.
 
 - **The Figma *desktop* MCP server serves reads ~30× faster, and is still the wrong tool for a chart
   build. Use it for a bulk survey of nodes that already exist; not in the per-chart flow.** The

--- a/.claude/skills/create-figma-chart/scripts/inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/inline_script.py
@@ -150,18 +150,31 @@ def main() -> int:
     args = ap.parse_args()
 
     if args.check:
-        worst = 0
-        print(f"{'script':<30} {'raw':>8} {'stripped':>9} {'of cap':>8}")
+        # What matters is the largest thing anyone actually SENDS, which for a script carrying
+        # #region markers is its biggest slice, not the whole file. Judging a sliceable script on
+        # its total would report a failure for a file that runs perfectly — verify_page.js sits a
+        # few hundred characters under the cap whole, and crossing it changes nothing about how it
+        # is used, because the whole-file path is already refused above CROWDED.
+        failed = False
+        print(f"{'script':<30} {'raw':>8} {'stripped':>9} {'sent':>9} {'of cap':>8}")
         for p in sorted(SCRIPTS.glob("*.js")):
             if p.name.startswith("test_"):
                 continue
-            raw = p.read_text()
-            stripped = strip_js(raw)
-            pct = len(stripped) / CAP * 100
-            flag = "  OVER CAP" if len(stripped) > CAP else ""
-            worst = max(worst, len(stripped))
-            print(f"{p.name:<30} {len(raw):>8,} {len(stripped):>9,} {pct:>7.0f}%{flag}")
-        return 1 if worst > CAP else 0
+            stripped = strip_js(p.read_text())
+            groups = list(dict.fromkeys(select_rows(stripped, set())[1]))
+            if groups:
+                sent = max(len(select_rows(stripped, {g})[0]) for g in groups)
+                how = f"  (largest of {len(groups)} slices)"
+            else:
+                sent = len(stripped)
+                how = ""
+            over = sent > CAP
+            failed = failed or over
+            print(
+                f"{p.name:<30} {len(p.read_text()):>8,} {len(stripped):>9,} {sent:>9,} "
+                f"{sent / CAP * 100:>7.0f}%{'  OVER CAP' if over else ''}{how}"
+            )
+        return 1 if failed else 0
 
     if not args.script:
         ap.error("give a script name, or --check")

--- a/.claude/skills/create-figma-chart/scripts/inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/inline_script.py
@@ -103,22 +103,27 @@ def strip_js(src: str) -> str:
     lines = [ln.rstrip() for ln in "".join(out).split("\n")]
     stripped = "\n".join(ln for ln in lines if ln.strip())
 
-    # A surviving line comment means the parse desynchronized and the rest of the file was copied
+    # Ending inside a literal means the parse desynchronized and the rest of the file was copied
     # verbatim — the failure this stripper exists to avoid, and it is SILENT: the output is still
-    # valid JS, just far larger, so it is sent and the size guard is what eventually notices.
+    # valid JS, just far larger, so it gets sent and the size guard is what eventually notices.
     #
     # It happened: a NESTED template literal (a backtick inside a `${}` inside a template) closes the
     # outer context on the inner backtick. Nesting is legal JS and this parser is not nesting-aware.
     # `--check` jumped 75% -> 96% of cap on a 1.8KB edit, which is the only reason it was caught.
-    # Verified against all ten scripts here: zero false positives. If legitimate content ever trips
-    # this, that content breaks the stripper too — failing is the correct answer either way.
-    survivors = [ln for ln in stripped.split("\n") if ln.lstrip().startswith("//") and not REGION.match(ln.strip())]
-    if survivors:
+    #
+    # The signature is the OPEN CONTEXT, not a surviving comment. The first version of this guard
+    # flagged any `//` line that came through, which is wrong: a template literal may legitimately
+    # contain one, the stripper handles that correctly, and the guard then called correct behaviour
+    # corruption. Measured — a legitimate template with a `//` line ends at context None; the nested
+    # case ends holding an unterminated backtick. Well-formed JS always closes its literals, so this
+    # has no false positive to trade away.
+    if context is not None:
+        kind = {"regex": "regex literal", "`": "template literal", "'": "string", '"': "string"}[context]
         raise ValueError(
-            "comment stripping failed: "
-            + f"{len(survivors)} line comment(s) survived, starting with {survivors[0].strip()[:60]!r}. "
-            "The parser lost sync — most likely a nested template literal (a backtick inside a ${} "
-            "inside a template) or an unterminated literal. Rewrite it as concatenation."
+            f"comment stripping failed: the file ends inside an unterminated {kind}, so the parser "
+            "lost sync and the rest of the source was copied verbatim. Most likely a NESTED template "
+            "literal (a backtick inside a ${} inside a template), which is legal JS but not handled "
+            "here — rewrite it as string concatenation."
         )
     return stripped
 
@@ -218,7 +223,7 @@ def main() -> int:
         # 45,131, so the optimiser would report 90% and exit 0 for a workflow that no longer runs.
         # The number has to be the one the operator will hit.
         failed = False
-        print(f"{'script':<30} {'raw':>8} {'stripped':>9} {'sent':>9} {'of cap':>8}")
+        print(f"{'script':<30} {'raw':>8} {'stripped':>9} {'sent':>9} {'of cap':>8} {'floor':>8}")
         for p in sorted(SCRIPTS.glob("*.js")):
             if p.name.startswith("test_"):
                 continue
@@ -250,14 +255,36 @@ def main() -> int:
             else:
                 sent = len(stripped)
                 how = ""
+            # The FLOOR: preamble + the single largest group, i.e. the smallest any call can ever be
+            # made by re-splitting. `sent` says whether today's documented calls fit; the floor says
+            # whether ANY partition can. They move independently, and confusing them misreads the
+            # risk in both directions — verify_page.js sat at 82% sent against a 72% floor, so it
+            # looked ~9,000 characters from trouble when re-splitting bought it ~14,000.
+            #
+            # Once the floor passes the cap, slicing is exhausted: the shared preamble plus one row
+            # group no longer fits, and the only remaining move is to break the script into separate
+            # files with their own preambles. That is a rewrite, so it wants warning, not discovery.
+            floor = max((len(select_rows(stripped, {g})[0]) for g in groups), default=len(stripped))
             over = sent > CAP
             failed = failed or over or bool(problem)
             print(
                 f"{p.name:<30} {len(p.read_text()):>8,} {len(stripped):>9,} {sent:>9,} "
-                f"{sent / CAP * 100:>7.0f}%{'  OVER CAP' if over else ''}{how}"
+                f"{sent / CAP * 100:>7.0f}% {floor / CAP * 100:>7.0f}%"
+                f"{'  OVER CAP' if over else ''}{how}"
             )
             if problem:
                 print(f"{'':<30}   ^ {problem}")
+            if groups and floor > CAP:
+                failed = True
+                print(
+                    f"{'':<30}   ^ FLOOR OVER CAP: preamble + the largest single group is {floor:,}, "
+                    "so no split fits. Move rows into a separate script with its own preamble."
+                )
+            elif groups and floor > CAP * 0.85:
+                print(
+                    f"{'':<30}   ^ floor at {floor / CAP * 100:.0f}% — re-splitting is nearly "
+                    f"exhausted; {CAP - floor:,} characters of shared preamble + largest group left."
+                )
             # Over the cap, the useful next step is the split that would fit, so the doc can be
             # rewritten to it. Enumerating the subsets is fine here: these are hand-authored #region
             # markers and there is a handful of them per script.

--- a/.claude/skills/create-figma-chart/scripts/inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/inline_script.py
@@ -31,8 +31,10 @@ corrupts all three, and the corruption surfaces as a plugin syntax error with no
 from __future__ import annotations
 
 import argparse
+import itertools
 import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parent
@@ -127,6 +129,12 @@ def _regex_allowed(out: list[str]) -> bool:
     return True
 
 
+def _proper_subsets(groups: list[str]) -> Iterator[tuple[str, ...]]:
+    """Every way to split `groups` into two non-empty calls, as the left half of each split."""
+    for size in range(1, len(groups)):
+        yield from itertools.combinations(groups, size)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("script", nargs="?", help="e.g. verify_page.js")
@@ -151,10 +159,16 @@ def main() -> int:
 
     if args.check:
         # What matters is the largest thing anyone actually SENDS, which for a script carrying
-        # #region markers is its biggest slice, not the whole file. Judging a sliceable script on
-        # its total would report a failure for a file that runs perfectly — verify_page.js sits a
-        # few hundred characters under the cap whole, and crossing it changes nothing about how it
-        # is used, because the whole-file path is already refused above CROWDED.
+        # #region markers is a slice, not the whole file. Judging a sliceable script on its total
+        # would report a failure for a file that runs perfectly — verify_page.js is now PAST the cap
+        # whole, and that changes nothing about how it is used, because the whole-file path is
+        # already refused above CROWDED.
+        #
+        # But the largest SINGLE group is not the answer either: `--rows` combines groups, and the
+        # documented pass is two calls covering all of them (CHECKS.md), so nobody sends one slice at
+        # a time. Measure that two-call partition — the split that minimises its larger call, which is
+        # what following the doc produces. Enumerating the subsets is fine: these are hand-authored
+        # #region markers and there is a handful of them per script.
         failed = False
         print(f"{'script':<30} {'raw':>8} {'stripped':>9} {'sent':>9} {'of cap':>8}")
         for p in sorted(SCRIPTS.glob("*.js")):
@@ -162,9 +176,18 @@ def main() -> int:
                 continue
             stripped = strip_js(p.read_text())
             groups = list(dict.fromkeys(select_rows(stripped, set())[1]))
-            if groups:
-                sent = max(len(select_rows(stripped, {g})[0]) for g in groups)
-                how = f"  (largest of {len(groups)} slices)"
+            if len(groups) > 1:
+                sent = min(
+                    max(
+                        len(select_rows(stripped, set(left))[0]),
+                        len(select_rows(stripped, set(groups) - set(left))[0]),
+                    )
+                    for left in _proper_subsets(groups)
+                )
+                how = f"  (larger call of the best 2-way split of {len(groups)} slices)"
+            elif groups:
+                sent = len(select_rows(stripped, set(groups))[0])
+                how = "  (its only slice)"
             else:
                 sent = len(stripped)
                 how = ""

--- a/.claude/skills/create-figma-chart/scripts/inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/inline_script.py
@@ -56,14 +56,22 @@ def strip_js(src: str) -> str:
     """Remove comments while respecting string, template-literal and regex context."""
     out: list[str] = []
     i, n = 0, len(src)
-    # None | "'" | '"' | '`' | 'regex'
-    context: str | None = None
+    # A STACK, not a single context, because a template literal can hold a `${}` expression that
+    # holds another template. That nesting is ordinary JS, and a flat context could not see it: the
+    # INNER opening backtick looked like the outer one closing, so from there the parser was
+    # one level out of step and stripped template text as if it were code. Balanced nesting left the
+    # final context at None, so the end-of-file guard passed it — the emitted script differed from
+    # the file on disk, silently, which is the one failure this stripper exists to prevent.
+    # "code" is the base level; "expr" is the inside of a `${}`, which is code too — a comment there
+    # IS a comment — and it ends at the brace that matches its own, so its depth is tracked.
+    stack: list[str] = ["code"]  # "code" | "expr" | "'" | '"' | "`" | "regex"
+    depth: list[int] = []  # brace depth within each "expr" entry, innermost last
 
     while i < n:
         ch = src[i]
         nxt = src[i + 1] if i + 1 < n else ""
 
-        if context is None:
+        if stack[-1] in ("code", "expr"):
             if ch == "/" and nxt == "/":
                 line_end = src.find("\n", i)
                 line_end = n if line_end < 0 else line_end
@@ -79,9 +87,17 @@ def strip_js(src: str) -> str:
                 i += 2
                 continue
             if ch in "'\"`":
-                context = ch
+                stack.append(ch)
             elif ch == "/" and _regex_allowed(out):
-                context = "regex"
+                stack.append("regex")
+            elif stack[-1] == "expr" and ch == "{":
+                depth[-1] += 1
+            elif stack[-1] == "expr" and ch == "}":
+                if depth[-1]:
+                    depth[-1] -= 1
+                else:
+                    stack.pop()
+                    depth.pop()
             out.append(ch)
             i += 1
             continue
@@ -93,10 +109,18 @@ def strip_js(src: str) -> str:
                 out.append(src[i + 1])
             i += 2
             continue
-        if (context == "regex" and ch == "/") or (context != "regex" and ch == context):
-            context = None
-        elif context in ("'", '"') and ch == "\n":
-            context = None  # unterminated string; bail rather than swallow the file
+        # `${` opens an expression INSIDE the template: code again, one level down.
+        if stack[-1] == "`" and ch == "$" and nxt == "{":
+            stack.append("expr")
+            depth.append(0)
+            out.append(ch)
+            out.append(nxt)
+            i += 2
+            continue
+        if (stack[-1] == "regex" and ch == "/") or (stack[-1] != "regex" and ch == stack[-1]):
+            stack.pop()
+        elif stack[-1] in ("'", '"') and ch == "\n":
+            stack.pop()  # unterminated string; bail rather than swallow the file
         out.append(ch)
         i += 1
 
@@ -106,24 +130,28 @@ def strip_js(src: str) -> str:
     # Ending inside a literal means the parse desynchronized and the rest of the file was copied
     # verbatim — the failure this stripper exists to avoid, and it is SILENT: the output is still
     # valid JS, just far larger, so it gets sent and the size guard is what eventually notices.
+    # It happened once already: `--check` jumped 75% -> 96% of cap on a 1.8KB edit, which is the only
+    # reason it was caught.
     #
-    # It happened: a NESTED template literal (a backtick inside a `${}` inside a template) closes the
-    # outer context on the inner backtick. Nesting is legal JS and this parser is not nesting-aware.
-    # `--check` jumped 75% -> 96% of cap on a 1.8KB edit, which is the only reason it was caught.
-    #
-    # The signature is the OPEN CONTEXT, not a surviving comment. The first version of this guard
+    # The signature is the OPEN CONTEXT, not a surviving comment. An earlier version of this guard
     # flagged any `//` line that came through, which is wrong: a template literal may legitimately
     # contain one, the stripper handles that correctly, and the guard then called correct behaviour
-    # corruption. Measured — a legitimate template with a `//` line ends at context None; the nested
-    # case ends holding an unterminated backtick. Well-formed JS always closes its literals, so this
-    # has no false positive to trade away.
-    if context is not None:
-        kind = {"regex": "regex literal", "`": "template literal", "'": "string", '"': "string"}[context]
+    # corruption. Well-formed JS always closes its literals, so this has no false positive to trade
+    # away — but it is only a backstop, and a BALANCED nested template closes everything it opens.
+    # That case is parsed rather than caught, by the stack above; the guard is what is left for
+    # genuinely unterminated source.
+    if len(stack) > 1:
+        kind = {
+            "regex": "regex literal",
+            "`": "template literal",
+            "'": "string",
+            '"': "string",
+            "expr": "template ${} expression",
+        }[stack[-1]]
         raise ValueError(
             f"comment stripping failed: the file ends inside an unterminated {kind}, so the parser "
-            "lost sync and the rest of the source was copied verbatim. Most likely a NESTED template "
-            "literal (a backtick inside a ${} inside a template), which is legal JS but not handled "
-            "here — rewrite it as string concatenation."
+            "lost sync and the rest of the source was copied verbatim. Check for an unclosed "
+            "backtick, quote, brace or regex literal."
         )
     return stripped
 
@@ -157,6 +185,42 @@ def _regex_allowed(out: list[str]) -> bool:
             continue
         return ch in "(,=:[!&|?{};+-*%~^<>"
     return True
+
+
+def split_advice(stripped: str, groups: list[str], floor: int) -> str | None:
+    """What to tell an operator whose script is over the cap — or None when there is nothing to say.
+
+    Three genuinely different answers, and the middle one used to be given for all three. Past the
+    FLOOR every 2-way split is over the cap by construction, so naming the smallest of them as "a
+    split that fits" contradicts the exhaustion line printed beside it and sends the reader off to
+    rewrite CHECKS.md around a call that would be refused.
+    """
+    if len(groups) < 2:
+        return None
+    size, left = min(
+        (
+            max(
+                len(select_rows(stripped, set(sub))[0]),
+                len(select_rows(stripped, set(groups) - set(sub))[0]),
+            ),
+            sub,
+        )
+        for sub in _proper_subsets(groups)
+    )
+    right = [g for g in groups if g not in left]
+    if size <= CAP:
+        return (
+            f"a 2-way split that fits: --rows {','.join(left)} then --rows {','.join(right)} "
+            f"(larger call {size:,}) — update CHECKS.md and DOCUMENTED_CALLS together"
+        )
+    if floor <= CAP:
+        return (
+            f"no 2-way split fits — the best is --rows {','.join(left)} / --rows {','.join(right)} "
+            f"at {size:,}. The floor is {floor:,}, under the {CAP:,} cap, so a finer split does: "
+            "try three calls."
+        )
+    # Floor over the cap: the line above already says no split fits and names the only remedy left.
+    return None
 
 
 def _proper_subsets(groups: list[str]) -> Iterator[tuple[str, ...]]:
@@ -288,23 +352,10 @@ def main() -> int:
             # Over the cap, the useful next step is the split that would fit, so the doc can be
             # rewritten to it. Enumerating the subsets is fine here: these are hand-authored #region
             # markers and there is a handful of them per script.
-            if over and len(groups) > 1:
-                size, left = min(
-                    (
-                        max(
-                            len(select_rows(stripped, set(sub))[0]),
-                            len(select_rows(stripped, set(groups) - set(sub))[0]),
-                        ),
-                        sub,
-                    )
-                    for sub in _proper_subsets(groups)
-                )
-                right = [g for g in groups if g not in left]
-                print(
-                    f"{'':<30}   ^ a 2-way split that fits: --rows {','.join(left)} then "
-                    f"--rows {','.join(right)} (larger call {size:,}) — update CHECKS.md and "
-                    "DOCUMENTED_CALLS together"
-                )
+            if over:
+                advice = split_advice(stripped, groups, floor)
+                if advice:
+                    print(f"{'':<30}   ^ {advice}")
         return 1 if failed else 0
 
     if not args.script:

--- a/.claude/skills/create-figma-chart/scripts/inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/inline_script.py
@@ -101,7 +101,26 @@ def strip_js(src: str) -> str:
         i += 1
 
     lines = [ln.rstrip() for ln in "".join(out).split("\n")]
-    return "\n".join(ln for ln in lines if ln.strip())
+    stripped = "\n".join(ln for ln in lines if ln.strip())
+
+    # A surviving line comment means the parse desynchronized and the rest of the file was copied
+    # verbatim — the failure this stripper exists to avoid, and it is SILENT: the output is still
+    # valid JS, just far larger, so it is sent and the size guard is what eventually notices.
+    #
+    # It happened: a NESTED template literal (a backtick inside a `${}` inside a template) closes the
+    # outer context on the inner backtick. Nesting is legal JS and this parser is not nesting-aware.
+    # `--check` jumped 75% -> 96% of cap on a 1.8KB edit, which is the only reason it was caught.
+    # Verified against all ten scripts here: zero false positives. If legitimate content ever trips
+    # this, that content breaks the stripper too — failing is the correct answer either way.
+    survivors = [ln for ln in stripped.split("\n") if ln.lstrip().startswith("//") and not REGION.match(ln.strip())]
+    if survivors:
+        raise ValueError(
+            "comment stripping failed: "
+            + f"{len(survivors)} line comment(s) survived, starting with {survivors[0].strip()[:60]!r}. "
+            "The parser lost sync — most likely a nested template literal (a backtick inside a ${} "
+            "inside a template) or an unterminated literal. Rewrite it as concatenation."
+        )
+    return stripped
 
 
 def select_rows(src: str, wanted: set[str]) -> tuple[str, list[str]]:

--- a/.claude/skills/create-figma-chart/scripts/inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/inline_script.py
@@ -45,6 +45,12 @@ CROWDED = 0.80
 # stripping, because --rows selects on them.
 REGION = re.compile(r"^//\s*#(region\s+\S+|endregion)\s*$")
 
+# The calls reference/CHECKS.md tells an operator to send, per script. `--check` measures THESE.
+# Keep the two in step: this list is the workflow, and the doc is where a human reads it.
+DOCUMENTED_CALLS: dict[str, list[tuple[str, ...]]] = {
+    "verify_page.js": [("type", "series"), ("geometry", "annotations")],
+}
+
 
 def strip_js(src: str) -> str:
     """Remove comments while respecting string, template-literal and regex context."""
@@ -135,6 +141,24 @@ def _proper_subsets(groups: list[str]) -> Iterator[tuple[str, ...]]:
         yield from itertools.combinations(groups, size)
 
 
+def _documented_problem(groups: list[str], calls: list[tuple[str, ...]]) -> str | None:
+    """A declared workflow must send every row group exactly once, or the measurement is a fiction.
+
+    Without this, a `#region` added to a script and not written into the call list is simply absent
+    from what --check measures: the number stays comfortable while a row nobody sends goes unchecked
+    in the frame. That is the same wrong-answer shape as measuring an undocumented split.
+    """
+    flat = [g for call in calls for g in call]
+    parts = []
+    if missing := [g for g in groups if g not in flat]:
+        parts.append(f"in the file but never sent: {', '.join(missing)}")
+    if unknown := [g for g in flat if g not in groups]:
+        parts.append(f"documented but not in the file: {', '.join(unknown)}")
+    if repeated := sorted({g for g in flat if flat.count(g) > 1}):
+        parts.append(f"sent by more than one call: {', '.join(repeated)}")
+    return "; ".join(parts) or None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("script", nargs="?", help="e.g. verify_page.js")
@@ -166,9 +190,14 @@ def main() -> int:
         #
         # But the largest SINGLE group is not the answer either: `--rows` combines groups, and the
         # documented pass is two calls covering all of them (CHECKS.md), so nobody sends one slice at
-        # a time. Measure that two-call partition — the split that minimises its larger call, which is
-        # what following the doc produces. Enumerating the subsets is fine: these are hand-authored
-        # #region markers and there is a handful of them per script.
+        # a time. So measure THE DOCUMENTED CALLS, the ones an operator is actually told to send —
+        # not the best split this script can find for itself. Minimising over every partition answers
+        # a question nobody asked, and it can hold the check green by discovering an undocumented
+        # split while the workflow in the doc is over the cap. Measured on this file: 16,000 more
+        # characters in `annotations` puts the documented `geometry,annotations` call at 50,314 —
+        # over the cap and refused — while `annotations` alone against the other three peaks at
+        # 45,131, so the optimiser would report 90% and exit 0 for a workflow that no longer runs.
+        # The number has to be the one the operator will hit.
         failed = False
         print(f"{'script':<30} {'raw':>8} {'stripped':>9} {'sent':>9} {'of cap':>8}")
         for p in sorted(SCRIPTS.glob("*.js")):
@@ -176,15 +205,26 @@ def main() -> int:
                 continue
             stripped = strip_js(p.read_text())
             groups = list(dict.fromkeys(select_rows(stripped, set())[1]))
-            if len(groups) > 1:
-                sent = min(
-                    max(
-                        len(select_rows(stripped, set(left))[0]),
-                        len(select_rows(stripped, set(groups) - set(left))[0]),
-                    )
-                    for left in _proper_subsets(groups)
+            documented = DOCUMENTED_CALLS.get(p.name)
+            problem = None
+            if documented is not None:
+                problem = _documented_problem(groups, documented)
+                sizes = [(call, len(select_rows(stripped, set(call))[0])) for call in documented]
+                sent = max(size for _, size in sizes)
+                how = (
+                    "  (largest of the documented calls: "
+                    + ", ".join(f"--rows {','.join(call)} {size:,}" for call, size in sizes)
+                    + ")"
                 )
-                how = f"  (larger call of the best 2-way split of {len(groups)} slices)"
+            elif len(groups) > 1:
+                # A sliceable script with no declared workflow is itself the gap: measuring it on
+                # some split of this tool's choosing would report a size nobody sends.
+                problem = (
+                    f"{len(groups)} row groups but no entry in DOCUMENTED_CALLS — add the calls "
+                    "CHECKS.md gives operators, so this measures what they send"
+                )
+                sent = len(select_rows(stripped, set(groups))[0])
+                how = "  (every slice at once — no documented split to measure)"
             elif groups:
                 sent = len(select_rows(stripped, set(groups))[0])
                 how = "  (its only slice)"
@@ -192,11 +232,33 @@ def main() -> int:
                 sent = len(stripped)
                 how = ""
             over = sent > CAP
-            failed = failed or over
+            failed = failed or over or bool(problem)
             print(
                 f"{p.name:<30} {len(p.read_text()):>8,} {len(stripped):>9,} {sent:>9,} "
                 f"{sent / CAP * 100:>7.0f}%{'  OVER CAP' if over else ''}{how}"
             )
+            if problem:
+                print(f"{'':<30}   ^ {problem}")
+            # Over the cap, the useful next step is the split that would fit, so the doc can be
+            # rewritten to it. Enumerating the subsets is fine here: these are hand-authored #region
+            # markers and there is a handful of them per script.
+            if over and len(groups) > 1:
+                size, left = min(
+                    (
+                        max(
+                            len(select_rows(stripped, set(sub))[0]),
+                            len(select_rows(stripped, set(groups) - set(sub))[0]),
+                        ),
+                        sub,
+                    )
+                    for sub in _proper_subsets(groups)
+                )
+                right = [g for g in groups if g not in left]
+                print(
+                    f"{'':<30}   ^ a 2-way split that fits: --rows {','.join(left)} then "
+                    f"--rows {','.join(right)} (larger call {size:,}) — update CHECKS.md and "
+                    "DOCUMENTED_CALLS together"
+                )
         return 1 if failed else 0
 
     if not args.script:

--- a/.claude/skills/create-figma-chart/scripts/solve_export.py
+++ b/.claude/skills/create-figma-chart/scripts/solve_export.py
@@ -338,9 +338,25 @@ def main() -> int:
         except ValueError:
             ap.error(f"{flag} must look like 508x409")
             raise
+        # `math.isfinite` and not `a <= 0`: float() accepts 'nan' and 'inf', and neither is caught by
+        # a sign test — `nan <= 0` is False and so is `inf <= 0`. Both used to sail through and die
+        # ~90 lines later in `int(round(w / h * 1000))` as an uncaught traceback.
+        if not (math.isfinite(a) and math.isfinite(b)):
+            ap.error(f"{flag} must be two finite numbers, got {s!r}")
         if a <= 0 or b <= 0:
             ap.error(f"{flag} must be positive on both axes, got {a:g}x{b:g}")
         return a, b
+
+    # Same hole on every scalar float flag, and the same reason: a sign test cannot see a non-finite.
+    # Swept off the parser rather than a hand-kept list, so a float flag added later is covered
+    # without anyone remembering to add it here — the first draft of this guard named two flags that
+    # do not exist (`label_gap`, `font_size`) while missing four that do, which is exactly the
+    # failure a hardcoded list invites.
+    for action in ap._actions:
+        if action.type is float:
+            value = getattr(args, action.dest, None)
+            if value is not None and not math.isfinite(value):
+                ap.error(f"{action.option_strings[0]} must be finite, got {value}")
 
     bw, bh = pair(args.band, "--band")
     placed_w = args.placed_width or bw

--- a/.claude/skills/create-figma-chart/scripts/test_inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/test_inline_script.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Harness for `inline_script.py`.
+
+It had none, which is the wrong shape for a tool whose whole job is to decide what is safe to send:
+a mistake here does not raise, it emits a *slightly different* script, and a corrupted check reports
+a wrong verdict rather than failing. The cases below are the ones that have actually gone wrong.
+
+    .venv/bin/python .claude/skills/create-figma-chart/scripts/test_inline_script.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from inline_script import CAP, DOCUMENTED_CALLS, select_rows, strip_js  # noqa: E402
+
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, cond: object, detail: object = "") -> None:
+    results.append((name, bool(cond), str(detail)[:220]))
+
+
+# --- stripping keeps what is NOT a comment -------------------------------------------------------
+# Each of these three was called out in the module docstring as a thing a naive regex breaks, so
+# they are the cases most worth pinning: the corruption they cause surfaces as a plugin syntax
+# error with no clue to its cause.
+src = """const url = "https://example.com/x"; // trailing comment
+const re = /\\/\\*not a comment\\*\\//;
+const tpl = `line one
+// not a comment, inside a template
+line two`;
+/* block
+   comment */
+const after = 1;
+"""
+out = strip_js(src)
+check("a URL's // survives", "https://example.com/x" in out, out)
+check("a regex holding /* survives", "/\\/\\*not a comment\\*\\//" in out, out)
+check("a template's // line survives", "// not a comment, inside a template" in out, out)
+check("the trailing line comment is gone", "// trailing comment" not in out, out)
+check("the block comment is gone", "block" not in out.replace("not a comment", ""), out)
+check("code after a block comment survives", "const after = 1;" in out, out)
+
+# --- the corruption guard ------------------------------------------------------------------------
+# A NESTED template literal (a backtick inside a ${} inside a template) is legal JS and this parser
+# is not nesting-aware: it closes the outer context on the inner backtick, desynchronizes, and stops
+# stripping for the rest of the file. Silent, and the output is still valid JS — just far larger.
+nested = 'const a = `x${c ? "" : ` inner \\`${y}\\``}`;\n// must be stripped\nconst b = 1;\n'
+try:
+    strip_js(nested)
+    check("a desynchronizing nested template is REFUSED", False, "no exception raised")
+except ValueError as exc:
+    check("a desynchronizing nested template is REFUSED", True, str(exc))
+    check("and the message names the likely cause", "NESTED template" in str(exc), str(exc))
+
+# Region markers are structure, not commentary — `--rows` selects on them, so they must survive.
+regioned = "const pre = 1;\n// #region alpha\nconst a = 1; // gone\n// #endregion\n// #region beta\nconst b = 2;\n// #endregion\n"
+kept = strip_js(regioned)
+check("region markers survive stripping", "// #region alpha" in kept and "// #endregion" in kept, kept)
+check("comments inside a region still go", "// gone" not in kept, kept)
+
+# --- slicing -------------------------------------------------------------------------------------
+preamble, groups = select_rows(kept, set())
+check("groups are discovered in order", groups == ["alpha", "beta"], groups)
+check(
+    "an empty selection yields the preamble only",
+    "const pre = 1;" in preamble and "const a = 1;" not in preamble,
+    preamble,
+)
+one, _ = select_rows(kept, {"alpha"})
+check("a slice carries the preamble", "const pre = 1;" in one, one)
+check("a slice carries its own group", "const a = 1;" in one, one)
+check("a slice excludes the others", "const b = 2;" not in one, one)
+both, _ = select_rows(kept, {"alpha", "beta"})
+check("groups combine", "const a = 1;" in both and "const b = 2;" in both, both)
+check(
+    "an unmarked file comes back whole",
+    select_rows("const x = 1;\n", set())[0].strip() == "const x = 1;",
+    select_rows("const x = 1;\n", set())[0],
+)
+
+# --- the floor metric ----------------------------------------------------------------------------
+# `sent` answers "do today's documented calls fit". The FLOOR answers "can ANY split fit" — preamble
+# plus the single largest group. They move independently: verify_page.js sat at 82% sent against a
+# 72% floor, so it read as ~9,000 characters from trouble when re-splitting bought it ~14,000.
+big = (
+    "const pre = 1;\n"
+    + "// #region alpha\n"
+    + "const a = 1;\n" * 50
+    + "// #endregion\n"
+    + "// #region beta\n"
+    + "const b = 2;\n" * 10
+    + "// #endregion\n"
+)
+stripped_big = strip_js(big)
+gs = select_rows(stripped_big, set())[1]
+floor = max(len(select_rows(stripped_big, {g})[0]) for g in gs)
+whole = len(select_rows(stripped_big, set(gs))[0])
+check("the floor is the largest SINGLE group, not the total", floor < whole, f"floor {floor} whole {whole}")
+check("the floor is preamble + largest group", floor == len(select_rows(stripped_big, {"alpha"})[0]), floor)
+check("the floor never exceeds the whole file", floor <= whole, f"{floor} vs {whole}")
+
+# --- the declared workflow must cover the file exactly once --------------------------------------
+# A declaration that drifts from the #regions is how the check goes on reporting a comfortable
+# number for a workflow that no longer covers the script.
+for script, calls in DOCUMENTED_CALLS.items():
+    path = Path(__file__).resolve().parent / script
+    check(f"{script} exists to be measured", path.exists(), str(path))
+    if not path.exists():
+        continue
+    actual = select_rows(strip_js(path.read_text()), set())[1]
+    declared = [g for call in calls for g in call]
+    check(
+        f"{script}: declared calls cover every group exactly once",
+        sorted(declared) == sorted(actual),
+        f"declared {sorted(declared)} vs actual {sorted(actual)}",
+    )
+    for call in calls:
+        size = len(select_rows(strip_js(path.read_text()), set(call))[0])
+        check(f"{script}: --rows {','.join(call)} fits the cap", size <= CAP, f"{size:,} > {CAP:,}")
+
+bad = [r for r in results if not r[1]]
+for name, ok, detail in results:
+    print(f"{'PASS' if ok else 'FAIL'}  {name}" + ("" if ok else f"  >> {detail}"))
+print(f"\n{len(bad)} FAILURES" if bad else f"\nall checks passed ({len(results)} checks)")
+sys.exit(1 if bad else 0)

--- a/.claude/skills/create-figma-chart/scripts/test_inline_script.py
+++ b/.claude/skills/create-figma-chart/scripts/test_inline_script.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from inline_script import CAP, DOCUMENTED_CALLS, select_rows, strip_js  # noqa: E402
+from inline_script import CAP, DOCUMENTED_CALLS, select_rows, split_advice, strip_js  # noqa: E402
 
 results: list[tuple[str, bool, str]] = []
 
@@ -45,17 +45,44 @@ check("the trailing line comment is gone", "// trailing comment" not in out, out
 check("the block comment is gone", "block" not in out.replace("not a comment", ""), out)
 check("code after a block comment survives", "const after = 1;" in out, out)
 
-# --- the corruption guard ------------------------------------------------------------------------
-# A NESTED template literal (a backtick inside a ${} inside a template) is legal JS and this parser
-# is not nesting-aware: it closes the outer context on the inner backtick, desynchronizes, and stops
-# stripping for the rest of the file. Silent, and the output is still valid JS — just far larger.
+# --- nested templates, which are ordinary JS ------------------------------------------------------
+# A template literal can hold a `${}` expression that holds another template. A flat context could
+# not see that: the INNER opening backtick read as the outer one closing, and from there the parser
+# was one level out of step. Balanced nesting still ended at context None, so the end-of-file guard
+# passed it and the emitted script differed from the file on disk — silently, which is the one
+# failure this stripper exists to prevent. Parsed with a stack, each level closes its own.
 nested = 'const a = `x${c ? "" : ` inner \\`${y}\\``}`;\n// must be stripped\nconst b = 1;\n'
-try:
-    strip_js(nested)
-    check("a desynchronizing nested template is REFUSED", False, "no exception raised")
-except ValueError as exc:
-    check("a desynchronizing nested template is REFUSED", True, str(exc))
-    check("and the message names the likely cause", "NESTED template" in str(exc), str(exc))
+kept_nested = strip_js(nested)
+check("a balanced nested template parses instead of refusing", "` inner" in kept_nested, kept_nested)
+check("and the parser is still in sync after it", "// must be stripped" not in kept_nested, kept_nested)
+check("so the code after it survives", "const b = 1;" in kept_nested, kept_nested)
+
+# The case that made this visible: a `//` inside the INNER template is template text, not a comment,
+# and the outer template resumes after the expression closes.
+inner_comment = "const t = `outer ${`inner // keep\nline`} tail`;\n// gone\nconst z = 2;\n"
+kept_inner = strip_js(inner_comment)
+check("a // inside a nested template is not stripped", "// keep" in kept_inner, kept_inner)
+check("the outer template's tail survives", "tail`" in kept_inner, kept_inner)
+check("and the comment after it is still stripped", "// gone" not in kept_inner, kept_inner)
+
+# Inside a `${}` the content is CODE, so a comment there is a comment and must go — the mirror of
+# the case above, and the reason the expression is tracked rather than copied verbatim.
+expr_comment = "const v = `a${ x /* drop */ }b`;\n"
+check("a comment inside a ${} expression IS stripped", "drop" not in strip_js(expr_comment), strip_js(expr_comment))
+
+# --- the corruption guard ------------------------------------------------------------------------
+# Well-formed JS closes every literal it opens, so ending inside one means the parse desynchronized
+# and the rest of the file was copied verbatim. That is the backstop the stack cannot replace.
+for label, bad in [
+    ("template", "const a = `unterminated\n// must be stripped\n"),
+    ("${} expression", "const a = `x${ y\n// must be stripped\n"),
+]:
+    try:
+        strip_js(bad)
+        check(f"an unterminated {label} is REFUSED", False, "no exception raised")
+    except ValueError as exc:
+        check(f"an unterminated {label} is REFUSED", True, str(exc))
+        check(f"and the {label} message names what is open", "unterminated" in str(exc), str(exc))
 
 # Region markers are structure, not commentary — `--rows` selects on them, so they must survive.
 regioned = "const pre = 1;\n// #region alpha\nconst a = 1; // gone\n// #endregion\n// #region beta\nconst b = 2;\n// #endregion\n"
@@ -103,6 +130,39 @@ whole = len(select_rows(stripped_big, set(gs))[0])
 check("the floor is the largest SINGLE group, not the total", floor < whole, f"floor {floor} whole {whole}")
 check("the floor is preamble + largest group", floor == len(select_rows(stripped_big, {"alpha"})[0]), floor)
 check("the floor never exceeds the whole file", floor <= whole, f"{floor} vs {whole}")
+
+
+# --- what to advise when a script is over the cap -------------------------------------------------
+# Three different situations, and one of them used to be given the middle answer: past the FLOOR
+# every 2-way split is over the cap by construction, so naming the smallest of them as "a split that
+# fits" contradicts the exhaustion line printed beside it and points at a call that would be refused.
+def group_src(a: int, b: int) -> str:
+    return (
+        "const pre = 1;\n"
+        + "// #region alpha\n"
+        + "const a = 1;\n" * a
+        + "// #endregion\n"
+        + "// #region beta\n"
+        + "const b = 2;\n" * b
+        + "// #endregion\n"
+    )
+
+
+def advice_for(a: int, b: int) -> tuple[str | None, int]:
+    kept_src = strip_js(group_src(a, b))
+    gs = select_rows(kept_src, set())[1]
+    fl = max(len(select_rows(kept_src, {g})[0]) for g in gs)
+    return split_advice(kept_src, gs, fl), fl
+
+
+# Two modest groups whose combined call is over the cap but either one alone is well under it.
+fits, _ = advice_for(3_600, 3_600)
+check("a split that fits is offered as one", fits is not None and "a 2-way split that fits" in fits, fits)
+
+# One group alone already past the cap: no partition can help, so nothing may be described as fitting.
+exhausted, fl_ex = advice_for(4_500, 100)
+check("the floor fixture really is exhausted", fl_ex > 50_000, fl_ex)
+check("past the floor, no split is advertised as fitting", exhausted is None or "fits" not in exhausted, exhausted)
 
 # --- the declared workflow must cover the file exactly once --------------------------------------
 # A declaration that drifts from the #regions is how the check goes on reporting a comfortable

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -976,6 +976,18 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // fails a correct ramp by construction, so the row must say so rather than hand over the command flat.
     check("33 a map warns that a sequential ramp is out of scope",
           /SEQUENTIAL ramp/.test(binned) && /--maps/.test(binned), binned);
+    // Figma switches a paint off two independent ways, and only `visible: false` was tested on the
+    // FILL side — so a mark left at `opacity: 0` handed the audit a category colour that paints no
+    // pixels, and could be sent a reviewer to go and "fix". The stroke side already applied both
+    // tests. This hex is carried by nothing else in the fixture, so its absence can only come from
+    // the opacity test; the visible segment is asserted present so the case cannot pass by the
+    // command going missing altogether.
+    const ghost = buildFrame({ barSegment: true });
+    chartOf(ghost).children.push(node({ type: "RECTANGLE", name: "bar__Ghost", x: 300, y: 380,
+      width: 60, height: 40, fills: [Object.assign(solid("#12ab34")[0], { opacity: 0 })] }));
+    const dGhost = row(await run(ghost, {}), "colour-vision").detail;
+    check("33 a fully transparent mark fill is not a palette colour",
+          !/#12ab34/.test(dGhost) && /#4c6a9c/.test(dGhost), dGhost);
 
     // --- when --names is safe to emit. Rename EVERY qualifying mark, not one: the emitter keeps the
     // FIRST name per distinct hex, so renaming an arbitrary node can leave its colour already

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -1135,6 +1135,50 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // audit's findings name the categories that need attention.
     check("33 clean names DO produce --names, carrying the category", /--names 'Chile'/.test(d1), d1);
     check("33 and then no omission note is attached", !/--names omitted/.test(d1), d1);
+    // 33b — the two conditions measured on the REAL file, not invented. A `static_viz` import names
+    // every series group `<kind>__<slug>` (the dataset, not the category) and every paint-bearing
+    // leaf `Vector`, so distinct colours arrive sharing one name. That is worse than a missing name
+    // because it looks right: the audit prints one row per colour, all under the same label.
+    const shareName = buildFrame();
+    const chartGrp = shareName.children.find((c) => c.name === "chart");
+    chartGrp.children.push(node({
+      name: "bars__agriculture-share", type: "GROUP", x: 100, y: 300, width: 120, height: 60,
+      children: [
+        node({ type: "RECTANGLE", name: "Vector", x: 100, y: 300, width: 40, height: 60, fills: solid("#00847e") }),
+        node({ type: "RECTANGLE", name: "Vector", x: 150, y: 300, width: 40, height: 60, fills: solid("#883039") }),
+      ],
+    }));
+    const dShare = row(await run(shareName, {}), "colour-vision").detail;
+    check("33b two colours under one category name drop --names",
+          !/--names '/.test(dShare) && /distinct name/.test(dShare), dShare);
+    check("33b and both colours still reach the palette",
+          /#00847e/.test(dShare) && /#883039/.test(dShare), dShare);
+
+    // A generic import name labels nothing, even when it is distinct per colour.
+    const generic = buildFrame();
+    const chartGrp2 = generic.children.find((c) => c.name === "chart");
+    chartGrp2.children.push(node({
+      name: "series__one", type: "GROUP", x: 100, y: 300, width: 40, height: 60,
+      children: [node({ type: "RECTANGLE", name: "Vector", x: 100, y: 300, width: 40, height: 60, fills: solid("#00847e") })],
+    }));
+    chartGrp2.children.push(node({ type: "RECTANGLE", name: "Rectangle 12", x: 150, y: 300, width: 40, height: 60, fills: solid("#883039") }));
+    const dGen = row(await run(generic, {}), "colour-vision").detail;
+    check("33b an import-default name drops --names and says so",
+          !/--names '/.test(dGen) && /(import default|distinct name)/.test(dGen), dGen);
+
+    // 33c — a `static_viz` chart group is `chart__<slug>`, and an exact-only match called that
+    // "ungrouped" while walking it anyway: a wrong explanation for a right answer.
+    const slugged = buildFrame();
+    slugged.children.find((c) => c.name === "chart").name = "chart__agriculture-share";
+    const outSlug = await run(slugged, {});
+    check("33c chart__<slug> resolves by name",
+          /name "chart__agriculture-share"/.test(outSlug.resolved.chartBy), outSlug.resolved.chartBy);
+    check("33c and is not reported as ungrouped",
+          !/ungrouped/.test(outSlug.resolved.chartBy), outSlug.resolved.chartBy);
+    check("33c plain `chart` still resolves exactly",
+          /name "chart"$/.test((await run(buildFrame(), {})).resolved.chartBy),
+          (await run(buildFrame(), {})).resolved.chartBy);
+
     // And the reason given must be the real one, not the comma message reused for a missing name.
     const anon = buildFrame({ barSegment: true });
     renameMarks(anon, "");

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -232,10 +232,13 @@ const annotation = (o) => text("annotation__test", o.chars || "Note", o.size || 
     textStyleId: o.styleId === undefined ? "S:abc" : o.styleId,
   });
 
-async function run(frame, config) {
+// `wrap` puts the frame under an ancestor — a section or a group — because two of the switches that
+// decide whether a frame renders at all live ABOVE it, and a page whose only child is the frame cannot
+// model either. It takes the frame and returns whatever should sit on the page in its place.
+async function run(frame, config, wrap) {
   const byId = {};
   const index = (n) => { if (n.id) byId[n.id] = n; for (const c of n.children || []) index(c); };
-  const page = node({ id: "P:1", type: "PAGE", name: "page", children: [frame] });
+  const page = node({ id: "P:1", type: "PAGE", name: "page", children: [wrap ? wrap(frame) : frame] });
   index(page);
   const figma = { currentPage: page, getNodeByIdAsync: async (id) => byId[id] || null, setCurrentPageAsync: async () => {} };
   const body = SRC.replace(/^const CONFIG = \{[\s\S]*?^\};/m, "const CONFIG = __CONFIG__;");
@@ -1082,15 +1085,15 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const dDimFrame = row(await run(dimFrame, {}), "colour-vision").detail;
     check("33 a frame's own opacity disqualifies every mark under it",
           !/#4c6a9c/.test(dDimFrame) && /translucent/.test(dDimFrame), dDimFrame);
-    // At zero the marks do not merely lose their colour, they leave every row — so the count is zero
-    // for a reason that has nothing to do with what is on the frame. Reported as "no data marks found"
-    // that reads as an empty frame and sends the operator hunting for nodes that are all present.
+    // At zero the marks do not merely lose their colour, they leave every row — and so does the frame:
+    // it paints no pixels, so it goes through the shared gate in case 35 rather than being explained
+    // inside a colour row while thirty other rows go on certifying it.
     const goneFrame = buildFrame({ barSegment: true });
     goneFrame.opacity = 0;
-    const dGoneFrame = row(await run(goneFrame, {}), "colour-vision").detail;
-    check("33 a frame at opacity 0 says so, instead of reporting an empty plot",
-          /FRAME itself is at effective opacity 0/.test(dGoneFrame)
-          && !/No data marks or series strokes found/.test(dGoneFrame), dGoneFrame);
+    const outGone = await run(goneFrame, {});
+    check("33 a frame at opacity 0 is not audited for colour at all",
+          !row(outGone, "colour-vision") && !!row(outGone, "frame-not-rendered"),
+          outGone.verdict);
     // And an ordinary frame must carry neither message, or both become noise on every run.
     // And the note must not fire on an ordinary opaque chart, or it becomes noise on every run.
     const opaque = row(await run(buildFrame({ barSegment: true }), {}), "colour-vision").detail;
@@ -1205,6 +1208,100 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     check("33c plain `chart` still resolves exactly",
           /name "chart"$/.test((await run(buildFrame(), {})).resolved.chartBy),
           (await run(buildFrame(), {})).resolved.chartBy);
+
+    // 34 — a LEGEND is a picture of the categories, not a set of categories. grapher draws it INSIDE
+    // the chart group and OUTSIDE `map` (measured: `chart > numeric-color-legend > {lines, swatches,
+    // labels, swatch-hit-areas}`, a sibling of `map`), so every swatch arrived as an ordinary filled
+    // plot mark with `fromMap: false`. An ordinary choropleth then reported TWO palettes — its own
+    // legend audited as chart marks, under `--separated`, against the wrong set.
+    const legendGroup = (name, swatches) => node({ name, x: 40, y: 470, width: 300, height: 30, children: [
+      node({ name: "swatches", x: 40, y: 470, width: 300, height: 12,
+             children: swatches.map(([nm, hex], i) => node({ type: "RECTANGLE", name: nm, x: 40 + i * 70,
+               y: 470, width: 60, height: 12, fills: solid(hex) })) }),
+      node({ name: "labels", x: 40, y: 486, width: 300, height: 14,
+             children: [text("0", "0", 12, 40, 486, 20, 14, "#2d2e2d")] })] });
+
+    // 34a — a pure map with grapher's numeric legend. Two of the swatches repeat the countries' own
+    // bin colours; the third is an empty bin, drawn in the legend and on no country.
+    const legMap = buildFrame({ mapCountries: true });
+    const legMapChart = legMap.children.find((c) => c.name === "chart");
+    legMapChart.children = legMapChart.children.filter((c) => !/^(line|outline)__|^datapoints__/.test(c.name));
+    legMapChart.children.push(legendGroup("numeric-color-legend", [
+      ["Rectangle 3", "#4c6a9c"], ["Rectangle 4", "#b13507"], ["Rectangle 5", "#e56e5a"]]));
+    const dLegMap = row(await run(legMap, {}), "colour-vision").detail;
+    check("34a a map's own legend does not make it a two-palette frame",
+          !/two separate runs/.test(dLegMap) && !/--separated/.test(dLegMap), dLegMap);
+    check("34a and the map itself is still audited", /--maps/.test(dLegMap) && /#4c6a9c/.test(dLegMap), dLegMap);
+    check("34a the excluded swatches are counted, not silently dropped",
+          /legend swatch\(es\) are NOT in this palette/.test(dLegMap), dLegMap);
+    check("34a and a colour that exists ONLY in the legend is named",
+          /#e56e5a/.test(dLegMap) && /ONLY in the legend/.test(dLegMap), dLegMap);
+    check("34a while a swatch's own node name never labels the audit",
+          !/Rectangle 3/.test(dLegMap), dLegMap);
+
+    // 34b — the same on an ordinary chart, where the harm lands on `--names`: a numeric legend's bins
+    // are unnamed rects, so one swatch in a colour of its own put an import default into the palette
+    // and dropped the flag for the whole run. The series here is `line__A`, which names itself.
+    const legLine = buildFrame();
+    legLine.children.find((c) => c.name === "chart").children
+      .push(legendGroup("categorical-color-legend", [["Rectangle 8", "#e56e5a"]]));
+    const dLegLine = row(await run(legLine, {}), "colour-vision").detail;
+    check("34b a legend swatch does not cost an ordinary chart its --names",
+          /--names 'A'/.test(dLegLine) && !/--names omitted/.test(dLegLine), dLegLine);
+    check("34b and the swatch colour is reported as legend-only, not audited as a category",
+          /#e56e5a/.test(dLegLine) && /ONLY in the legend/.test(dLegLine), dLegLine);
+
+    // 34c — excluded from the PALETTE is not excluded from the page: an annotation dropped over the
+    // legend still covers something the reader needs. It keeps its box and is named for what it is,
+    // because "covers a filled data mark" sends the reader hunting for a bar that is not there.
+    const legAnn = buildFrame({ annotation: annotation({ x: 45, y: 468, w: 40, h: 16, stroke: "#ffffff", strokeWeight: 3 }) });
+    legAnn.children.find((c) => c.name === "chart").children
+      .push(legendGroup("categorical-color-legend", [["Rectangle 8", "#e56e5a"]]));
+    const dLegAnn = row(await run(legAnn, {}), "annotation-overlap");
+    check("34c an annotation over a legend swatch still FAILS", dLegAnn.status === "FAIL", dLegAnn.detail);
+    check("34c and it is called a legend swatch, not a data mark",
+          /a legend swatch/.test(dLegAnn.detail) && !/Rectangle 8 — a filled data mark/.test(dLegAnn.detail), dLegAnn.detail);
+
+    // 35 — the frame that paints no pixels. `collect` tests `visible` on every node it walks, but it
+    // starts at the frame's CHILDREN: a `visible: false` on the frame itself, or on a section holding
+    // it, was never read, and those children carry their own `visible: true`. The frame certified a
+    // full sheet of rows about a deliverable that is switched off.
+    const hiddenFrame = buildFrame({ barSegment: true });
+    hiddenFrame.visible = false;
+    const outHidden = await run(hiddenFrame, {});
+    check("35 a hidden frame emits ONE row, not a sheet of verdicts",
+          outHidden.rows.length === 1 && outHidden.rows[0].check === "frame-not-rendered", `${outHidden.rows.length} rows`);
+    check("35 the row FAILS rather than passing quietly", outHidden.rows[0].status === "FAIL", outHidden.rows[0].status);
+    check("35 the verdict says NOT CHECKED, never 'no mechanical row failed'",
+          /NOT CHECKED/.test(outHidden.verdict) && !/no mechanical row failed/.test(outHidden.verdict), outHidden.verdict);
+    check("35 and it names the switch that is off", /visible=false/.test(outHidden.rows[0].detail), outHidden.rows[0].detail);
+    // The ancestor half. Nothing on the frame or under it is touched here, so only the climb can
+    // account for the difference — and unhiding the frame would not help.
+    const underSection = buildFrame({ barSegment: true });
+    const outSection = await run(underSection, {}, (f) => node({ type: "SECTION", name: "WIP", visible: false, children: [f] }));
+    check("35 a hidden SECTION above the frame counts too",
+          outSection.rows.length === 1 && outSection.rows[0].check === "frame-not-rendered", `${outSection.rows.length} rows`);
+    check("35 and the ancestor is named, since unhiding the frame would not help",
+          /WIP/.test(outSection.rows[0].detail), outSection.rows[0].detail);
+    // Zero effective opacity is the same state reached by the other switch, and takes the same route.
+    const zeroFrame = buildFrame({ barSegment: true });
+    zeroFrame.opacity = 0;
+    const outZero = await run(zeroFrame, {});
+    check("35 an effectively invisible frame takes the same gate",
+          outZero.rows.length === 1 && /effective opacity/.test(outZero.rows[0].detail), outZero.verdict);
+    // And the gate must not fire on a frame that merely CONTAINS something hidden, or every page with
+    // a switched-off spare layer stops being checked at all.
+    const hiddenChild = buildFrame({ barSegment: true });
+    hiddenChild.children.find((c) => c.name === "chart").visible = false;
+    const outChild = await run(hiddenChild, {});
+    check("35 a hidden CHILD does not stop the frame being checked",
+          !row(outChild, "frame-not-rendered") && outChild.rows.length > 20, `${outChild.rows.length} rows`);
+    // A visible frame under a visible section is the other direction: the climb must not invent a
+    // hidden ancestor out of a `visible: true` one.
+    const outVisibleSection = await run(buildFrame({ barSegment: true }), {}, (f) => node({ type: "SECTION", name: "Live", children: [f] }));
+    check("35 a visible section above the frame changes nothing",
+          !row(outVisibleSection, "frame-not-rendered") && outVisibleSection.rows.length > 20,
+          `${outVisibleSection.rows.length} rows`);
 
     // And the reason given must be the real one, not the comma message reused for a missing name.
     const anon = buildFrame({ barSegment: true });

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -1010,6 +1010,42 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const dDim = row(await run(dimGroup, {}), "colour-vision").detail;
     check("33 an ancestor's opacity disqualifies an opaque leaf's colour",
           !/#12ab34/.test(dDim) && /translucent/.test(dDim), dDim);
+    // ZERO node opacity is NOT partial opacity, and the two must not share a verdict. A node at
+    // `opacity: 0` paints no pixels at all — the same non-rendering state as `visible: false` and as a
+    // zero-opacity PAINT, both of which are already dropped outright. Grouped with partial opacity it
+    // came back as a held-back translucent mark, so the audit NAMED an invisible category and told the
+    // operator to reset its opacity or judge it by eye: a verdict about something not on the canvas.
+    // The group carries the zero and the leaf is fully opaque, so the leaf's own paint cannot excuse it.
+    const zeroGroup = buildFrame({ barSegment: true });
+    chartOf(zeroGroup).children.push(node({ name: "series__Invisible", x: 300, y: 380, width: 60, height: 40,
+      opacity: 0, children: [node({ type: "RECTANGLE", name: "Rectangle 9", x: 300, y: 380,
+        width: 60, height: 40, fills: solid("#12ab34") })] }));
+    const dZero = row(await run(zeroGroup, {}), "colour-vision").detail;
+    check("33 a node at opacity 0 is not a palette colour",
+          !/#12ab34/.test(dZero) && /#4c6a9c/.test(dZero), dZero);
+    check("33 and it is not reported as a translucent mark to go and check",
+          !/translucent/.test(dZero) && !/Invisible/.test(dZero), dZero);
+    // Opacity MULTIPLIES down the tree, so invisibility can be reached without any single node being
+    // zero: 0.05 inside 0.05 is 0.0025, under the same floor `renders` puts a paint. A boolean could
+    // only ever call this pair "dim"; the product is what sees it is gone.
+    const compounded = buildFrame({ barSegment: true });
+    chartOf(compounded).children.push(node({ name: "series__Vanished", x: 300, y: 380, width: 60, height: 40,
+      opacity: 0.05, children: [node({ name: "inner", x: 300, y: 380, width: 60, height: 40, opacity: 0.05,
+        children: [node({ type: "RECTANGLE", name: "Rectangle 10", x: 300, y: 380,
+          width: 60, height: 40, fills: solid("#12ab34") })] })] }));
+    const dComp = row(await run(compounded, {}), "colour-vision").detail;
+    check("33 compounded opacity below the floor is invisible, not dim",
+          !/#12ab34/.test(dComp) && !/translucent/.test(dComp) && /#4c6a9c/.test(dComp), dComp);
+    // But a compounded value that is still ABOVE the floor is genuinely on the canvas: it keeps the
+    // translucent treatment and stays NAMED, or the new zero gate would swallow every dimmed mark.
+    const stillVisible = buildFrame({ barSegment: true });
+    chartOf(stillVisible).children.push(node({ name: "series__Halved", x: 300, y: 380, width: 60, height: 40,
+      opacity: 0.5, children: [node({ name: "inner", x: 300, y: 380, width: 60, height: 40, opacity: 0.5,
+        children: [node({ type: "RECTANGLE", name: "Rectangle 11", x: 300, y: 380,
+          width: 60, height: 40, fills: solid("#12ab34") })] })] }));
+    const dStill = row(await run(stillVisible, {}), "colour-vision").detail;
+    check("33 a compounded but still-visible mark stays translucent and named",
+          !/#12ab34/.test(dStill) && /translucent/.test(dStill) && /Halved/.test(dStill), dStill);
     // And the note must not fire on an ordinary opaque chart, or it becomes noise on every run.
     const opaque = row(await run(buildFrame({ barSegment: true }), {}), "colour-vision").detail;
     check("33 an opaque plot carries no translucency note",

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -988,6 +988,32 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const dGhost = row(await run(ghost, {}), "colour-vision").detail;
     check("33 a fully transparent mark fill is not a palette colour",
           !/#12ab34/.test(dGhost) && /#4c6a9c/.test(dGhost), dGhost);
+    // PARTIAL opacity is the other half, and it is not the same case: the mark IS on the canvas, so it
+    // keeps its box and its other rows — but its colour is the raw paint, not the composite the reader
+    // sees, so auditing it asks about a colour that is not on the page. Held back and NAMED, since a
+    // silently shorter palette is a subset audit reported as a whole one.
+    const faded = buildFrame({ barSegment: true });
+    chartOf(faded).children.push(node({ type: "RECTANGLE", name: "bar__Faded", x: 300, y: 380,
+      width: 60, height: 40, fills: [Object.assign(solid("#12ab34")[0], { opacity: 0.5 })] }));
+    const dFaded = row(await run(faded, {}), "colour-vision").detail;
+    check("33 a translucent mark is held out of the palette",
+          !/#12ab34/.test(dFaded) && /#4c6a9c/.test(dFaded), dFaded);
+    check("33 and the held-back mark is named, not silently dropped",
+          /translucent/.test(dFaded) && /Faded/.test(dFaded), dFaded);
+    // NODE opacity dims every paint under it and accumulates down the tree, so a fully opaque leaf
+    // inside a half-opacity group is just as unreportable. Read off the leaf's own paint alone, this
+    // one looks perfectly measurable — which is why the group carries the opacity here, not the leaf.
+    const dimGroup = buildFrame({ barSegment: true });
+    chartOf(dimGroup).children.push(node({ name: "series__Muted", x: 300, y: 380, width: 60, height: 40,
+      opacity: 0.4, children: [node({ type: "RECTANGLE", name: "Rectangle 7", x: 300, y: 380,
+        width: 60, height: 40, fills: solid("#12ab34") })] }));
+    const dDim = row(await run(dimGroup, {}), "colour-vision").detail;
+    check("33 an ancestor's opacity disqualifies an opaque leaf's colour",
+          !/#12ab34/.test(dDim) && /translucent/.test(dDim), dDim);
+    // And the note must not fire on an ordinary opaque chart, or it becomes noise on every run.
+    const opaque = row(await run(buildFrame({ barSegment: true }), {}), "colour-vision").detail;
+    check("33 an opaque plot carries no translucency note",
+          !/translucent/.test(opaque) && /#4c6a9c/.test(opaque), opaque);
 
     // --- when --names is safe to emit. Rename EVERY qualifying mark, not one: the emitter keeps the
     // FIRST name per distinct hex, so renaming an arbitrary node can leave its colour already

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -976,6 +976,32 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // fails a correct ramp by construction, so the row must say so rather than hand over the command flat.
     check("33 a map warns that a sequential ramp is out of scope",
           /SEQUENTIAL ramp/.test(binned) && /--maps/.test(binned), binned);
+    // A frame can hold BOTH families at once — combination.md's exemplar is a line chart with an inset
+    // locator map whose countries are filled with the same colours as their series. `isMap` is
+    // frame-level, so the map won the single mode flag and the LINE STROKES were audited under
+    // `--maps`, whose --suggest answers out of the lighter Categorical Maps set: fill colours
+    // recommended for thin strokes, the exact swap `--line` exists to prevent. Worse, colour dedupe ran
+    // across both families, so the series entry collapsed into the country that shares its colour and
+    // the series disappeared from `--names` altogether. This fixture IS that chart: `mapCountries` adds
+    // the inset to the default line series, and `country__FRA` reuses the series colour exactly as the
+    // guidelines prescribe.
+    const combo = row(await run(buildFrame({ mapCountries: true }), {}), "colour-vision").detail;
+    check("33 a combination frame audits the series as a LINE, not as a map",
+          /--names 'A' --line/.test(combo), combo);
+    check("33 and still audits its inset map as a map",
+          /--names 'country__FRA,country__DEU' --maps/.test(combo), combo);
+    check("33 and says why there are two runs, so the shared colour is not read as a clash",
+          /two separate runs/.test(combo) && /expected/.test(combo), combo);
+    // The split must not fire on a frame with only one family, or every ordinary chart grows a note
+    // about a map it does not have. Both directions, since either alone can pass on a broken gate.
+    const mapOnly = buildFrame({ mapCountries: true });
+    chartOf(mapOnly).children = chartOf(mapOnly).children.filter((c) => c.name !== "line__A");
+    const dMapOnly = row(await run(mapOnly, {}), "colour-vision").detail;
+    check("33 a map with no series is still ONE run, in --maps",
+          /--maps/.test(dMapOnly) && !/--line/.test(dMapOnly) && !/two separate runs/.test(dMapOnly), dMapOnly);
+    const lineOnly = row(await run(buildFrame({}), {}), "colour-vision").detail;
+    check("33 a line chart with no map is still ONE run, in --line",
+          /--line/.test(lineOnly) && !/--maps/.test(lineOnly) && !/two separate runs/.test(lineOnly), lineOnly);
     // Figma switches a paint off two independent ways, and only `visible: false` was tested on the
     // FILL side — so a mark left at `opacity: 0` handed the audit a category colour that paints no
     // pixels, and could be sent a reviewer to go and "fix". The stroke side already applied both

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -960,6 +960,10 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const dAnc = row(await run(ancestry, {}), "colour-vision").detail;
     check("33 a marker's category is read from its group, not its leaf name",
           /#58ac8c carries (Peru \+ Nepal|Nepal \+ Peru)/.test(dAnc), dAnc);
+    // And the category is what LABELS the audit too. Left as the leaf name, a failing pair reads
+    // "Ellipse 12 vs Ellipse 12" and identifies nothing.
+    check("33 and it labels the audit, so --names never says Ellipse 12",
+          /--names '[^']*Peru/.test(dAnc) && !/Ellipse 12/.test(dAnc), dAnc);
     // But a choropleth puts every country in a bin into ONE colour by design, so the same note must
     // not fire on a map or it fires on every map.
     const sameBin = buildFrame({ mapCountries: true });
@@ -1007,7 +1011,9 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const named = buildFrame({ barSegment: true });
     renameMarks(named, "series__Chile");
     const d1 = row(await run(named, {}), "colour-vision").detail;
-    check("33 clean names DO produce --names", /--names 'series__Chile'/.test(d1), d1);
+    // The label is the CATEGORY the mark belongs to, not the node's raw name — `--names` exists so the
+    // audit's findings name the categories that need attention.
+    check("33 clean names DO produce --names, carrying the category", /--names 'Chile'/.test(d1), d1);
     check("33 and then no omission note is attached", !/--names omitted/.test(d1), d1);
     // And the reason given must be the real one, not the comma message reused for a missing name.
     const anon = buildFrame({ barSegment: true });

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -1072,6 +1072,26 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const dStill = row(await run(stillVisible, {}), "colour-vision").detail;
     check("33 a compounded but still-visible mark stays translucent and named",
           !/#12ab34/.test(dStill) && /translucent/.test(dStill) && /Halved/.test(dStill), dStill);
+    // The FRAME is the one ancestor every mark shares, and it sits ABOVE the walk — which was seeded
+    // with a literal 1, so it was the only node whose opacity was never examined. A frame left at
+    // reduced opacity dims every mark on the canvas, and the raw paints went on being emitted as a
+    // paste-ready command. Nothing inside the frame is touched here, so only the frame can account for
+    // the difference.
+    const dimFrame = buildFrame({ barSegment: true });
+    dimFrame.opacity = 0.4;
+    const dDimFrame = row(await run(dimFrame, {}), "colour-vision").detail;
+    check("33 a frame's own opacity disqualifies every mark under it",
+          !/#4c6a9c/.test(dDimFrame) && /translucent/.test(dDimFrame), dDimFrame);
+    // At zero the marks do not merely lose their colour, they leave every row — so the count is zero
+    // for a reason that has nothing to do with what is on the frame. Reported as "no data marks found"
+    // that reads as an empty frame and sends the operator hunting for nodes that are all present.
+    const goneFrame = buildFrame({ barSegment: true });
+    goneFrame.opacity = 0;
+    const dGoneFrame = row(await run(goneFrame, {}), "colour-vision").detail;
+    check("33 a frame at opacity 0 says so, instead of reporting an empty plot",
+          /FRAME itself is at effective opacity 0/.test(dGoneFrame)
+          && !/No data marks or series strokes found/.test(dGoneFrame), dGoneFrame);
+    // And an ordinary frame must carry neither message, or both become noise on every run.
     // And the note must not fire on an ordinary opaque chart, or it becomes noise on every run.
     const opaque = row(await run(buildFrame({ barSegment: true }), {}), "colour-vision").detail;
     check("33 an opaque plot carries no translucency note",

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -149,6 +149,11 @@ function buildFrame(opts = {}) {
                       node({ type: "ELLIPSE", name: "dp2", x: 60, y: 262, width: 8, height: 8 })] }),
   ];
   if (opts.extraLine) kids.push(line("line__B", [[40, 420], [200, 340], [440, 300]], opts.extraLine));
+  // A second category in a SECOND colour. The palette rows compare pairs, so a one-colour fixture has
+  // no pair for them to check and the command is withheld by design — any case asserting on that
+  // command therefore needs two colours, or it is asserting on a branch that no longer runs.
+  if (opts.secondColour) kids.push(node({ type: "RECTANGLE", name: "bar__B", x: 420, y: 400,
+    width: 40, height: 30, fills: solid("#883039") }));
   if (opts.zeroAreaTick) kids.push(node({ name: "horizontal-axis", x: 40, y: 470, width: 400, height: 6, children: [
     node({ type: "VECTOR", name: "tick-0", x: 40, y: 470, width: 0, height: 6,
       strokeWeight: 1, strokes: solid("#dddddd"), dashPattern: opts.tickDash || [], strokeAlign: "CENTER", fills: solid("#000000"),
@@ -903,7 +908,7 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
   // name. They stay SKIPPED (no shell inside a Figma plugin), but a gap the operator has to
   // reconstruct by hand is the one that actually gets skipped.
   {
-    const out = await run(buildFrame(), {});
+    const out = await run(buildFrame({ secondColour: true }), {});
     for (const name of ["colour-vision", "grayscale-seams"]) {
       const r = row(out, name);
       check(`33 ${name} still declares itself skipped`, r.status === "SKIPPED", r.status);
@@ -924,7 +929,7 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
           / --line\b/.test(row(out, "colour-vision").detail), row(out, "colour-vision").detail);
     // A stacked chart is the case where order matters, so the warning must be present there — and only
     // there, since neither a map nor a line chart has seams. Strip the series lines to reach that branch.
-    const noSeries = buildFrame({ barSegment: true });
+    const noSeries = buildFrame({ barSegment: true, secondColour: true });
     const chartOf = (f) => f.children.find((c) => c.name === "chart");
     chartOf(noSeries).children = chartOf(noSeries).children.filter((c) => !/^(line|outline)__/.test(c.name));
     const dSep = row(await run(noSeries, {}), "colour-vision").detail;
@@ -969,9 +974,13 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
           /--names '[^']*Peru/.test(dAnc) && !/Ellipse 12/.test(dAnc), dAnc);
     // But a choropleth puts every country in a bin into ONE colour by design, so the same note must
     // not fire on a map or it fires on every map.
+    // Three countries, two of them in one bin: sharing a bin must not read as a clash, and the third
+    // keeps a genuine PAIR in the palette so the map's own run is still emitted.
     const sameBin = buildFrame({ mapCountries: true });
-    sameBin.children.find((c) => c.name === "chart").children
-      .find((c) => c.name === "map").children.find((c) => c.name === "country__DEU").fills = solid("#4c6a9c");
+    const sameBinMap = sameBin.children.find((c) => c.name === "chart").children.find((c) => c.name === "map");
+    sameBinMap.children.find((c) => c.name === "country__DEU").fills = solid("#4c6a9c");
+    sameBinMap.children.push(node({ type: "VECTOR", name: "country__BRA", x: 200, y: 160, width: 60, height: 40,
+      fills: solid("#b13507") }));
     const binned = row(await run(sameBin, {}), "colour-vision").detail;
     check("33 map shapes sharing a bin colour are NOT reported as a clash",
           !/judge them by eye/.test(binned), binned);
@@ -988,9 +997,9 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // the series disappeared from `--names` altogether. This fixture IS that chart: `mapCountries` adds
     // the inset to the default line series, and `country__FRA` reuses the series colour exactly as the
     // guidelines prescribe.
-    const combo = row(await run(buildFrame({ mapCountries: true }), {}), "colour-vision").detail;
+    const combo = row(await run(buildFrame({ mapCountries: true, secondColour: true }), {}), "colour-vision").detail;
     check("33 a combination frame audits the series as a LINE, not as a map",
-          /--names 'A' --line/.test(combo), combo);
+          /--names 'B,A' --line/.test(combo), combo);
     check("33 and still audits its inset map as a map",
           /--names 'country__FRA,country__DEU' --maps/.test(combo), combo);
     check("33 and says why there are two runs, so the shared colour is not read as a clash",
@@ -1002,7 +1011,7 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const dMapOnly = row(await run(mapOnly, {}), "colour-vision").detail;
     check("33 a map with no series is still ONE run, in --maps",
           /--maps/.test(dMapOnly) && !/--line/.test(dMapOnly) && !/two separate runs/.test(dMapOnly), dMapOnly);
-    const lineOnly = row(await run(buildFrame({}), {}), "colour-vision").detail;
+    const lineOnly = row(await run(buildFrame({ secondColour: true }), {}), "colour-vision").detail;
     check("33 a line chart with no map is still ONE run, in --line",
           /--line/.test(lineOnly) && !/--maps/.test(lineOnly) && !/two separate runs/.test(lineOnly), lineOnly);
     // Figma switches a paint off two independent ways, and only `visible: false` was tested on the
@@ -1126,17 +1135,21 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // registered under a clean earlier name and silently test nothing. (That is exactly how this case
     // first passed vacuously.) `barSegment` supplies a filled RECTANGLE — a data mark, which is what
     // now feeds the palette; renaming text fills tests nothing.
+    // `to` may be a function of the mark's index, for the cases where the names must differ from each
+    // other — a palette of two colours under one name is a different defect, tested separately.
     const renameMarks = (frame, to) => {
       let renamed = 0;
       (function walk(n) {
         if (n.type !== "TEXT" && !(n.children && n.children.length)
-            && n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) { n.name = to; renamed++; }
+            && n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) {
+          n.name = typeof to === "function" ? to(renamed) : to; renamed++;
+        }
         (n.children || []).forEach(walk);
       })(frame);
       return renamed;
     };
     // A comma in a name would misalign every --names entry after it, so the flag is dropped.
-    const comma = buildFrame({ barSegment: true });
+    const comma = buildFrame({ barSegment: true, secondColour: true });
     const renamed = renameMarks(comma, "series__Chile, mainland");
     check("33 the comma fixture actually renamed a data mark", renamed > 0, `renamed ${renamed}`);
     const d2 = row(await run(comma, {}), "colour-vision").detail;
@@ -1146,18 +1159,18 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
           !/--names '/.test(d2) && /contains a comma/.test(d2), d2);
     // An apostrophe would end the single-quoted shell argument mid-name, so the advertised paste-ready
     // command would not parse. Same treatment, and the reason must name the apostrophe.
-    const apos = buildFrame({ barSegment: true });
+    const apos = buildFrame({ barSegment: true, secondColour: true });
     renameMarks(apos, "series__Women's employment");
     const d4 = row(await run(apos, {}), "colour-vision").detail;
     check("33 an apostrophe in a name drops --names rather than breaking the shell",
           !/--names '/.test(d4) && /apostrophe/.test(d4), d4);
     // The happy path, or the negatives above would pass on a build that never emits --names at all.
-    const named = buildFrame({ barSegment: true });
-    renameMarks(named, "series__Chile");
+    const named = buildFrame({ barSegment: true, secondColour: true });
+    renameMarks(named, (i) => `series__${["Chile", "Peru", "Nepal"][i] || "Other"}`);
     const d1 = row(await run(named, {}), "colour-vision").detail;
     // The label is the CATEGORY the mark belongs to, not the node's raw name — `--names` exists so the
     // audit's findings name the categories that need attention.
-    check("33 clean names DO produce --names, carrying the category", /--names 'Chile'/.test(d1), d1);
+    check("33 clean names DO produce --names, carrying the category", /--names 'Chile[,']/.test(d1), d1);
     check("33 and then no omission note is attached", !/--names omitted/.test(d1), d1);
     // 33b — the two conditions measured on the REAL file, not invented. A `static_viz` import names
     // every series group `<kind>__<slug>` (the dataset, not the category) and every paint-bearing
@@ -1263,12 +1276,12 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // 34b — the same on an ordinary chart, where the harm lands on `--names`: a numeric legend's bins
     // are unnamed rects, so one swatch in a colour of its own put an import default into the palette
     // and dropped the flag for the whole run. The series here is `line__A`, which names itself.
-    const legLine = buildFrame();
+    const legLine = buildFrame({ secondColour: true });
     legLine.children.find((c) => c.name === "chart").children
       .push(legendGroup("categorical-color-legend", [["Rectangle 8", "#e56e5a"]]));
     const dLegLine = row(await run(legLine, {}), "colour-vision").detail;
     check("34b a legend swatch does not cost an ordinary chart its --names",
-          /--names 'A'/.test(dLegLine) && !/--names omitted/.test(dLegLine), dLegLine);
+          /--names 'B,A'/.test(dLegLine) && !/--names omitted/.test(dLegLine), dLegLine);
     check("34b and the swatch colour is reported as legend-only, not audited as a category",
           /#e56e5a/.test(dLegLine) && /ONLY in the legend/.test(dLegLine), dLegLine);
 
@@ -1325,11 +1338,47 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
           `${outVisibleSection.rows.length} rows`);
 
     // And the reason given must be the real one, not the comma message reused for a missing name.
-    const anon = buildFrame({ barSegment: true });
+    const anon = buildFrame({ barSegment: true, secondColour: true });
     renameMarks(anon, "");
     const d3 = row(await run(anon, {}), "colour-vision").detail;
     check("33 an unnamed mark reports THAT, not a phantom comma",
           /has no name/.test(d3) && !/contains a comma/.test(d3) && !/apostrophe/.test(d3), d3);
+
+    // 36 — a palette of ONE colour has no pair, and both rows compare pairs. `color_audit.py` does not
+    // say so: handed a single hex it prints an empty pair list, "overall: min dE inf", and exits 0,
+    // which reads exactly like a clean audit. GUIDELINES.md rules on this case directly — one
+    // categorical colour against neutral grays has nothing to check — so the command is withheld and
+    // the two checks that ARE live are handed over instead.
+    const oneColour = row(await run(buildFrame(), {}), "colour-vision").detail;
+    check("36 a one-colour palette emits no command at all",
+          !/Run: /.test(oneColour) && !/--names|--line|--maps|--separated/.test(oneColour)
+          && /NOTHING TO RUN/.test(oneColour), oneColour);
+    check("36 and it names the colour rather than reporting an empty plot",
+          /#4c6a9c/.test(oneColour) && !/No data marks or series strokes found/.test(oneColour), oneColour);
+    check("36 and hands over the two checks that are live",
+          /contrast against the frame's background/.test(oneColour) && /grayscale/.test(oneColour), oneColour);
+    check("36 and says why running it anyway would look clean",
+          /inf/.test(oneColour) && /GUIDELINES/.test(oneColour), oneColour);
+    // The negative control: two colours is a pair, so the command comes back.
+    const twoColour = row(await run(buildFrame({ secondColour: true }), {}), "colour-vision").detail;
+    check("36 two colours still produce a runnable command",
+          /Run: \.venv\/bin\/python/.test(twoColour) && !/NOTHING TO RUN/.test(twoColour), twoColour);
+    // And the clash note must SURVIVE the withheld command. Two categories painted one colour ARE a
+    // one-colour palette — deltaE 0, the severest collision there is — so the branch that withholds
+    // the run is the branch that most needs to report what it found. Computed before the exit.
+    const twoOnOne = row(await run(buildFrame({ extraLine: 3 }), {}), "colour-vision").detail;
+    check("36 a withheld run still names two categories sharing one colour",
+          /NOTHING TO RUN/.test(twoOnOne) && /judge them by eye/.test(twoOnOne)
+          && /(A \+ B|B \+ A)/.test(twoOnOne), twoOnOne);
+    // GUIDELINES.md rules the same way on a declared highlight treatment: the muting grays are
+    // furniture, so one highlight against them leaves no categorical pair. Which entries are muting
+    // grays is not decidable here — a category legitimately painted gray is a category — so the run is
+    // annotated rather than suppressed, and only when the treatment is DECLARED.
+    const hi = row(await run(buildFrame({ secondColour: true }), { highlightTreatment: true }), "colour-vision").detail;
+    check("36 a declared highlight treatment warns before the command",
+          /highlightTreatment is set/.test(hi) && /Run: \.venv\/bin\/python/.test(hi), hi);
+    check("36 and an undeclared frame carries no such warning",
+          !/highlightTreatment is set/.test(twoColour), twoColour);
   }
 
   const bad = results.filter((x) => !x.ok);

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -896,6 +896,64 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     check("31 a symmetric 14/14 still passes", row(await run(even, {}), "gap").status === "ok", row(await run(even, {}), "gap").detail);
   }
 
+  // 33 — the colour-vision / grayscale-seams rows must hand over a RUNNABLE command, not a tool
+  // name. They stay SKIPPED (no shell inside a Figma plugin), but a gap the operator has to
+  // reconstruct by hand is the one that actually gets skipped.
+  {
+    const out = await run(buildFrame(), {});
+    for (const name of ["colour-vision", "grayscale-seams"]) {
+      const r = row(out, name);
+      check(`33 ${name} still declares itself skipped`, r.status === "SKIPPED", r.status);
+      check(`33 ${name} names its owner`, r.ownedBy === "scripts/color_audit.py", String(r.ownedBy));
+      check(`33 ${name} emits the interpreter, not a bare script`,
+            /\.venv\/bin\/python \.claude\/skills\/create-figma-chart\/scripts\/color_audit\.py/.test(r.detail), r.detail);
+      check(`33 ${name} passes real hexes`, /'#[0-9a-f]{6}(,#[0-9a-f]{6})*'/.test(r.detail), r.detail);
+      check(`33 ${name} declares an adjacency mode`, /--separated|--maps/.test(r.detail), r.detail);
+    }
+    // Both rows must offer the SAME command — they are one run of one script.
+    const cmdOf = (n) => (/color_audit\.py (.*?)(?: —|$)/.exec(row(out, n).detail) || [])[1];
+    check("33 both rows hand over one identical command", cmdOf("colour-vision") === cmdOf("grayscale-seams"),
+          `${cmdOf("colour-vision")} vs ${cmdOf("grayscale-seams")}`);
+    // A stacked chart is the case where order matters, so the warning must be present off a map.
+    check("33 non-map run warns that stack order matters",
+          /STACKED or SEGMENTED/.test(row(out, "colour-vision").detail), row(out, "colour-vision").detail);
+    // A comma in a node name would misalign every --names entry after it, so the flag is dropped.
+    // Rename EVERY filled descendant, not one: the emitter keeps the FIRST name per distinct hex,
+    // so renaming an arbitrary node can leave its colour already registered under a clean earlier
+    // name and silently test nothing. (That is exactly how this case first passed vacuously.)
+    const comma = buildFrame();
+    let renamed = 0;
+    (function walk(n) {
+      if (n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) { n.name = "series__Chile, mainland"; renamed++; }
+      (n.children || []).forEach(walk);
+    })(comma);
+    check("33 the comma fixture actually renamed a filled node", renamed > 0, `renamed ${renamed}`);
+    const d2 = row(await run(comma, {}), "colour-vision").detail;
+    // Match the FLAG (`--names '…'`), not the substring: the explanatory note says "--names
+    // omitted", so a bare /--names/ is satisfied by the very sentence proving it was dropped.
+    check("33 a comma in a node name drops --names rather than misaligning it",
+          !/--names '/.test(d2) && /contains a comma/.test(d2), d2);
+    // The happy path, or the two negatives above would pass on a build that never emits --names at
+    // all. Clean names on every filled node must produce the flag, carrying those names.
+    const named = buildFrame();
+    (function walk(n) {
+      if (n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) n.name = "series__Chile";
+      (n.children || []).forEach(walk);
+    })(named);
+    const d1 = row(await run(named, {}), "colour-vision").detail;
+    check("33 clean names DO produce --names", /--names 'series__Chile'/.test(d1), d1);
+    check("33 and then no omission note is attached", !/--names omitted/.test(d1), d1);
+    // And the reason given must be the real one, not the comma message reused for a missing name.
+    const anon = buildFrame();
+    (function walk(n) {
+      if (n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) n.name = "";
+      (n.children || []).forEach(walk);
+    })(anon);
+    const d3 = row(await run(anon, {}), "colour-vision").detail;
+    check("33 an unnamed fill node reports THAT, not a phantom comma",
+          /has no name/.test(d3) && !/contains a comma/.test(d3), d3);
+  }
+
   const bad = results.filter((x) => !x.ok);
   for (const x of results) console.log(`${x.ok ? "PASS" : "FAIL"}  ${x.name}${x.ok ? "" : "  >> " + x.detail}`);
   console.log(bad.length ? `\n${bad.length} FAILURES` : `\nALL PASS (${results.length} checks)`);

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -917,41 +917,80 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     // A stacked chart is the case where order matters, so the warning must be present off a map.
     check("33 non-map run warns that stack order matters",
           /STACKED or SEGMENTED/.test(row(out, "colour-vision").detail), row(out, "colour-vision").detail);
-    // A comma in a node name would misalign every --names entry after it, so the flag is dropped.
-    // Rename EVERY filled descendant, not one: the emitter keeps the FIRST name per distinct hex,
-    // so renaming an arbitrary node can leave its colour already registered under a clean earlier
-    // name and silently test nothing. (That is exactly how this case first passed vacuously.)
-    const comma = buildFrame();
-    let renamed = 0;
-    (function walk(n) {
-      if (n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) { n.name = "series__Chile, mainland"; renamed++; }
-      (n.children || []).forEach(walk);
-    })(comma);
-    check("33 the comma fixture actually renamed a filled node", renamed > 0, `renamed ${renamed}`);
+    // --- what the palette is BUILT FROM. The `fills` inventory was the wrong source: it carries every
+    // solid paint on an area node in the plot, and a TEXT node has one, while a line chart's series
+    // colour is a STROKE and is not in it at all. On this very fixture that meant the emitted command
+    // audited `label__A`'s text fill and omitted the series colour — furniture in, data out.
+    const offPaletteLabel = row(await run(buildFrame({ labelFill: "#123456" }), {}), "colour-vision").detail;
+    check("33 a text label's fill is NOT audited as a category",
+          !/#123456/.test(offPaletteLabel), offPaletteLabel);
+    // The other half: the series colour must be PRESENT, and it exists only as a stroke.
+    const strokeOnly = row(await run(buildFrame({ gappedLine: true }), {}), "colour-vision").detail;
+    check("33 a line series' stroke colour IS audited", /#b13507/.test(strokeOnly), strokeOnly);
+    // `outline__*` is the white halo under a line, shared by every series — not a category colour.
+    const rings = row(await run(buildFrame({ scatterRings: true }), {}), "colour-vision").detail;
+    check("33 the white outline halo is not taken for a category",
+          !/#ffffff/.test(rings) && /#b13507/.test(rings), rings);
+    // A colour carrying two categories is collapsed by the hex dedupe, so it is NAMED instead of
+    // silently dropped — otherwise the severest clash there is (deltaE 0) produces a vacuous pass.
+    const twoSeries = row(await run(buildFrame({ extraLine: 3 }), {}), "colour-vision").detail;
+    check("33 two series on one colour are named, not silently merged",
+          /judge them by eye/.test(twoSeries) && /A \+ B|B \+ A/.test(twoSeries), twoSeries);
+    // But a choropleth puts every country in a bin into ONE colour by design, so the same note must
+    // not fire on a map or it fires on every map.
+    const sameBin = buildFrame({ mapCountries: true });
+    sameBin.children.find((c) => c.name === "chart").children
+      .find((c) => c.name === "map").children.find((c) => c.name === "country__DEU").fills = solid("#4c6a9c");
+    const binned = row(await run(sameBin, {}), "colour-vision").detail;
+    check("33 map shapes sharing a bin colour are NOT reported as a clash",
+          !/judge them by eye/.test(binned), binned);
+    // A map is audited as a CATEGORICAL choropleth, which a sequential ramp is not: the deltaE 20 gate
+    // fails a correct ramp by construction, so the row must say so rather than hand over the command flat.
+    check("33 a map warns that a sequential ramp is out of scope",
+          /SEQUENTIAL ramp/.test(binned) && /--maps/.test(binned), binned);
+
+    // --- when --names is safe to emit. Rename EVERY qualifying mark, not one: the emitter keeps the
+    // FIRST name per distinct hex, so renaming an arbitrary node can leave its colour already
+    // registered under a clean earlier name and silently test nothing. (That is exactly how this case
+    // first passed vacuously.) `barSegment` supplies a filled RECTANGLE — a data mark, which is what
+    // now feeds the palette; renaming text fills tests nothing.
+    const renameMarks = (frame, to) => {
+      let renamed = 0;
+      (function walk(n) {
+        if (n.type !== "TEXT" && !(n.children && n.children.length)
+            && n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) { n.name = to; renamed++; }
+        (n.children || []).forEach(walk);
+      })(frame);
+      return renamed;
+    };
+    // A comma in a name would misalign every --names entry after it, so the flag is dropped.
+    const comma = buildFrame({ barSegment: true });
+    const renamed = renameMarks(comma, "series__Chile, mainland");
+    check("33 the comma fixture actually renamed a data mark", renamed > 0, `renamed ${renamed}`);
     const d2 = row(await run(comma, {}), "colour-vision").detail;
     // Match the FLAG (`--names '…'`), not the substring: the explanatory note says "--names
     // omitted", so a bare /--names/ is satisfied by the very sentence proving it was dropped.
-    check("33 a comma in a node name drops --names rather than misaligning it",
+    check("33 a comma in a name drops --names rather than misaligning it",
           !/--names '/.test(d2) && /contains a comma/.test(d2), d2);
-    // The happy path, or the two negatives above would pass on a build that never emits --names at
-    // all. Clean names on every filled node must produce the flag, carrying those names.
-    const named = buildFrame();
-    (function walk(n) {
-      if (n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) n.name = "series__Chile";
-      (n.children || []).forEach(walk);
-    })(named);
+    // An apostrophe would end the single-quoted shell argument mid-name, so the advertised paste-ready
+    // command would not parse. Same treatment, and the reason must name the apostrophe.
+    const apos = buildFrame({ barSegment: true });
+    renameMarks(apos, "series__Women's employment");
+    const d4 = row(await run(apos, {}), "colour-vision").detail;
+    check("33 an apostrophe in a name drops --names rather than breaking the shell",
+          !/--names '/.test(d4) && /apostrophe/.test(d4), d4);
+    // The happy path, or the negatives above would pass on a build that never emits --names at all.
+    const named = buildFrame({ barSegment: true });
+    renameMarks(named, "series__Chile");
     const d1 = row(await run(named, {}), "colour-vision").detail;
     check("33 clean names DO produce --names", /--names 'series__Chile'/.test(d1), d1);
     check("33 and then no omission note is attached", !/--names omitted/.test(d1), d1);
     // And the reason given must be the real one, not the comma message reused for a missing name.
-    const anon = buildFrame();
-    (function walk(n) {
-      if (n.fills && n.fills.length && n.fills.some((f) => f.type === "SOLID")) n.name = "";
-      (n.children || []).forEach(walk);
-    })(anon);
+    const anon = buildFrame({ barSegment: true });
+    renameMarks(anon, "");
     const d3 = row(await run(anon, {}), "colour-vision").detail;
-    check("33 an unnamed fill node reports THAT, not a phantom comma",
-          /has no name/.test(d3) && !/contains a comma/.test(d3), d3);
+    check("33 an unnamed mark reports THAT, not a phantom comma",
+          /has no name/.test(d3) && !/contains a comma/.test(d3) && !/apostrophe/.test(d3), d3);
   }
 
   const bad = results.filter((x) => !x.ok);

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -908,15 +908,26 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
       check(`33 ${name} emits the interpreter, not a bare script`,
             /\.venv\/bin\/python \.claude\/skills\/create-figma-chart\/scripts\/color_audit\.py/.test(r.detail), r.detail);
       check(`33 ${name} passes real hexes`, /'#[0-9a-f]{6}(,#[0-9a-f]{6})*'/.test(r.detail), r.detail);
-      check(`33 ${name} declares an adjacency mode`, /--separated|--maps/.test(r.detail), r.detail);
+      check(`33 ${name} declares an adjacency mode`, /--separated|--maps|--line/.test(r.detail), r.detail);
     }
     // Both rows must offer the SAME command — they are one run of one script.
     const cmdOf = (n) => (/color_audit\.py (.*?)(?: —|$)/.exec(row(out, n).detail) || [])[1];
     check("33 both rows hand over one identical command", cmdOf("colour-vision") === cmdOf("grayscale-seams"),
           `${cmdOf("colour-vision")} vs ${cmdOf("grayscale-seams")}`);
-    // A stacked chart is the case where order matters, so the warning must be present off a map.
-    check("33 non-map run warns that stack order matters",
-          /STACKED or SEGMENTED/.test(row(out, "colour-vision").detail), row(out, "colour-vision").detail);
+    // The mode flag also picks which palette a --suggest rerun searches, so it is not cosmetic.
+    // A line/slope palette needs `--line`: `--separated` alone would have the search recommend FILL
+    // colours for thin strokes. The default fixture is a line chart.
+    check("33 a line series asks for the Line and Slope variants",
+          / --line\b/.test(row(out, "colour-vision").detail), row(out, "colour-vision").detail);
+    // A stacked chart is the case where order matters, so the warning must be present there — and only
+    // there, since neither a map nor a line chart has seams. Strip the series lines to reach that branch.
+    const noSeries = buildFrame({ barSegment: true });
+    const chartOf = (f) => f.children.find((c) => c.name === "chart");
+    chartOf(noSeries).children = chartOf(noSeries).children.filter((c) => !/^(line|outline)__/.test(c.name));
+    const dSep = row(await run(noSeries, {}), "colour-vision").detail;
+    check("33 a fill-only palette gets --separated, not --line",
+          / --separated\b/.test(dSep) && !/--line/.test(dSep), dSep);
+    check("33 and that run warns that stack order matters", /STACKED or SEGMENTED/.test(dSep), dSep);
     // --- what the palette is BUILT FROM. The `fills` inventory was the wrong source: it carries every
     // solid paint on an area node in the plot, and a TEXT node has one, while a line chart's series
     // colour is a STROKE and is not in it at all. On this very fixture that meant the emitted command
@@ -936,6 +947,19 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     const twoSeries = row(await run(buildFrame({ extraLine: 3 }), {}), "colour-vision").detail;
     check("33 two series on one colour are named, not silently merged",
           /judge them by eye/.test(twoSeries) && /A \+ B|B \+ A/.test(twoSeries), twoSeries);
+    // The category name sits on the GROUP and the paint on its leaves — grapher's documented
+    // `datapoints__<Entity>` shape, where the filled marker is called something like `Ellipse 12`.
+    // Reading the category off the painted node's own name loses it on exactly that shape, so two
+    // entities sharing a marker colour would be merged with no warning. The colour here is carried by
+    // NOTHING else in the fixture, so this can only pass via the ancestor.
+    const ancestry = buildFrame();
+    const marker = (entity) => node({ name: `datapoints__${entity}`, x: 60, y: 150, width: 40, height: 40,
+      children: [node({ type: "ELLIPSE", name: "Ellipse 12", x: 60, y: 150, width: 8, height: 8,
+                        fills: solid("#58ac8c") })] });
+    chartOf(ancestry).children.push(marker("Peru"), marker("Nepal"));
+    const dAnc = row(await run(ancestry, {}), "colour-vision").detail;
+    check("33 a marker's category is read from its group, not its leaf name",
+          /#58ac8c carries (Peru \+ Nepal|Nepal \+ Peru)/.test(dAnc), dAnc);
     // But a choropleth puts every country in a bin into ONE colour by design, so the same note must
     // not fire on a map or it fires on every map.
     const sameBin = buildFrame({ mapCountries: true });

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -345,6 +345,28 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     check("6b and so does a fully transparent one",
           row(clear, "annotation-knockout").status === "FAIL" && /carries NO knockout/.test(row(clear, "annotation-knockout").detail),
           row(clear, "annotation-knockout").detail);
+    // 6b-2 — between the two. A knockout works by PAINTING the frame's colour over what it crosses,
+    //        so a nearly transparent one masks nothing while still passing the weight, alignment and
+    //        colour checks — a clean `ok` on a crossing the reader can see straight through. Zero is
+    //        the case above; anything positive is on the canvas but cannot be certified from here,
+    //        since how much it masks depends on what is behind it. REVIEW, with the number named.
+    const faintKO = await run(buildFrame({ annotation: annotation({ x: 100, y: 195, w: 120, h: 18, stroke: "#ffffff", strokeWeight: 3, strokeOpacity: 0.005 }) }), {});
+    check("6b-2 a nearly transparent knockout is not certified",
+          row(faintKO, "annotation-knockout").status === "REVIEW", row(faintKO, "annotation-knockout").detail);
+    check("6b-2 and the effective opacity is named, not just flagged",
+          /0\.005|effective opacity/.test(row(faintKO, "annotation-knockout").detail), row(faintKO, "annotation-knockout").detail);
+    // The NODE's own opacity dims the knockout just as effectively as the paint's, and it is the half
+    // a paint-only read cannot see: this paint is fully opaque.
+    const dimAnn = annotation({ x: 100, y: 195, w: 120, h: 18, stroke: "#ffffff", strokeWeight: 3 });
+    dimAnn.opacity = 0.4;
+    const dimKO = await run(buildFrame({ annotation: dimAnn }), {});
+    check("6b-2 a dimmed annotation node is not certified either",
+          row(dimKO, "annotation-knockout").status === "REVIEW", row(dimKO, "annotation-knockout").detail);
+    // The control: a fully opaque knockout still passes cleanly, or this becomes a row that always
+    // reviews and therefore says nothing.
+    const solidKO = await run(buildFrame({ annotation: annotation({ x: 100, y: 195, w: 120, h: 18, stroke: "#ffffff", strokeWeight: 3 }) }), {});
+    check("6b-2 while an opaque knockout still passes",
+          row(solidKO, "annotation-knockout").status === "ok", row(solidKO, "annotation-knockout").detail);
     // ...and the COLOUR check must read the paint that renders, not strokes[0]
     const decoy = await run(buildFrame({ frameFill: "#fffbf5", annotation: annotation({ x: 100, y: 195, w: 120, h: 18, stroke: "#fffbf5", strokeWeight: 3, decoyStroke: "#ffffff" }) }), {});
     check("6b an invisible paint in front does not become the colour that is judged",

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -1166,6 +1166,26 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
     check("33b an import-default name drops --names and says so",
           !/--names '/.test(dGen) && /(import default|distinct name)/.test(dGen), dGen);
 
+    // 33b-grapher — the OTHER naming convention, and the one --names exists for. Grapher's own SVG
+    // export emits `line__<Entity>` / `outline__<Entity>` / `datapoints__<Entity>` per series, where
+    // the second token IS the category. That must keep producing labels; the guards above are aimed
+    // at `static_viz`'s `<slug>__<part>`, where it is not. One frame proves both halves are separable.
+    const grapher = buildFrame();
+    const gChart = grapher.children.find((c) => c.name === "chart");
+    for (const [entity, hex] of [["Chile", "#883039"], ["Peru", "#00847e"]]) {
+      gChart.children.push(node({
+        name: `line__${entity}`, type: "GROUP", x: 100, y: 200, width: 200, height: 80,
+        children: [node({ type: "VECTOR", name: "Vector", x: 100, y: 200, width: 200, height: 80,
+                          strokes: solid(hex), strokeWeight: 3, strokeAlign: "CENTER", dashPattern: [] })],
+      }));
+    }
+    const dGrapher = row(await run(grapher, {}), "colour-vision").detail;
+    check("33b grapher line__<Entity> DOES produce --names",
+          /--names '[^']*Chile[^']*Peru[^']*'/.test(dGrapher) || /--names '[^']*Peru[^']*Chile[^']*'/.test(dGrapher), dGrapher);
+    check("33b and the leaf's generic `Vector` name is not what gets used",
+          !/--names '[^']*Vector/.test(dGrapher), dGrapher);
+    check("33b a line palette selects --line", /--line\b/.test(dGrapher), dGrapher);
+
     // 33c — a `static_viz` chart group is `chart__<slug>`, and an exact-only match called that
     // "ungrouped" while walking it anyway: a wrong explanation for a right answer.
     const slugged = buildFrame();
@@ -1175,6 +1195,13 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
           /name "chart__agriculture-share"/.test(outSlug.resolved.chartBy), outSlug.resolved.chartBy);
     check("33c and is not reported as ungrouped",
           !/ungrouped/.test(outSlug.resolved.chartBy), outSlug.resolved.chartBy);
+    // The third variant counted in the file: a two-format page names them `chart-desktop`/`chart-mobile`.
+    const hyphen = buildFrame();
+    hyphen.children.find((c) => c.name === "chart").name = "chart-desktop";
+    const outHyphen = await run(hyphen, {});
+    check("33c chart-desktop resolves by name",
+          /name "chart-desktop"/.test(outHyphen.resolved.chartBy) && !/ungrouped/.test(outHyphen.resolved.chartBy),
+          outHyphen.resolved.chartBy);
     check("33c plain `chart` still resolves exactly",
           /name "chart"$/.test((await run(buildFrame(), {})).resolved.chartBy),
           (await run(buildFrame(), {})).resolved.chartBy);

--- a/.claude/skills/create-figma-chart/scripts/test_verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/test_verify_page.js
@@ -1054,17 +1054,38 @@ const row = (out, name) => out.rows.find((x) => x.check === name);
           !/#12ab34/.test(dZero) && /#4c6a9c/.test(dZero), dZero);
     check("33 and it is not reported as a translucent mark to go and check",
           !/translucent/.test(dZero) && !/Invisible/.test(dZero), dZero);
-    // Opacity MULTIPLIES down the tree, so invisibility can be reached without any single node being
-    // zero: 0.05 inside 0.05 is 0.0025, under the same floor `renders` puts a paint. A boolean could
-    // only ever call this pair "dim"; the product is what sees it is gone.
+    // Opacity MULTIPLIES down the tree, so a pair of small values compounds to a very small one:
+    // 0.05 inside 0.05 is 0.0025. That is FAINT, not absent — the non-rendering exit is exactly zero,
+    // never a floor — so it takes the translucent treatment: out of the palette, and NAMED, because
+    // "reset the opacity and re-run" is the one instruction that helps here. A cutoff would have
+    // dropped it from every row in the file instead, including the rows that never look at colour.
     const compounded = buildFrame({ barSegment: true });
     chartOf(compounded).children.push(node({ name: "series__Vanished", x: 300, y: 380, width: 60, height: 40,
       opacity: 0.05, children: [node({ name: "inner", x: 300, y: 380, width: 60, height: 40, opacity: 0.05,
         children: [node({ type: "RECTANGLE", name: "Rectangle 10", x: 300, y: 380,
           width: 60, height: 40, fills: solid("#12ab34") })] })] }));
     const dComp = row(await run(compounded, {}), "colour-vision").detail;
-    check("33 compounded opacity below the floor is invisible, not dim",
-          !/#12ab34/.test(dComp) && !/translucent/.test(dComp) && /#4c6a9c/.test(dComp), dComp);
+    check("33 a mark compounded to near-zero is held out of the palette and named",
+          !/#12ab34/.test(dComp) && /translucent/.test(dComp) && /Vanished/.test(dComp) && /#4c6a9c/.test(dComp), dComp);
+    // And it stays in the rows that are not about colour at all. A cutoff took the whole subtree out of
+    // the walk, so an 8px label at 0.005 left `text-floor` reporting that every range cleared the floor
+    // — a row certifying a frame on input it had silently removed. Faint is not gone.
+    const faintText = buildFrame();
+    chartOf(faintText).children.push(node({ name: "faint", x: 60, y: 300, width: 80, height: 12, opacity: 0.005,
+      children: [text("label__Faint", "8px and faint", 8, 60, 300, 80, 12, "#4c6a9c")] }));
+    const outFaint = await run(faintText, {});
+    check("33 a near-transparent 8px label is still judged by text-floor",
+          row(outFaint, "text-floor").status === "FAIL" && /8px and faint/.test(row(outFaint, "text-floor").detail),
+          row(outFaint, "text-floor").detail);
+    // Exactly zero is the other side of that line, and it must stay dropped: the product reaches it
+    // only through a factor of zero, so nothing here is a threshold judgement.
+    const zeroText = buildFrame();
+    chartOf(zeroText).children.push(node({ name: "gone", x: 60, y: 300, width: 80, height: 12, opacity: 0,
+      children: [text("label__Gone", "8px and gone", 8, 60, 300, 80, 12, "#4c6a9c")] }));
+    const outZeroText = await run(zeroText, {});
+    check("33 while an 8px label at opacity 0 is not judged at all",
+          row(outZeroText, "text-floor").status === "ok" && !/8px and gone/.test(row(outZeroText, "text-floor").detail),
+          row(outZeroText, "text-floor").detail);
     // But a compounded value that is still ABOVE the floor is genuinely on the canvas: it keeps the
     // translucent treatment and stays NAMED, or the new zero gate would swallow every dimmed mark.
     const stillVisible = buildFrame({ barSegment: true });

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -172,6 +172,12 @@ const checkFrame = async (frameId) => {
   // series at all and the weight row skips in silence. Same shape as `datapoints__<Entity>`: name on
   // the group, properties on the child. So carry the nearest naming ancestor down the walk.
   const SERIES_ANY = /^(line|slope|outline)__(.+)$/;
+  // The CATEGORY a node belongs to, by grapher's `<kind>__<Entity>` naming. Broader than SERIES_ANY on
+  // purpose: `datapoints__<Entity>`, `bar__<Entity>` and `country__<ISO>` all name a category and none
+  // of them is a series line. Like `seriesOf` it has to travel DOWN the walk, because the name sits on
+  // the group while the paint sits on its leaves — a `datapoints__<Entity>` marker is a filled leaf
+  // called `Ellipse 12`, so reading the category off the painted node's own name loses it every time.
+  const CATEGORY_ANY = /^[a-z][a-z-]*__(.+)$/i;
   // A map is detected structurally, by grapher's own container. It matters because a map is the one
   // chart type whose INK ASPECT IS FIXED: measured live, a map requested at a 1.4033 target came back
   // at 1.5428 (and at 1.7446 unsolved), because the projection sets the aspect and any extra canvas
@@ -180,7 +186,7 @@ const checkFrame = async (frameId) => {
   // far larger than the 12-16px band rule by construction.
   const MAP_GROUPS = /^(map|countries|countries-without-data)$/i;
   let isMap = false;
-  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap) => {
+  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor) => {
     if ("visible" in n && !n.visible) return;
     // The furniture CONTAINER name is carried, not just the boolean: the dash target is decided by what
     // a node IS (a gridline vs a zero line vs a tick), and deciding it from the node's own current dash
@@ -189,6 +195,8 @@ const checkFrame = async (frameId) => {
     if (insidePlot && MAP_GROUPS.test(n.name)) { isMap = true; insideMap = true; }
     const sm = SERIES_ANY.exec(n.name);
     if (sm) seriesOf = { kind: sm[1], series: sm[2] };
+    const cm = CATEGORY_ANY.exec(n.name);
+    if (cm) catAncestor = cm[1];
     if (n.type === "TEXT") {
       const tf = Array.isArray(n.fills) && n.fills[0] && n.fills[0].type === "SOLID" && n.fills[0].visible !== false
         ? "#" + [n.fills[0].color.r, n.fills[0].color.g, n.fills[0].color.b].map((x) => Math.round(x * 255).toString(16).padStart(2, "0")).join("")
@@ -257,7 +265,7 @@ const checkFrame = async (frameId) => {
       // country split across the antimeridian has a box spanning almost the whole map, so an annotation
       // over open ocean falls inside it. Counting those as covered marks reports a FAIL that is not
       // there, so the annotation row drops them and says so rather than judging them by bbox.
-      if (filled && mb0 && mb0.w > 0 && mb0.h > 0) markBoxes.push({ name: n.name, box: mb0, why: "a filled data mark", insidePlot, fromMap: !!insideMap, hex: hexOf(markPaint) });
+      if (filled && mb0 && mb0.w > 0 && mb0.h > 0) markBoxes.push({ name: n.name, box: mb0, why: "a filled data mark", insidePlot, fromMap: !!insideMap, hex: hexOf(markPaint), cat: catAncestor || null });
     }
     if (/^datapoints__|^dot__|^value__/.test(n.name)) {
       const why = /^value__/.test(n.name) ? "a value label" : "a dot";
@@ -274,13 +282,13 @@ const checkFrame = async (frameId) => {
     // the fixture models), so a bare node here loses it and the name-only filter below matches nothing —
     // every slope segment silently absent from `polylines`, and annotation-overlap unable to fail.
     if (n.type === "VECTOR" && insidePlot) vectors.push({ node: n, seriesOf });
-    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap)); return; }
+    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor)); return; }
     const b = rel(n);
     if (b && b.w > 0 && b.h > 0) leaves.push({ name: n.name, type: n.type, box: b, insidePlot, fromMap: !!insideMap });
   };
   for (const child of frame.children) {
     if (child === logo) continue;
-    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false);
+    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null);
   }
 
   // ---------------------------------------------------------------- rows
@@ -1005,9 +1013,13 @@ const checkFrame = async (frameId) => {
     // data is the confident wrong answer these rows exist to prevent.
     // `outline__*` strokes are excluded along with it: that is the white halo grapher draws under a
     // line so crossings stay readable. Every series shares it, and it is not a category colour.
-    const catOf = (nm) => (/^[a-z][a-z-]*__(.+)$/i.exec(nm || "") || [])[1] || null;
+    // `cat` comes from the walk's nearest categorical ANCESTOR, not from the painted node's own name.
+    // grapher puts the stable name on the group and the paint on its leaves — a `datapoints__<Entity>`
+    // marker is a filled leaf called `Ellipse 12` — so reading it off `m.name` loses the category on
+    // exactly the shape the collector already goes out of its way to preserve, and the clash note below
+    // then cannot fire for those marks.
     const marks = markBoxes.filter((m) => m.insidePlot && m.hex)
-      .map((m) => ({ id: m.name, hex: m.hex, cat: m.fromMap ? null : catOf(m.name) }));
+      .map((m) => ({ id: m.name, hex: m.hex, cat: m.fromMap ? null : m.cat }));
     const seriesStrokes = stroked.filter((s) => s.insidePlot && !s.inFurniture && s.hex
                                                 && (s.seriesKind === "line" || s.seriesKind === "slope"))
       .map((s) => ({ id: s.seriesName, hex: s.hex, cat: s.seriesName }));
@@ -1046,11 +1058,18 @@ const checkFrame = async (frameId) => {
       : names.some((n) => n.includes("'")) ? "a name contains an apostrophe, which would break the quoted shell argument"
       : null;
     const namesSafe = !nameProblem;
+    // The mode flag also selects which PALETTE color_audit.py searches when the operator follows its
+    // "rerun with --suggest" instruction, so `--separated` is not interchangeable with the others.
+    // `--separated` only turns the seam gate off; `--line` turns it off AND installs the Line and Slope
+    // variants, the darker set meant for thin marks on white. A line or slope palette given plain
+    // `--separated` therefore gets fill colours recommended for strokes. All three imply "nothing
+    // shares an edge", which is why only the stacked/segmented case ever needs the flag dropped.
+    const mode = isMap ? "--maps" : seriesStrokes.length ? "--line" : "--separated";
     const cmd = hexes.length
       ? ".venv/bin/python .claude/skills/create-figma-chart/scripts/color_audit.py "
         + `'${hexes.join(",")}'`
         + (namesSafe ? ` --names '${names.join(",")}'` : "")
-        + (isMap ? " --maps" : " --separated")
+        + ` ${mode}`
       : null;
     // `--maps` swaps in the CATEGORICAL Maps palette, and the deltaE 20 all-pairs gate is a categorical
     // test. A SEQUENTIAL choropleth — Viridis, a ColorBrewer ramp — is ordered by construction and set
@@ -1062,9 +1081,13 @@ const checkFrame = async (frameId) => {
       + " If these fills are a SEQUENTIAL ramp, do not run it: the ramp is ordered and grapher sets it,"
       + " adjacent stops are meant to be close, so the deltaE 20 gate fails correct work and --suggest"
       + " would offer an unordered categorical palette in its place. Judge a ramp by lightness order.";
+    const lineNote = " — `--line` is `--separated` plus the Line and Slope Chart variants, the darker set"
+      + " meant for thin marks and text on white, so a --suggest rerun recommends stroke colours rather"
+      + " than fill colours. A line or slope chart has no seams, so nothing here needs reordering.";
     const how = cmd
       ? ` Run: ${cmd}`
-        + (isMap ? mapNote : " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
+        + (isMap ? mapNote : mode === "--line" ? lineNote
+            : " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
             + " and plain/grouped bars. On a STACKED or SEGMENTED chart drop it and reorder the"
             + " colours into stack order first, because the seam check reads adjacency off that order.")
         + ` Palette: ${hexes.length} distinct colour(s) drawn from ${paletteSrc.length} plot mark(s)/series.`

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -84,8 +84,14 @@ const hexOf = (f) => (f && f.type === "SOLID"
 // drift apart again. It is the same reasoning that already excludes zero-area nodes from the fill
 // inventory: a paint nobody can see is a phantom colour, and reporting one sends a reviewer to go and
 // fix a mark that is not on the canvas.
+// The test is ZERO, not a floor. A 0.01 cutoff was a threshold nobody chose: a paint at 0.005 does
+// reach the canvas, and dropping it took its node out of EVERY row — text-floor, overlap, margins —
+// with nothing anywhere saying so. Silently auditing a subset is the failure this file exists to
+// remove, and it does not become acceptable because the subset is faint. Anything positive is
+// TRANSLUCENT: held out of the palette, named, and still judged by every row that is about geometry
+// rather than colour.
 const renders = (p) => !!p && p.type === "SOLID" && p.visible !== false
-                       && (p.opacity === undefined || p.opacity > 0.01);
+                       && (p.opacity === undefined || p.opacity > 0);
 // PARTIAL opacity is a different problem from zero, and it is not solved by dropping the node: the mark
 // IS on the canvas, so it still has a box, still blocks an annotation, still needs its stroke weight
 // judged. What it does NOT have is a reportable COLOUR. `hexOf` returns the paint's raw RGB, and what
@@ -140,11 +146,10 @@ const checkFrame = async (frameId) => {
   // the frame is the last place they were handled as two. Whichever way it is off, every row below would
   // be a verdict about something no reader can see, so the frame is REPORTED as not rendered instead and
   // no other row is emitted. That is the honest shape: not "nothing failed", but "nothing was checked".
-  if (hiddenAncestors.length || frameOpacity <= 0.01) {
+  if (hiddenAncestors.length || frameOpacity <= 0) {
     const why = hiddenAncestors.length
       ? `switched off with visible=false on ${hiddenAncestors.join(", then ")}`
-      : `at effective opacity ${r(frameOpacity)}, counting every group and section above it`
-        + " (zero, or under the same 0.01 floor a paint is dropped at)";
+      : "at effective opacity ZERO, counting every group and section above it";
     add("frame-not-rendered", "FAIL",
         `NOT CHECKED — this frame paints no pixels: ${why}. Both switches are INHERITED, and the walk`
         + " below starts at the frame's children, so a descendant's own visible=true and opacity=1 say"
@@ -286,14 +291,19 @@ const checkFrame = async (frameId) => {
     // PARTIAL are two different answers and a boolean cannot tell them apart. Read as a boolean, a node
     // the reader cannot see at all came back as a held-back TRANSLUCENT mark: the audit named an
     // invisible category and told the operator to reset its opacity or judge it by eye — a verdict
-    // about something that is not on the canvas. Two nested nodes at 0.05 compound to 0.0025, so the
-    // product is also the only way to see that pair as invisible rather than merely dim.
+    // about something that is not on the canvas. The product is also what sees a group at 0 holding an
+    // opaque leaf, which no single-node test can.
     if ("opacity" in n && typeof n.opacity === "number") nodeOpacity *= n.opacity;
-    // Effective opacity zero paints NO PIXELS. That is the same non-rendering state as `visible: false`
+    // Effective opacity ZERO paints NO PIXELS. That is the same non-rendering state as `visible: false`
     // directly above and as a zero-opacity paint under `renders`, so it takes the same treatment both of
     // those take — out of every row entirely — rather than being grouped with genuinely visible partial
-    // opacity. Same 0.01 floor `renders` applies to a paint, applied here to the node instead.
-    if (nodeOpacity <= 0.01) return;
+    // opacity. The test is exactly zero, and the multiplication is what reaches it: a factor of 0
+    // anywhere on the climb zeroes the product exactly. It is NOT a floor. A near-zero node — 0.05
+    // inside 0.05 — is faint, not absent, and dropping it here took it out of every row in the file,
+    // including the ones that never look at colour: an 8px label at 0.005 left `text-floor` reporting
+    // that all of its ranges cleared the floor. A subset audited as a whole is the defect this script
+    // exists to catch, so faintness is reported through the translucent path instead, which names it.
+    if (nodeOpacity <= 0) return;
     const dimmed = nodeOpacity < 0.999;
     // The furniture CONTAINER name is carried, not just the boolean: the dash target is decided by what
     // a node IS (a gridline vs a zero line vs a tick), and deciding it from the node's own current dash
@@ -995,7 +1005,7 @@ const checkFrame = async (frameId) => {
         // whose knockout paints nothing passed the weight, alignment and colour checks — the row
         // certified the missing knockout it exists to catch. And the colour check read `strokes[0]`
         // unconditionally, which is the wrong paint the moment an invisible one sits in front of it.
-        const paint = (n.strokes || []).find((s) => s && s.visible !== false && (s.opacity === undefined || s.opacity > 0.01));
+        const paint = (n.strokes || []).find((s) => s && s.visible !== false && (s.opacity === undefined || s.opacity > 0));
         const hasStroke = !!paint && n.strokeWeight > 0;
         const crosses = crossings[a.name] || [];
         if (crosses.length && !hasStroke) {

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -1075,10 +1075,13 @@ const checkFrame = async (frameId) => {
     // whole one, which is the failure this row exists to avoid.
     const dimMarks = markSrc.filter((m) => m.translucent);
     const dimStrokes = strokeSrc.filter((s) => s.translucent);
+    // `fromMap` and `stroke` travel with the entry because they decide WHICH PALETTE the audit searches,
+    // and that is a property of the mark, not of the frame it sits in.
     const marks = markSrc.filter((m) => !m.translucent)
-      .map((m) => ({ id: (m.fromMap ? null : m.cat) || m.name, hex: m.hex, cat: m.fromMap ? null : m.cat }));
+      .map((m) => ({ id: (m.fromMap ? null : m.cat) || m.name, hex: m.hex, cat: m.fromMap ? null : m.cat,
+                     fromMap: !!m.fromMap, stroke: false }));
     const seriesStrokes = strokeSrc.filter((s) => !s.translucent)
-      .map((s) => ({ id: s.seriesName, hex: s.hex, cat: s.seriesName }));
+      .map((s) => ({ id: s.seriesName, hex: s.hex, cat: s.seriesName, fromMap: false, stroke: true }));
     const paletteSrc = [...marks, ...seriesStrokes];
     // The name is the category where there is one, so the note points at something the operator can
     // find on the canvas rather than at a count.
@@ -1092,53 +1095,6 @@ const checkFrame = async (frameId) => {
         + " wrong question. Reset the opacity to 1 (GUIDELINES.md does this for grapher's non-focused"
         + " series) and re-run, or judge those by eye."
       : "";
-    // Dedupe by COLOUR, because color_audit.py takes a PALETTE: hand it forty bar segments in six
-    // colours and every real finding competes with dozens of deltaE 0 self-pairs.
-    const seen = new Map();  // hex -> first mark/series name, in walk order
-    for (const p of paletteSrc) if (!seen.has(p.hex.toLowerCase())) seen.set(p.hex.toLowerCase(), p.id);
-    const hexes = [...seen.keys()];
-    // What that collapse HIDES is stated, not swallowed. Two categories on one colour is the severest
-    // collision there is — deltaE 0, indistinguishable to everyone — and the audit cannot report it,
-    // because to the audit they are one entry. So name them here instead.
-    // Not graded, and phrased as a question, because sharing a colour is often correct: a highlight
-    // treatment greys every unhighlighted series to the same value on purpose. Map shapes are left out
-    // of the note altogether — a choropleth puts every country in a bin into one colour by definition,
-    // so flagging that would fire on every map. Only grapher's `<kind>__<Entity>` names count as a
-    // category; an SVG import's `Rectangle 12` is unique per node and means nothing.
-    const catsByHex = new Map();
-    for (const p of paletteSrc) {
-      if (!p.cat) continue;
-      const h = p.hex.toLowerCase();
-      if (!catsByHex.has(h)) catsByHex.set(h, new Set());
-      catsByHex.get(h).add(p.cat);
-    }
-    const shared = [...catsByHex].filter(([, c]) => c.size > 1)
-      .map(([h, c]) => `${h} carries ${[...c].slice(0, 4).join(" + ")}`);
-    // A name carrying a comma would silently split into two --names entries and misalign every label
-    // after it; a name carrying an apostrophe would end the single-quoted shell argument mid-name, so
-    // "Women's employment" turns a paste-ready command into a shell syntax error. Both drop the flag
-    // wholesale rather than emitting it subtly wrong. State the ACTUAL reason: an unnamed mark, a
-    // comma'd one and an apostrophe'd one all disqualify the flag, and reporting one as another is the
-    // same wrong-verdict habit these checks exist to catch.
-    const names = [...seen.values()];
-    const nameProblem = names.some((n) => !n) ? "a mark has no name"
-      : names.some((n) => n.includes(",")) ? "a name contains a comma, which would misalign the labels"
-      : names.some((n) => n.includes("'")) ? "a name contains an apostrophe, which would break the quoted shell argument"
-      : null;
-    const namesSafe = !nameProblem;
-    // The mode flag also selects which PALETTE color_audit.py searches when the operator follows its
-    // "rerun with --suggest" instruction, so `--separated` is not interchangeable with the others.
-    // `--separated` only turns the seam gate off; `--line` turns it off AND installs the Line and Slope
-    // variants, the darker set meant for thin marks on white. A line or slope palette given plain
-    // `--separated` therefore gets fill colours recommended for strokes. All three imply "nothing
-    // shares an edge", which is why only the stacked/segmented case ever needs the flag dropped.
-    const mode = isMap ? "--maps" : seriesStrokes.length ? "--line" : "--separated";
-    const cmd = hexes.length
-      ? ".venv/bin/python .claude/skills/create-figma-chart/scripts/color_audit.py "
-        + `'${hexes.join(",")}'`
-        + (namesSafe ? ` --names '${names.join(",")}'` : "")
-        + ` ${mode}`
-      : null;
     // `--maps` swaps in the CATEGORICAL Maps palette, and the deltaE 20 all-pairs gate is a categorical
     // test. A SEQUENTIAL choropleth — Viridis, a ColorBrewer ramp — is ordered by construction and set
     // in grapher: its adjacent stops are MEANT to sit close together, so that gate fails a correct ramp,
@@ -1152,18 +1108,89 @@ const checkFrame = async (frameId) => {
     const lineNote = " — `--line` is `--separated` plus the Line and Slope Chart variants, the darker set"
       + " meant for thin marks and text on white, so a --suggest rerun recommends stroke colours rather"
       + " than fill colours. A line or slope chart has no seams, so nothing here needs reordering.";
-    const how = cmd
-      ? ` Run: ${cmd}`
-        + (isMap ? mapNote : mode === "--line" ? lineNote
-            : " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
-            + " and plain/grouped bars. On a STACKED or SEGMENTED chart drop it and reorder the"
-            + " colours into stack order first, because the seam check reads adjacency off that order.")
-        + ` Palette: ${hexes.length} distinct colour(s) drawn from ${paletteSrc.length} plot mark(s)/series.`
+    const separatedNote = " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
+      + " and plain/grouped bars. On a STACKED or SEGMENTED chart drop it and reorder the"
+      + " colours into stack order first, because the seam check reads adjacency off that order.";
+    // ONE RUN PER PALETTE FAMILY, not one per FRAME. A frame can hold both at once: combination.md's
+    // exemplar is a line chart with an inset locator map whose countries are filled with THE SAME
+    // COLOURS AS THEIR SERIES. `isMap` is a frame-level flag, so on that frame the map won and the line
+    // strokes were audited under `--maps` — whose "rerun with --suggest" answers out of the LIGHTER
+    // Categorical Maps set, recommending FILL colours for thin strokes. That is the exact swap `--line`
+    // exists to prevent, arrived at because one verdict was picked for a frame that holds two different
+    // things. The frame is one; the palettes are two, so each is deduped, named, flagged and emitted on
+    // its own, and neither is judged against the other's palette.
+    const mapPal = paletteSrc.filter((p) => p.fromMap);
+    const chartPal = paletteSrc.filter((p) => !p.fromMap);
+    const mixed = mapPal.length > 0 && chartPal.length > 0;
+    const paletteRun = (src) => {
+      // Dedupe by COLOUR, because color_audit.py takes a PALETTE: hand it forty bar segments in six
+      // colours and every real finding competes with dozens of deltaE 0 self-pairs.
+      const seen = new Map();  // hex -> first mark/series name, in walk order
+      for (const p of src) if (!seen.has(p.hex.toLowerCase())) seen.set(p.hex.toLowerCase(), p.id);
+      const hexes = [...seen.keys()];
+      if (!hexes.length) return "";
+      // What that collapse HIDES is stated, not swallowed. Two categories on one colour is the severest
+      // collision there is — deltaE 0, indistinguishable to everyone — and the audit cannot report it,
+      // because to the audit they are one entry. So name them here instead.
+      // Not graded, and phrased as a question, because sharing a colour is often correct: a highlight
+      // treatment greys every unhighlighted series to the same value on purpose. Map shapes are left out
+      // of the note altogether — a choropleth puts every country in a bin into one colour by definition,
+      // so flagging that would fire on every map. Only grapher's `<kind>__<Entity>` names count as a
+      // category; an SVG import's `Rectangle 12` is unique per node and means nothing.
+      const catsByHex = new Map();
+      for (const p of src) {
+        if (!p.cat) continue;
+        const h = p.hex.toLowerCase();
+        if (!catsByHex.has(h)) catsByHex.set(h, new Set());
+        catsByHex.get(h).add(p.cat);
+      }
+      const shared = [...catsByHex].filter(([, c]) => c.size > 1)
+        .map(([h, c]) => `${h} carries ${[...c].slice(0, 4).join(" + ")}`);
+      // A name carrying a comma would silently split into two --names entries and misalign every label
+      // after it; a name carrying an apostrophe would end the single-quoted shell argument mid-name, so
+      // "Women's employment" turns a paste-ready command into a shell syntax error. Both drop the flag
+      // wholesale rather than emitting it subtly wrong. State the ACTUAL reason: an unnamed mark, a
+      // comma'd one and an apostrophe'd one all disqualify the flag, and reporting one as another is the
+      // same wrong-verdict habit these checks exist to catch.
+      const names = [...seen.values()];
+      const nameProblem = names.some((n) => !n) ? "a mark has no name"
+        : names.some((n) => n.includes(",")) ? "a name contains a comma, which would misalign the labels"
+        : names.some((n) => n.includes("'")) ? "a name contains an apostrophe, which would break the quoted shell argument"
+        : null;
+      const namesSafe = !nameProblem;
+      // The mode flag also selects which PALETTE color_audit.py searches when the operator follows its
+      // "rerun with --suggest" instruction, so `--separated` is not interchangeable with the others.
+      // `--separated` only turns the seam gate off; `--line` turns it off AND installs the Line and Slope
+      // variants, the darker set meant for thin marks on white. A line or slope palette given plain
+      // `--separated` therefore gets fill colours recommended for strokes. All three imply "nothing
+      // shares an edge", which is why only the stacked/segmented case ever needs the flag dropped.
+      // Read off THIS palette's own marks, so a mixed frame cannot hand one family the other's flag.
+      const isMapPal = src.some((p) => p.fromMap);
+      const mode = isMapPal ? "--maps" : src.some((p) => p.stroke) ? "--line" : "--separated";
+      const cmd = ".venv/bin/python .claude/skills/create-figma-chart/scripts/color_audit.py "
+        + `'${hexes.join(",")}'`
+        + (namesSafe ? ` --names '${names.join(",")}'` : "")
+        + ` ${mode}`;
+      return (mixed ? (isMapPal ? " MAP shapes —" : " Chart marks and series —") : "")
+        + ` Run: ${cmd}`
+        + (isMapPal ? mapNote : mode === "--line" ? lineNote : separatedNote)
+        + ` Palette: ${hexes.length} distinct colour(s) drawn from ${src.length} plot mark(s)/series.`
         + (shared.length ? ` One colour, two categories — the audit sees these as ONE entry and cannot`
             + ` report the clash, so judge them by eye: ${shared.slice(0, 4).join("; ")}. Correct for a`
             + ` highlight treatment; a defect if they are separate categories.` : "")
-        + (namesSafe ? "" : ` (--names omitted: ${nameProblem}.)`)
-        + dimNote
+        + (namesSafe ? "" : ` (--names omitted: ${nameProblem}.)`);
+    };
+    // The overlap between the two is NOT a finding: combination.md fills the locator map's countries
+    // with their own series colours on purpose, so saying so here stops the split from reading as a
+    // clash the operator has to go and reconcile.
+    const mixedNote = mixed
+      ? " This frame holds BOTH a map and chart marks/series. They take DIFFERENT color_audit.py"
+        + " palettes — Categorical Maps against the Line and Slope variants — so they are audited as two"
+        + " separate runs rather than one, and a colour appearing in both is expected (combination.md"
+        + " fills an inset locator map's countries with their series colours)."
+      : "";
+    const how = paletteSrc.length
+      ? mixedNote + paletteRun(chartPal) + paletteRun(mapPal) + dimNote
       // An all-translucent plot must not report "no data marks found" — that reads as an empty frame
       // and sends the operator looking for missing nodes instead of at the opacity they set.
       : dimNote

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -213,9 +213,15 @@ const checkFrame = async (frameId) => {
     }
     if (/^annotation__/.test(n.name)) annotations.push({ node: n, name: n.name, box: rel(n), type: n.type });
     if ("strokeWeight" in n && typeof n.strokeWeight === "number" && n.strokes && n.strokes.length) {
+      // The stroke's COLOUR travels with it, picked the same way the knockout row picks one: the first
+      // paint that actually RENDERS, not `strokes[0]`, which can be a switched-off or transparent decoy.
+      // A line chart's series colour lives here and nowhere else — it is not a fill — so without this
+      // the colour rows can only ever see a chart's fills.
       stroked.push({ node: n, name: n.name, type: n.type, w: n.strokeWeight,
                      dash: "dashPattern" in n && n.dashPattern ? [...n.dashPattern] : [],
                      align: n.strokeAlign, insidePlot, inFurniture, furnitureGroup: furnitureGroup || null, insideMap: !!insideMap,
+                     hex: hexOf(n.strokes.find((s) => s && s.type === "SOLID" && s.visible !== false
+                                                      && (s.opacity === undefined || s.opacity > 0.01))),
                      seriesKind: seriesOf ? seriesOf.kind : null, seriesName: seriesOf ? seriesOf.series : null });
     }
     // Zero-area nodes are EXCLUDED from the fill inventory and KEPT for the stroke rows (CHECKS.md).
@@ -990,17 +996,54 @@ const checkFrame = async (frameId) => {
   // ready to paste instead of a tool name to go and look up. A declared gap the operator has to
   // reconstruct by hand is the one most likely to be skipped for real.
   {
-    const paletteSrc = fills.filter((f) => f.insidePlot && f.hex);
-    const seen = new Map();  // hex -> first node name, in walk order
-    for (const f of paletteSrc) if (!seen.has(f.hex.toLowerCase())) seen.set(f.hex.toLowerCase(), f.name);
+    // The palette is built from IDENTIFIED DATA MARKS AND SERIES STROKES, never from the `fills`
+    // inventory. `fills` holds every solid paint on an area node inside the plot and a TEXT node has
+    // both, so axis and legend labels would enter the palette as categories; meanwhile a line chart's
+    // series colours live on STROKES and are not in `fills` at all. Measured on this script's own test
+    // fixture, that inventory returned exactly one entry — the fill of `label__A`, a text node — with
+    // the series colour it should have audited missing entirely. Auditing furniture while omitting the
+    // data is the confident wrong answer these rows exist to prevent.
+    // `outline__*` strokes are excluded along with it: that is the white halo grapher draws under a
+    // line so crossings stay readable. Every series shares it, and it is not a category colour.
+    const catOf = (nm) => (/^[a-z][a-z-]*__(.+)$/i.exec(nm || "") || [])[1] || null;
+    const marks = markBoxes.filter((m) => m.insidePlot && m.hex)
+      .map((m) => ({ id: m.name, hex: m.hex, cat: m.fromMap ? null : catOf(m.name) }));
+    const seriesStrokes = stroked.filter((s) => s.insidePlot && !s.inFurniture && s.hex
+                                                && (s.seriesKind === "line" || s.seriesKind === "slope"))
+      .map((s) => ({ id: s.seriesName, hex: s.hex, cat: s.seriesName }));
+    const paletteSrc = [...marks, ...seriesStrokes];
+    // Dedupe by COLOUR, because color_audit.py takes a PALETTE: hand it forty bar segments in six
+    // colours and every real finding competes with dozens of deltaE 0 self-pairs.
+    const seen = new Map();  // hex -> first mark/series name, in walk order
+    for (const p of paletteSrc) if (!seen.has(p.hex.toLowerCase())) seen.set(p.hex.toLowerCase(), p.id);
     const hexes = [...seen.keys()];
-    // A name carrying a comma would silently split into two --names entries and misalign every
-    // label after it, so the flag is dropped wholesale rather than emitted subtly wrong. State the
-    // ACTUAL reason: an unnamed node and a comma'd one both disqualify the flag, and reporting one
-    // as the other is the same wrong-verdict habit these checks exist to catch.
+    // What that collapse HIDES is stated, not swallowed. Two categories on one colour is the severest
+    // collision there is — deltaE 0, indistinguishable to everyone — and the audit cannot report it,
+    // because to the audit they are one entry. So name them here instead.
+    // Not graded, and phrased as a question, because sharing a colour is often correct: a highlight
+    // treatment greys every unhighlighted series to the same value on purpose. Map shapes are left out
+    // of the note altogether — a choropleth puts every country in a bin into one colour by definition,
+    // so flagging that would fire on every map. Only grapher's `<kind>__<Entity>` names count as a
+    // category; an SVG import's `Rectangle 12` is unique per node and means nothing.
+    const catsByHex = new Map();
+    for (const p of paletteSrc) {
+      if (!p.cat) continue;
+      const h = p.hex.toLowerCase();
+      if (!catsByHex.has(h)) catsByHex.set(h, new Set());
+      catsByHex.get(h).add(p.cat);
+    }
+    const shared = [...catsByHex].filter(([, c]) => c.size > 1)
+      .map(([h, c]) => `${h} carries ${[...c].slice(0, 4).join(" + ")}`);
+    // A name carrying a comma would silently split into two --names entries and misalign every label
+    // after it; a name carrying an apostrophe would end the single-quoted shell argument mid-name, so
+    // "Women's employment" turns a paste-ready command into a shell syntax error. Both drop the flag
+    // wholesale rather than emitting it subtly wrong. State the ACTUAL reason: an unnamed mark, a
+    // comma'd one and an apostrophe'd one all disqualify the flag, and reporting one as another is the
+    // same wrong-verdict habit these checks exist to catch.
     const names = [...seen.values()];
-    const nameProblem = names.some((n) => !n) ? "a fill node has no name"
-      : names.some((n) => n.includes(",")) ? "a node name contains a comma, which would misalign the labels"
+    const nameProblem = names.some((n) => !n) ? "a mark has no name"
+      : names.some((n) => n.includes(",")) ? "a name contains a comma, which would misalign the labels"
+      : names.some((n) => n.includes("'")) ? "a name contains an apostrophe, which would break the quoted shell argument"
       : null;
     const namesSafe = !nameProblem;
     const cmd = hexes.length
@@ -1009,13 +1052,27 @@ const checkFrame = async (frameId) => {
         + (namesSafe ? ` --names '${names.join(",")}'` : "")
         + (isMap ? " --maps" : " --separated")
       : null;
+    // `--maps` swaps in the CATEGORICAL Maps palette, and the deltaE 20 all-pairs gate is a categorical
+    // test. A SEQUENTIAL choropleth — Viridis, a ColorBrewer ramp — is ordered by construction and set
+    // in grapher: its adjacent stops are MEANT to sit close together, so that gate fails a correct ramp,
+    // and the script's own "rerun with --suggest" would then answer with an unordered categorical set.
+    // Nothing here can tell a ramp from a categorical choropleth off the fills alone, so it is not
+    // guessed: the map branch says which chart the command is for and which chart it does not apply to.
+    const mapNote = " — this frame is a MAP, and this row covers a CATEGORICAL choropleth ONLY."
+      + " If these fills are a SEQUENTIAL ramp, do not run it: the ramp is ordered and grapher sets it,"
+      + " adjacent stops are meant to be close, so the deltaE 20 gate fails correct work and --suggest"
+      + " would offer an unordered categorical palette in its place. Judge a ramp by lightness order.";
     const how = cmd
       ? ` Run: ${cmd}`
-        + (isMap ? "" : " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
+        + (isMap ? mapNote : " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
             + " and plain/grouped bars. On a STACKED or SEGMENTED chart drop it and reorder the"
             + " colours into stack order first, because the seam check reads adjacency off that order.")
+        + ` Palette: ${hexes.length} distinct colour(s) drawn from ${paletteSrc.length} plot mark(s)/series.`
+        + (shared.length ? ` One colour, two categories — the audit sees these as ONE entry and cannot`
+            + ` report the clash, so judge them by eye: ${shared.slice(0, 4).join("; ")}. Correct for a`
+            + ` highlight treatment; a defect if they are separate categories.` : "")
         + (namesSafe ? "" : ` (--names omitted: ${nameProblem}.)`)
-      : " No solid plot fills found on this frame, so there is no palette to audit.";
+      : " No data marks or series strokes found in the plot, so there is no palette to audit.";
     skip("colour-vision", "all-pairs deltaE 20 for deuteranopia/protanopia on CATEGORICAL fills." + how, "scripts/color_audit.py");
     skip("grayscale-seams", "adjacent pairs above ~1.6:1 — same command, same run as colour-vision." + how, "scripts/color_audit.py");
   }

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -181,9 +181,12 @@ const checkFrame = async (frameId) => {
   // fell through to the ungrouped branch — which still walked the right node, but reported "the chart
   // group looks ungrouped" about a frame whose chart group is right there and correctly named.
   // A wrong explanation for a working result is how the next reader is sent to fix the wrong thing.
+  // Three variants counted on the live file, so match all three rather than the one this default
+  // was written for: `chart` (grapher import), `chart__<slug>` (a static_viz import), and
+  // `chart-desktop` / `chart-mobile` (a two-format page). Exact first, then a `__` or `-` suffix.
+  const chartSuffixed = (c) => c.name.startsWith(CONFIG.chartName + "__") || c.name.startsWith(CONFIG.chartName + "-");
   let chart = CONFIG.chartName
-    ? frame.children.find((c) => c.name === CONFIG.chartName)
-      || frame.children.find((c) => c.name.startsWith(CONFIG.chartName + "__"))
+    ? frame.children.find((c) => c.name === CONFIG.chartName) || frame.children.find(chartSuffixed)
     : null;
   let plotRoots = chart
     ? [chart]
@@ -191,7 +194,7 @@ const checkFrame = async (frameId) => {
   // NOT a nested template literal: `inline_script.py`'s stripper is not nesting-aware, so a backtick
   // inside a ${} closes the outer context, desynchronizes, and silently stops stripping comments for
   // the rest of the file. Caught by --check jumping 75% -> 96% of cap on a 1.8KB edit.
-  const chartSuffix = chart && chart.name !== CONFIG.chartName ? ' (matched "' + CONFIG.chartName + '__<slug>")' : "";
+  const chartSuffix = chart && chart.name !== CONFIG.chartName ? ' (matched "' + CONFIG.chartName + '__|-<suffix>")' : "";
   const chartResolvedBy = chart
     ? `name "${chart.name}"` + chartSuffix
     : plotRoots.length

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -111,8 +111,18 @@ const checkFrame = async (frameId) => {
   rows = [];
   const frame = await figma.getNodeByIdAsync(frameId);
   if (!frame) throw new Error(`frameId ${frameId} not found`);
+  // The FRAME is the one ancestor EVERY mark shares, and it sits ABOVE the walk below — which was
+  // seeded with a literal 1, so the frame was the only node whose opacity was never examined. A frame
+  // left at reduced opacity (or the section holding it) dims every mark on the canvas while the colour
+  // rows go on reporting raw paints: the same wrong-verdict-about-what-is-not-there this file guards
+  // against everywhere else, reached by the one path that skipped the guard. Accumulated on the climb
+  // that already runs to find the PAGE, so it picks up section and group ancestors too.
+  let frameOpacity = 1;
   let page = frame;
-  while (page && page.type !== "PAGE") page = page.parent;
+  while (page && page.type !== "PAGE") {
+    if ("opacity" in page && typeof page.opacity === "number") frameOpacity *= page.opacity;
+    page = page.parent;
+  }
   if (page && figma.currentPage !== page) await figma.setCurrentPageAsync(page);
 
   const fb = frame.absoluteBoundingBox;
@@ -327,7 +337,7 @@ const checkFrame = async (frameId) => {
   };
   for (const child of frame.children) {
     if (child === logo) continue;
-    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, 1);
+    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, frameOpacity);
   }
 
   // ---------------------------------------------------------------- rows
@@ -1192,7 +1202,13 @@ const checkFrame = async (frameId) => {
     const how = paletteSrc.length
       ? mixedNote + paletteRun(chartPal) + paletteRun(mapPal) + dimNote
       // An all-translucent plot must not report "no data marks found" — that reads as an empty frame
-      // and sends the operator looking for missing nodes instead of at the opacity they set.
+      // and sends the operator looking for missing nodes instead of at the opacity they set. A frame at
+      // effective opacity zero is the same trap one level up: every node under it returned early, so
+      // the count is zero for a reason that has nothing to do with what is on the frame.
+      : frameOpacity <= 0.01
+        ? " The FRAME itself is at effective opacity 0, so nothing on it paints any pixels and there is"
+          + " no palette to read — this is not an empty frame. Reset the frame's opacity (and any"
+          + " section or group above it) to 1 and re-run."
       : dimNote
         ? ` No auditable palette:${dimNote}`
         : " No data marks or series strokes found in the plot, so there is no palette to audit.";

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -176,12 +176,24 @@ const checkFrame = async (frameId) => {
   // So: everything that is not the header, the footer, the logo or one of OUR annotations is plot
   // content. Annotations are excluded because they are ours rather than the chart's — they have their
   // own four rows, and counting their fills among the plot's invents off-palette entries.
-  let chart = CONFIG.chartName ? frame.children.find((c) => c.name === CONFIG.chartName) : null;
+  // Exact name first, then `<chartName>__<slug>`. Measured on the real file: a `static_viz` import
+  // lands as `chart__agriculture-share`, so an exact-only match resolved NOTHING on those pages and
+  // fell through to the ungrouped branch — which still walked the right node, but reported "the chart
+  // group looks ungrouped" about a frame whose chart group is right there and correctly named.
+  // A wrong explanation for a working result is how the next reader is sent to fix the wrong thing.
+  let chart = CONFIG.chartName
+    ? frame.children.find((c) => c.name === CONFIG.chartName)
+      || frame.children.find((c) => c.name.startsWith(CONFIG.chartName + "__"))
+    : null;
   let plotRoots = chart
     ? [chart]
     : frame.children.filter((c) => c !== header && c !== footer && c !== logo && !/^annotation__/.test(c.name));
+  // NOT a nested template literal: `inline_script.py`'s stripper is not nesting-aware, so a backtick
+  // inside a ${} closes the outer context, desynchronizes, and silently stops stripping comments for
+  // the rest of the file. Caught by --check jumping 75% -> 96% of cap on a 1.8KB edit.
+  const chartSuffix = chart && chart.name !== CONFIG.chartName ? ' (matched "' + CONFIG.chartName + '__<slug>")' : "";
   const chartResolvedBy = chart
-    ? `name "${CONFIG.chartName}"`
+    ? `name "${chart.name}"` + chartSuffix
     : plotRoots.length
       ? `${plotRoots.length} ungrouped frame child(ren) — the chart group looks ungrouped: ${plotRoots.map((c) => c.name).join(", ")}`
       : "NOT RESOLVED — no frame child left after the header, footer, logo and annotations";
@@ -1163,9 +1175,20 @@ const checkFrame = async (frameId) => {
       // comma'd one and an apostrophe'd one all disqualify the flag, and reporting one as another is the
       // same wrong-verdict habit these checks exist to catch.
       const names = [...seen.values()];
+      // A name that is not DISTINCT across the palette is the worst of the lot, because it looks
+      // right. Measured on the real file: a `static_viz` import names every bar group `bars__<slug>`
+      // — the dataset, not the category — and every paint-bearing leaf `Vector`, so four genuinely
+      // different colours came out labelled `agriculture-share,agriculture-share,...`. The audit
+      // would then print four rows under one name and the operator would read a per-category verdict
+      // off labels that name no category. Distinctness is the property `--names` actually promises.
+      const genericName = /^(vector|rectangle|ellipse|group|frame|line|path|polygon|union|subtract)\b/i;
       const nameProblem = names.some((n) => !n) ? "a mark has no name"
         : names.some((n) => n.includes(",")) ? "a name contains a comma, which would misalign the labels"
         : names.some((n) => n.includes("'")) ? "a name contains an apostrophe, which would break the quoted shell argument"
+        : new Set(names).size !== names.length
+          ? `${names.length} colours share only ${new Set(names).size} distinct name(s) (${[...new Set(names)].slice(0, 3).join(", ")}) — the names identify the series or the import, not the category`
+        : names.some((n) => genericName.test(n))
+          ? `a name is an import default (${names.find((n) => genericName.test(n))}), which labels nothing`
         : null;
       const namesSafe = !nameProblem;
       // The mode flag also selects which PALETTE color_audit.py searches when the operator follows its

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -211,13 +211,22 @@ const checkFrame = async (frameId) => {
   // far larger than the 12-16px band rule by construction.
   const MAP_GROUPS = /^(map|countries|countries-without-data)$/i;
   let isMap = false;
-  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, dimmed) => {
+  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, nodeOpacity) => {
     if ("visible" in n && !n.visible) return;
     // NODE opacity dims every paint under it, and it ACCUMULATES down the tree — a group at 0.5 holding
-    // a leaf at 0.5 renders the leaf at 0.25. Carried as a boolean rather than a product because the
-    // only question asked of it is "is this colour still reportable", and once anything above has
-    // dimmed the node the answer is no whatever the exact factor.
-    if ("opacity" in n && typeof n.opacity === "number" && n.opacity < 0.999) dimmed = true;
+    // a leaf at 0.5 renders the leaf at 0.25. Carried as the PRODUCT, not a boolean, because ZERO and
+    // PARTIAL are two different answers and a boolean cannot tell them apart. Read as a boolean, a node
+    // the reader cannot see at all came back as a held-back TRANSLUCENT mark: the audit named an
+    // invisible category and told the operator to reset its opacity or judge it by eye — a verdict
+    // about something that is not on the canvas. Two nested nodes at 0.05 compound to 0.0025, so the
+    // product is also the only way to see that pair as invisible rather than merely dim.
+    if ("opacity" in n && typeof n.opacity === "number") nodeOpacity *= n.opacity;
+    // Effective opacity zero paints NO PIXELS. That is the same non-rendering state as `visible: false`
+    // directly above and as a zero-opacity paint under `renders`, so it takes the same treatment both of
+    // those take — out of every row entirely — rather than being grouped with genuinely visible partial
+    // opacity. Same 0.01 floor `renders` applies to a paint, applied here to the node instead.
+    if (nodeOpacity <= 0.01) return;
+    const dimmed = nodeOpacity < 0.999;
     // The furniture CONTAINER name is carried, not just the boolean: the dash target is decided by what
     // a node IS (a gridline vs a zero line vs a tick), and deciding it from the node's own current dash
     // instead makes a cleared gridline dash self-justifying. See the furniture-dash row.
@@ -312,13 +321,13 @@ const checkFrame = async (frameId) => {
     // the fixture models), so a bare node here loses it and the name-only filter below matches nothing —
     // every slope segment silently absent from `polylines`, and annotation-overlap unable to fail.
     if (n.type === "VECTOR" && insidePlot) vectors.push({ node: n, seriesOf });
-    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, dimmed)); return; }
+    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, nodeOpacity)); return; }
     const b = rel(n);
     if (b && b.w > 0 && b.h > 0) leaves.push({ name: n.name, type: n.type, box: b, insidePlot, fromMap: !!insideMap });
   };
   for (const child of frame.children) {
     if (child === logo) continue;
-    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, false);
+    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, 1);
   }
 
   // ---------------------------------------------------------------- rows

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -86,6 +86,20 @@ const hexOf = (f) => (f && f.type === "SOLID"
 // fix a mark that is not on the canvas.
 const renders = (p) => !!p && p.type === "SOLID" && p.visible !== false
                        && (p.opacity === undefined || p.opacity > 0.01);
+// PARTIAL opacity is a different problem from zero, and it is not solved by dropping the node: the mark
+// IS on the canvas, so it still has a box, still blocks an annotation, still needs its stroke weight
+// judged. What it does NOT have is a reportable COLOUR. `hexOf` returns the paint's raw RGB, and what
+// the reader sees is that RGB composited onto whatever is behind it — LABELING.md works the same sum
+// the other way round and measures the gap as `#ecebe8` against `#fbf9f3`, "close enough to look
+// deliberate and wrong enough to see". Auditing the raw value asks color_audit.py about a colour that
+// is not on the page: its deltaE and grayscale verdicts, and any `--suggest` replacement, are then all
+// answers to the wrong question. This is not hypothetical — grapher exports non-focused series at
+// `stroke-opacity="0.5"` (GUIDELINES.md) and this skill's own period band is a fill at 50%.
+// Compositing it here is the tempting fix and is refused: it needs what is DIRECTLY behind the mark,
+// which for a mark inside a plot is usually another mark rather than the frame, plus every ancestor's
+// opacity. Guessing the frame would just relocate the confident wrong answer. So a translucent paint
+// is declared UNMEASURABLE and named, the same way a sequential ramp and an unsafe `--names` are.
+const translucent = (p) => !!p && typeof p.opacity === "number" && p.opacity < 0.999;
 let rows = [];
 const add = (name, status, detail, extra) => rows.push({ check: name, status, detail, ...(extra || {}) });
 const skip = (name, why, owner) => add(name, "SKIPPED", why, owner ? { ownedBy: owner } : null);
@@ -197,8 +211,13 @@ const checkFrame = async (frameId) => {
   // far larger than the 12-16px band rule by construction.
   const MAP_GROUPS = /^(map|countries|countries-without-data)$/i;
   let isMap = false;
-  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor) => {
+  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, dimmed) => {
     if ("visible" in n && !n.visible) return;
+    // NODE opacity dims every paint under it, and it ACCUMULATES down the tree — a group at 0.5 holding
+    // a leaf at 0.5 renders the leaf at 0.25. Carried as a boolean rather than a product because the
+    // only question asked of it is "is this colour still reportable", and once anything above has
+    // dimmed the node the answer is no whatever the exact factor.
+    if ("opacity" in n && typeof n.opacity === "number" && n.opacity < 0.999) dimmed = true;
     // The furniture CONTAINER name is carried, not just the boolean: the dash target is decided by what
     // a node IS (a gridline vs a zero line vs a tick), and deciding it from the node's own current dash
     // instead makes a cleared gridline dash self-justifying. See the furniture-dash row.
@@ -210,6 +229,7 @@ const checkFrame = async (frameId) => {
     if (cm) catAncestor = cm[1];
     if (n.type === "TEXT") {
       const tf = Array.isArray(n.fills) && renders(n.fills[0]) ? hexOf(n.fills[0]) : null;
+      const tfDim = dimmed || translucent(Array.isArray(n.fills) ? n.fills[0] : null);
       // The WEIGHTS, not just whether they differ: a uniformly non-Regular node is style-unbindable
       // for the same API reason a mixed-weight one is, and named-styles has to know the difference
       // between "bold throughout" (prescribed) and "Regular and unbound" (a defect).
@@ -225,7 +245,7 @@ const checkFrame = async (frameId) => {
       for (const sr of ranges) {
         texts.push({ node: n, name: n.name, chars: (n.characters || "").slice(0, 30), size: sr.size,
                      sizeRange: sr.range, mixedSize: ranges.length > 1,
-                     styleId: n.textStyleId || "", box: rel(n), insidePlot, fill: tf, mixedWeight, weights });
+                     styleId: n.textStyleId || "", box: rel(n), insidePlot, fill: tf, translucent: tfDim, mixedWeight, weights });
       }
     }
     if (/^annotation__/.test(n.name)) annotations.push({ node: n, name: n.name, box: rel(n), type: n.type });
@@ -234,10 +254,11 @@ const checkFrame = async (frameId) => {
       // paint that actually RENDERS, not `strokes[0]`, which can be a switched-off or transparent decoy.
       // A line chart's series colour lives here and nowhere else — it is not a fill — so without this
       // the colour rows can only ever see a chart's fills.
+      const strokePaint = n.strokes.find(renders);
       stroked.push({ node: n, name: n.name, type: n.type, w: n.strokeWeight,
                      dash: "dashPattern" in n && n.dashPattern ? [...n.dashPattern] : [],
                      align: n.strokeAlign, insidePlot, inFurniture, furnitureGroup: furnitureGroup || null, insideMap: !!insideMap,
-                     hex: hexOf(n.strokes.find(renders)),
+                     hex: hexOf(strokePaint), translucent: dimmed || translucent(strokePaint),
                      seriesKind: seriesOf ? seriesOf.kind : null, seriesName: seriesOf ? seriesOf.series : null });
     }
     // Zero-area nodes are EXCLUDED from the fill inventory and KEPT for the stroke rows (CHECKS.md).
@@ -273,7 +294,8 @@ const checkFrame = async (frameId) => {
       // country split across the antimeridian has a box spanning almost the whole map, so an annotation
       // over open ocean falls inside it. Counting those as covered marks reports a FAIL that is not
       // there, so the annotation row drops them and says so rather than judging them by bbox.
-      if (filled && mb0 && mb0.w > 0 && mb0.h > 0) markBoxes.push({ name: n.name, box: mb0, why: "a filled data mark", insidePlot, fromMap: !!insideMap, hex: hexOf(markPaint), cat: catAncestor || null });
+      if (filled && mb0 && mb0.w > 0 && mb0.h > 0) markBoxes.push({ name: n.name, box: mb0, why: "a filled data mark", insidePlot, fromMap: !!insideMap, hex: hexOf(markPaint),
+                                      translucent: dimmed || translucent(markPaint), cat: catAncestor || null });
     }
     if (/^datapoints__|^dot__|^value__/.test(n.name)) {
       const why = /^value__/.test(n.name) ? "a value label" : "a dot";
@@ -290,13 +312,13 @@ const checkFrame = async (frameId) => {
     // the fixture models), so a bare node here loses it and the name-only filter below matches nothing —
     // every slope segment silently absent from `polylines`, and annotation-overlap unable to fail.
     if (n.type === "VECTOR" && insidePlot) vectors.push({ node: n, seriesOf });
-    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor)); return; }
+    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, dimmed)); return; }
     const b = rel(n);
     if (b && b.w > 0 && b.h > 0) leaves.push({ name: n.name, type: n.type, box: b, insidePlot, fromMap: !!insideMap });
   };
   for (const child of frame.children) {
     if (child === logo) continue;
-    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null);
+    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, false);
   }
 
   // ---------------------------------------------------------------- rows
@@ -979,8 +1001,13 @@ const checkFrame = async (frameId) => {
     const overlaps = (a, b) => a.l < b.rr && a.rr > b.l && a.t < b.bb && a.bb > b.t;
     const mapShapes = markBoxes.filter((x) => x.insidePlot && x.fromMap && x.hex);
     const marksUnder = (t) => (t.box ? mapShapes.filter((m) => overlaps(t.box, m.box)) : []);
+    // A THIRD way in: a translucent label. Its `fill` is the raw paint, but what the reader sees is that
+    // colour composited onto the background, which is always LOWER contrast than the raw value — so
+    // measuring the raw one passes text that is genuinely too faint, the one direction this row must
+    // not fail in. The ratio is not computable here for the same reason the palette will not audit it,
+    // so it joins the by-eye bucket rather than being scored or dropped.
     const ambiguous = candidates.filter((t) =>
-      (frameFill && t.fill.toLowerCase() === frameFill.toLowerCase()) || marksUnder(t).length);
+      (frameFill && t.fill.toLowerCase() === frameFill.toLowerCase()) || marksUnder(t).length || t.translucent);
     const onBg = candidates.filter((t) => ambiguous.indexOf(t) === -1);
     // Named per label, with the arithmetic where it exists: against a map shape's own fill the ratio IS
     // computable, it is just not certain to be the fill behind the text.
@@ -988,6 +1015,7 @@ const checkFrame = async (frameId) => {
       const over = marksUnder(t);
       const worst = over.length ? over.reduce((a, m) => (contrast(t.fill, m.hex) < contrast(t.fill, a.hex) ? m : a)) : null;
       return `"${t.chars}" ${t.fill}` +
+             (t.translucent ? " — partly transparent, so the colour that reaches the reader is this one composited onto what is behind it and ALWAYS lower contrast than the raw value; reset the opacity to 1 to have it measured" : "") +
              (frameFill && t.fill.toLowerCase() === frameFill.toLowerCase() ? " — the frame's own colour, so either inside a darker mark (correct) or invisible text on the frame" : "") +
              (worst ? ` — overlaps ${over.length} map shape(s), worst ${worst.name} ${worst.hex} = ${r(contrast(t.fill, worst.hex))}:1` : "");
     };
@@ -1030,12 +1058,31 @@ const checkFrame = async (frameId) => {
     // need attention, and a marker's painted leaf is called `Ellipse 12`. Reporting a failing pair as
     // "Ellipse 12 vs Ellipse 12" identifies nothing. Fall back to the node's own name only when there
     // is no categorical ancestor. Map shapes keep their node names, which already carry the country.
-    const marks = markBoxes.filter((m) => m.insidePlot && m.hex)
+    const markSrc = markBoxes.filter((m) => m.insidePlot && m.hex);
+    const strokeSrc = stroked.filter((s) => s.insidePlot && !s.inFurniture && s.hex
+                                            && (s.seriesKind === "line" || s.seriesKind === "slope"));
+    // Translucent paints are held back rather than audited at their raw value (see `translucent`).
+    // COUNTED, though, and named below: a silently shorter palette is a subset audit reported as a
+    // whole one, which is the failure this row exists to avoid.
+    const dimMarks = markSrc.filter((m) => m.translucent);
+    const dimStrokes = strokeSrc.filter((s) => s.translucent);
+    const marks = markSrc.filter((m) => !m.translucent)
       .map((m) => ({ id: (m.fromMap ? null : m.cat) || m.name, hex: m.hex, cat: m.fromMap ? null : m.cat }));
-    const seriesStrokes = stroked.filter((s) => s.insidePlot && !s.inFurniture && s.hex
-                                                && (s.seriesKind === "line" || s.seriesKind === "slope"))
+    const seriesStrokes = strokeSrc.filter((s) => !s.translucent)
       .map((s) => ({ id: s.seriesName, hex: s.hex, cat: s.seriesName }));
     const paletteSrc = [...marks, ...seriesStrokes];
+    // The name is the category where there is one, so the note points at something the operator can
+    // find on the canvas rather than at a count.
+    const dimNames = [...new Set([...dimMarks.map((m) => (m.fromMap ? null : m.cat) || m.name),
+                                 ...dimStrokes.map((s) => s.seriesName)].filter(Boolean))];
+    const dimNote = dimMarks.length + dimStrokes.length
+      ? ` ${dimMarks.length + dimStrokes.length} translucent mark(s)/series are NOT in this palette`
+        + (dimNames.length ? ` (${dimNames.slice(0, 6).join(", ")})` : "")
+        + " — a partly transparent paint reads as its colour composited onto whatever is behind it, which"
+        + " this script cannot determine from inside the plot, so auditing its raw value would answer the"
+        + " wrong question. Reset the opacity to 1 (GUIDELINES.md does this for grapher's non-focused"
+        + " series) and re-run, or judge those by eye."
+      : "";
     // Dedupe by COLOUR, because color_audit.py takes a PALETTE: hand it forty bar segments in six
     // colours and every real finding competes with dozens of deltaE 0 self-pairs.
     const seen = new Map();  // hex -> first mark/series name, in walk order
@@ -1107,7 +1154,12 @@ const checkFrame = async (frameId) => {
             + ` report the clash, so judge them by eye: ${shared.slice(0, 4).join("; ")}. Correct for a`
             + ` highlight treatment; a defect if they are separate categories.` : "")
         + (namesSafe ? "" : ` (--names omitted: ${nameProblem}.)`)
-      : " No data marks or series strokes found in the plot, so there is no palette to audit.";
+        + dimNote
+      // An all-translucent plot must not report "no data marks found" — that reads as an empty frame
+      // and sends the operator looking for missing nodes instead of at the opacity they set.
+      : dimNote
+        ? ` No auditable palette:${dimNote}`
+        : " No data marks or series strokes found in the plot, so there is no palette to audit.";
     skip("colour-vision", "all-pairs deltaE 20 for deuteranopia/protanopia on CATEGORICAL fills." + how, "scripts/color_audit.py");
     skip("grayscale-seams", "adjacent pairs above ~1.6:1 — same command, same run as colour-vision." + how, "scripts/color_audit.py");
   }

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -1238,14 +1238,17 @@ const checkFrame = async (frameId) => {
       for (const p of src) if (!seen.has(p.hex.toLowerCase())) seen.set(p.hex.toLowerCase(), p.id);
       const hexes = [...seen.keys()];
       if (!hexes.length) return "";
-      // What that collapse HIDES is stated, not swallowed. Two categories on one colour is the severest
-      // collision there is — deltaE 0, indistinguishable to everyone — and the audit cannot report it,
-      // because to the audit they are one entry. So name them here instead.
-      // Not graded, and phrased as a question, because sharing a colour is often correct: a highlight
-      // treatment greys every unhighlighted series to the same value on purpose. Map shapes are left out
-      // of the note altogether — a choropleth puts every country in a bin into one colour by definition,
-      // so flagging that would fire on every map. Only grapher's `<kind>__<Entity>` names count as a
-      // category; an SVG import's `Rectangle 12` is unique per node and means nothing.
+      // BOTH rows compare PAIRS — the deltaE gate across all of them, the seam gate across adjacent
+      // ones — so a palette of one colour has nothing to compare. `color_audit.py` does not say so: it
+      // runs, prints an empty pair list and an overall minimum deltaE of `inf`, and exits 0, which
+      // reads exactly like a clean audit. GUIDELINES.md already rules on this case in as many words —
+      // "one categorical color against neutral grays has no pair to check, and reporting no failures
+      // from a two-color audit reads as coverage you don't have" — and names the two checks that ARE
+      // live instead. So the command is withheld and those two are handed over in its place. Emitting
+      // it would be this file's own failure mode: a runnable-looking gate that cannot fail.
+      // Computed BEFORE the single-colour exit below, not after it. Two categories painted the same
+      // colour ARE a one-colour palette, and that is the severest collision there is — so the one
+      // branch that withholds the command is the branch that most needs to say what it found.
       const catsByHex = new Map();
       for (const p of src) {
         if (!p.cat) continue;
@@ -1255,6 +1258,31 @@ const checkFrame = async (frameId) => {
       }
       const shared = [...catsByHex].filter(([, c]) => c.size > 1)
         .map(([h, c]) => `${h} carries ${[...c].slice(0, 4).join(" + ")}`);
+      const sharedNote = shared.length
+        ? ` One colour, two categories — the audit sees these as ONE entry and cannot report the clash,`
+          + ` so judge them by eye: ${shared.slice(0, 4).join("; ")}. Correct for a highlight treatment;`
+          + " a defect if they are separate categories."
+        : "";
+      const soleName = [...seen.values()][0];
+      if (hexes.length < 2) {
+        return (mixed ? (src.some((x) => x.fromMap) ? " MAP shapes —" : " Chart marks and series —") : "")
+          + ` NOTHING TO RUN: this palette holds ONE colour (${hexes[0]}${soleName ? ", " + soleName : ""})`
+          + ` drawn from ${src.length} plot mark(s)/series, and both rows compare PAIRS, so there is no`
+          + " categorical pair to check. color_audit.py would still run on it and exit 0, printing an"
+          + " overall minimum deltaE of `inf` from an empty pair list — a clean-looking verdict from a"
+          + " comparison that never happened. GUIDELINES.md says not to run it on a chart like this."
+          + " Check the two things that ARE live: this colour's contrast against the frame's background,"
+          + " and whether it still separates from the neutral grays in grayscale."
+          + sharedNote + dimNote + legendNote;
+      }
+      // What that collapse HIDES is stated above, not swallowed. Two categories on one colour is the
+      // severest collision there is — deltaE 0, indistinguishable to everyone — and the audit cannot
+      // report it, because to the audit they are one entry.
+      // Not graded, and phrased as a question, because sharing a colour is often correct: a highlight
+      // treatment greys every unhighlighted series to the same value on purpose. Map shapes are left out
+      // of the note altogether — a choropleth puts every country in a bin into one colour by definition,
+      // so flagging that would fire on every map. Only grapher's `<kind>__<Entity>` names count as a
+      // category; an SVG import's `Rectangle 12` is unique per node and means nothing.
       // A name carrying a comma would silently split into two --names entries and misalign every label
       // after it; a name carrying an apostrophe would end the single-quoted shell argument mid-name, so
       // "Women's employment" turns a paste-ready command into a shell syntax error. Both drop the flag
@@ -1291,13 +1319,24 @@ const checkFrame = async (frameId) => {
         + `'${hexes.join(",")}'`
         + (namesSafe ? ` --names '${names.join(",")}'` : "")
         + ` ${mode}`;
+      // The other case GUIDELINES.md rules on: one highlight against neutral grays. Those grays are
+      // FURNITURE, not categories, so a palette that is one real colour plus muting grays is the
+      // single-colour case wearing a larger count — and "no failures" out of it is coverage nobody has.
+      // Not suppressed, because which entries are muting grays is a judgement this script cannot make
+      // (a category legitimately painted gray is a category), and a check silently withheld is worse
+      // than one a human is told to weigh. Fires only when the treatment is DECLARED.
+      const highlightNote = CONFIG.highlightTreatment
+        ? " CONFIG.highlightTreatment is set: if this palette is one highlight plus muting grays, do NOT"
+          + " run it — GUIDELINES.md rules that out, because the grays are furniture and leave no"
+          + " categorical pair. Check the highlight's contrast against the background and its grayscale"
+          + " separation from the grays instead. Run it only for the pairs that are real categories."
+        : "";
       return (mixed ? (isMapPal ? " MAP shapes —" : " Chart marks and series —") : "")
+        + highlightNote
         + ` Run: ${cmd}`
         + (isMapPal ? mapNote : mode === "--line" ? lineNote : separatedNote)
         + ` Palette: ${hexes.length} distinct colour(s) drawn from ${src.length} plot mark(s)/series.`
-        + (shared.length ? ` One colour, two categories — the audit sees these as ONE entry and cannot`
-            + ` report the clash, so judge them by eye: ${shared.slice(0, 4).join("; ")}. Correct for a`
-            + ` highlight treatment; a defect if they are separate categories.` : "")
+        + sharedNote
         + (namesSafe ? "" : ` (--names omitted: ${nameProblem}.)`);
     };
     // The overlap between the two is NOT a finding: combination.md fills the locator map's countries

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -1000,7 +1000,7 @@ const checkFrame = async (frameId) => {
   // ---------------------------------------------------------------- declared gaps in coverage
 // #endregion
   // These two are owned by color_audit.py, which cannot run in here — this is a Figma plugin
-  // sandbox with no shell. But the palette it needs is already in `fills`, so emit the command
+  // sandbox with no shell. But the palette it needs is already on the canvas, so emit the command
   // ready to paste instead of a tool name to go and look up. A declared gap the operator has to
   // reconstruct by hand is the one most likely to be skipped for real.
   {
@@ -1018,8 +1018,12 @@ const checkFrame = async (frameId) => {
     // marker is a filled leaf called `Ellipse 12` — so reading it off `m.name` loses the category on
     // exactly the shape the collector already goes out of its way to preserve, and the clash note below
     // then cannot fire for those marks.
+    // The category is also the LABEL: `--names` exists so the audit's findings name the categories that
+    // need attention, and a marker's painted leaf is called `Ellipse 12`. Reporting a failing pair as
+    // "Ellipse 12 vs Ellipse 12" identifies nothing. Fall back to the node's own name only when there
+    // is no categorical ancestor. Map shapes keep their node names, which already carry the country.
     const marks = markBoxes.filter((m) => m.insidePlot && m.hex)
-      .map((m) => ({ id: m.name, hex: m.hex, cat: m.fromMap ? null : m.cat }));
+      .map((m) => ({ id: (m.fromMap ? null : m.cat) || m.name, hex: m.hex, cat: m.fromMap ? null : m.cat }));
     const seriesStrokes = stroked.filter((s) => s.insidePlot && !s.inFurniture && s.hex
                                                 && (s.seriesKind === "line" || s.seriesKind === "slope"))
       .map((s) => ({ id: s.seriesName, hex: s.hex, cat: s.seriesName }));

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -75,6 +75,17 @@ const contrast = (a, b) => { const la = lum(a), lb = lum(b); return (Math.max(la
 const hexOf = (f) => (f && f.type === "SOLID"
   ? "#" + [f.color.r, f.color.g, f.color.b].map((x) => Math.round(x * 255).toString(16).padStart(2, "0")).join("")
   : null);
+// A paint that PAINTS NO PIXELS is not a colour this file may report. Figma switches a paint off two
+// independent ways — `visible: false` and `opacity: 0` — and only the first of those was tested at the
+// sites that pick a FILL, so a fully transparent decoy could still supply a mark's colour. That mark
+// then entered the colour-audit palette as a category nobody can see (and could be recommended a
+// replacement for), and stood in as the backdrop a label's contrast was measured against. The stroke
+// collector already applied both tests; this is that same predicate, named once so the sites cannot
+// drift apart again. It is the same reasoning that already excludes zero-area nodes from the fill
+// inventory: a paint nobody can see is a phantom colour, and reporting one sends a reviewer to go and
+// fix a mark that is not on the canvas.
+const renders = (p) => !!p && p.type === "SOLID" && p.visible !== false
+                       && (p.opacity === undefined || p.opacity > 0.01);
 let rows = [];
 const add = (name, status, detail, extra) => rows.push({ check: name, status, detail, ...(extra || {}) });
 const skip = (name, why, owner) => add(name, "SKIPPED", why, owner ? { ownedBy: owner } : null);
@@ -95,7 +106,7 @@ const checkFrame = async (frameId) => {
   const TEXT_FLOOR = CONFIG.textFloor !== null && CONFIG.textFloor !== undefined ? CONFIG.textFloor : (isSmall ? 11 : 12);
   const LADDER = isSmall ? [11, ...LADDER_FULL] : LADDER_FULL;
   const frameFill = (() => { const f = frame.fills && frame.fills[0];
-    if (!f || f.type !== "SOLID" || f.visible === false) return null;
+    if (!renders(f)) return null;
     return "#" + [f.color.r, f.color.g, f.color.b].map((x) => Math.round(x * 255).toString(16).padStart(2, "0")).join(""); })();
   const rel = (n) => {
     const b = n.absoluteBoundingBox;
@@ -198,9 +209,7 @@ const checkFrame = async (frameId) => {
     const cm = CATEGORY_ANY.exec(n.name);
     if (cm) catAncestor = cm[1];
     if (n.type === "TEXT") {
-      const tf = Array.isArray(n.fills) && n.fills[0] && n.fills[0].type === "SOLID" && n.fills[0].visible !== false
-        ? "#" + [n.fills[0].color.r, n.fills[0].color.g, n.fills[0].color.b].map((x) => Math.round(x * 255).toString(16).padStart(2, "0")).join("")
-        : null;
+      const tf = Array.isArray(n.fills) && renders(n.fills[0]) ? hexOf(n.fills[0]) : null;
       // The WEIGHTS, not just whether they differ: a uniformly non-Regular node is style-unbindable
       // for the same API reason a mixed-weight one is, and named-styles has to know the difference
       // between "bold throughout" (prescribed) and "Regular and unbound" (a defect).
@@ -228,8 +237,7 @@ const checkFrame = async (frameId) => {
       stroked.push({ node: n, name: n.name, type: n.type, w: n.strokeWeight,
                      dash: "dashPattern" in n && n.dashPattern ? [...n.dashPattern] : [],
                      align: n.strokeAlign, insidePlot, inFurniture, furnitureGroup: furnitureGroup || null, insideMap: !!insideMap,
-                     hex: hexOf(n.strokes.find((s) => s && s.type === "SOLID" && s.visible !== false
-                                                      && (s.opacity === undefined || s.opacity > 0.01))),
+                     hex: hexOf(n.strokes.find(renders)),
                      seriesKind: seriesOf ? seriesOf.kind : null, seriesName: seriesOf ? seriesOf.series : null });
     }
     // Zero-area nodes are EXCLUDED from the fill inventory and KEPT for the stroke rows (CHECKS.md).
@@ -240,7 +248,7 @@ const checkFrame = async (frameId) => {
     const hasArea = areaBox && areaBox.w > 0 && areaBox.h > 0;
     if (hasArea && "fills" in n && Array.isArray(n.fills)) {
       for (const f of n.fills) {
-        if (f.type === "SOLID" && f.visible !== false) fills.push({ name: n.name, type: n.type, hex: hexOf(f), styleId: n.fillStyleId || "", insidePlot });
+        if (renders(f)) fills.push({ name: n.name, type: n.type, hex: hexOf(f), styleId: n.fillStyleId || "", insidePlot });
       }
     }
     // Marker groups and value labels. The NAME is on the group and the GEOMETRY is on its children, and
@@ -259,7 +267,7 @@ const checkFrame = async (frameId) => {
       const mb0 = rel(n);
       // The mark's own COLOUR travels with its box. Without it, a label sitting on a mark can only ever be
       // measured against the frame, which is not what is behind it (see label-contrast-on-background).
-      const markPaint = Array.isArray(n.fills) ? n.fills.find((f) => f.type === "SOLID" && f.visible !== false) : null;
+      const markPaint = Array.isArray(n.fills) ? n.fills.find(renders) : null;
       const filled = !!markPaint;
       // `fromMap` is carried because a MAP SHAPE's bbox is not its ink: per-chart-type/maps.md, a
       // country split across the antimeridian has a box spanning almost the whole map, so an annotation

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -985,8 +985,40 @@ const checkFrame = async (frameId) => {
 
   // ---------------------------------------------------------------- declared gaps in coverage
 // #endregion
-  skip("colour-vision", "all-pairs deltaE 20 for deuteranopia/protanopia on CATEGORICAL fills", "scripts/color_audit.py");
-  skip("grayscale-seams", "adjacent pairs above ~1.6:1; needs --separated for non-stacked charts", "scripts/color_audit.py");
+  // These two are owned by color_audit.py, which cannot run in here — this is a Figma plugin
+  // sandbox with no shell. But the palette it needs is already in `fills`, so emit the command
+  // ready to paste instead of a tool name to go and look up. A declared gap the operator has to
+  // reconstruct by hand is the one most likely to be skipped for real.
+  {
+    const paletteSrc = fills.filter((f) => f.insidePlot && f.hex);
+    const seen = new Map();  // hex -> first node name, in walk order
+    for (const f of paletteSrc) if (!seen.has(f.hex.toLowerCase())) seen.set(f.hex.toLowerCase(), f.name);
+    const hexes = [...seen.keys()];
+    // A name carrying a comma would silently split into two --names entries and misalign every
+    // label after it, so the flag is dropped wholesale rather than emitted subtly wrong. State the
+    // ACTUAL reason: an unnamed node and a comma'd one both disqualify the flag, and reporting one
+    // as the other is the same wrong-verdict habit these checks exist to catch.
+    const names = [...seen.values()];
+    const nameProblem = names.some((n) => !n) ? "a fill node has no name"
+      : names.some((n) => n.includes(",")) ? "a node name contains a comma, which would misalign the labels"
+      : null;
+    const namesSafe = !nameProblem;
+    const cmd = hexes.length
+      ? ".venv/bin/python .claude/skills/create-figma-chart/scripts/color_audit.py "
+        + `'${hexes.join(",")}'`
+        + (namesSafe ? ` --names '${names.join(",")}'` : "")
+        + (isMap ? " --maps" : " --separated")
+      : null;
+    const how = cmd
+      ? ` Run: ${cmd}`
+        + (isMap ? "" : " — `--separated` assumes nothing shares an edge, which holds for lines, maps"
+            + " and plain/grouped bars. On a STACKED or SEGMENTED chart drop it and reorder the"
+            + " colours into stack order first, because the seam check reads adjacency off that order.")
+        + (namesSafe ? "" : ` (--names omitted: ${nameProblem}.)`)
+      : " No solid plot fills found on this frame, so there is no palette to audit.";
+    skip("colour-vision", "all-pairs deltaE 20 for deuteranopia/protanopia on CATEGORICAL fills." + how, "scripts/color_audit.py");
+    skip("grayscale-seams", "adjacent pairs above ~1.6:1 — same command, same run as colour-vision." + how, "scripts/color_audit.py");
+  }
   skip("spelling-and-prose", "American spelling, typos, style-guide breaches", ".venv/bin/codespell + /check-metadata-style");
   skip("text-true-of-indicator", "every claim in every string checked against the producer's documentation", "/adversarial-data-review");
   skip("entities-all-render", "needs the EFFECTIVE selection (URL country=, or the MDim view's resolved list from the DB) — never the SVG's own labels, which makes the check unable to fail", "Step 1's table + /query-grapher-db");

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -117,15 +117,49 @@ const checkFrame = async (frameId) => {
   // rows go on reporting raw paints: the same wrong-verdict-about-what-is-not-there this file guards
   // against everywhere else, reached by the one path that skipped the guard. Accumulated on the climb
   // that already runs to find the PAGE, so it picks up section and group ancestors too.
+  // VISIBILITY is the OTHER switch, and it is inherited the same way. `collect` tests `visible` on every
+  // node it walks, but it starts at the frame's CHILDREN — so a `visible: false` on the frame itself, or
+  // on a group or section holding it, was never read, and a hidden node's descendants keep their own
+  // `visible: true`. The frame then certified a sheet of verdicts about a deliverable that is switched
+  // off. Same climb, same reason as the opacity above; collected as a LIST because unhiding the nearest
+  // ancestor is not enough when two of them are off.
   let frameOpacity = 1;
+  const hiddenAncestors = [];
   let page = frame;
   while (page && page.type !== "PAGE") {
     if ("opacity" in page && typeof page.opacity === "number") frameOpacity *= page.opacity;
+    if ("visible" in page && page.visible === false) hiddenAncestors.push(`${page.name || "(unnamed)"} (${page.type})`);
     page = page.parent;
   }
   if (page && figma.currentPage !== page) await figma.setCurrentPageAsync(page);
 
   const fb = frame.absoluteBoundingBox;
+  // A frame that PAINTS NO PIXELS is not a frame with a lot of passing rows on it. Figma switches a node
+  // off two independent ways — `visible: false` and opacity — and this file already treats those as ONE
+  // state everywhere else (see `renders` for a paint and the zero-opacity return in `collect` for a node);
+  // the frame is the last place they were handled as two. Whichever way it is off, every row below would
+  // be a verdict about something no reader can see, so the frame is REPORTED as not rendered instead and
+  // no other row is emitted. That is the honest shape: not "nothing failed", but "nothing was checked".
+  if (hiddenAncestors.length || frameOpacity <= 0.01) {
+    const why = hiddenAncestors.length
+      ? `switched off with visible=false on ${hiddenAncestors.join(", then ")}`
+      : `at effective opacity ${r(frameOpacity)}, counting every group and section above it`
+        + " (zero, or under the same 0.01 floor a paint is dropped at)";
+    add("frame-not-rendered", "FAIL",
+        `NOT CHECKED — this frame paints no pixels: ${why}. Both switches are INHERITED, and the walk`
+        + " below starts at the frame's children, so a descendant's own visible=true and opacity=1 say"
+        + " nothing about whether it renders. Every other row would be a verdict about something the"
+        + " reader cannot see, so none was emitted: this is not an empty or a passing frame. Unhide it,"
+        + " or reset its opacity, along with any group or section above it, and re-run.");
+    return {
+      frame: { id: frame.id, name: frame.name, w: fb ? r(fb.width) : null, h: fb ? r(fb.height) : null },
+      resolved: { chartBy: "not resolved — nothing under a frame that paints no pixels was walked",
+                  contentBox: [null, null], band: [null, null],
+                  counts: { texts: 0, stroked: 0, plotLeaves: 0, annotations: 0 } },
+      verdict: `NOT CHECKED — the frame paints no pixels (${hiddenAncestors.length ? "hidden" : "effective opacity " + r(frameOpacity)})`,
+      rows,
+    };
+  }
   const isSmall = fb ? Math.round(fb.width) <= SMALL_FRAME_W : false;
   const TEXT_FLOOR = CONFIG.textFloor !== null && CONFIG.textFloor !== undefined ? CONFIG.textFloor : (isSmall ? 11 : 12);
   const LADDER = isSmall ? [11, ...LADDER_FULL] : LADDER_FULL;
@@ -235,8 +269,17 @@ const checkFrame = async (frameId) => {
   // maps.md fits it WIDTH-first instead ("scale so it spans the content width") — which leaves gaps
   // far larger than the 12-16px band rule by construction.
   const MAP_GROUPS = /^(map|countries|countries-without-data)$/i;
+  // A LEGEND is furniture that happens to be filled, and grapher draws it INSIDE the chart group and
+  // OUTSIDE the map: measured on the file, a map page reads `chart > numeric-color-legend > {lines,
+  // swatches, labels, swatch-hit-areas}` as a SIBLING of `map`. So every swatch is a filled non-text
+  // plot leaf whose ancestors MAP_GROUPS does not match, and an ordinary map came back holding "both a
+  // map and chart marks" — its own legend audited as a second, chart-side palette, against the wrong
+  // set, with a recommendation to go and restyle the legend rather than the categories. The names are
+  // read off grapher's own `makeFigmaId` calls, not guessed: `numeric-color-legend`,
+  // `categorical-color-legend` and `vertical-color-legend`, each holding a `swatches` group.
+  const LEGEND_GROUPS = /^(numeric|categorical|vertical)-color-legend$|^legend$|^legend[-_]/i;
   let isMap = false;
-  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, nodeOpacity) => {
+  const collect = (n, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, nodeOpacity, insideLegend) => {
     if ("visible" in n && !n.visible) return;
     // NODE opacity dims every paint under it, and it ACCUMULATES down the tree — a group at 0.5 holding
     // a leaf at 0.5 renders the leaf at 0.25. Carried as the PRODUCT, not a boolean, because ZERO and
@@ -257,6 +300,7 @@ const checkFrame = async (frameId) => {
     // instead makes a cleared gridline dash self-justifying. See the furniture-dash row.
     if (FURNITURE_GROUPS.test(n.name)) { inFurniture = true; furnitureGroup = n.name; }
     if (insidePlot && MAP_GROUPS.test(n.name)) { isMap = true; insideMap = true; }
+    if (insidePlot && LEGEND_GROUPS.test(n.name)) insideLegend = true;
     const sm = SERIES_ANY.exec(n.name);
     if (sm) seriesOf = { kind: sm[1], series: sm[2] };
     const cm = CATEGORY_ANY.exec(n.name);
@@ -328,7 +372,12 @@ const checkFrame = async (frameId) => {
       // country split across the antimeridian has a box spanning almost the whole map, so an annotation
       // over open ocean falls inside it. Counting those as covered marks reports a FAIL that is not
       // there, so the annotation row drops them and says so rather than judging them by bbox.
-      if (filled && mb0 && mb0.w > 0 && mb0.h > 0) markBoxes.push({ name: n.name, box: mb0, why: "a filled data mark", insidePlot, fromMap: !!insideMap, hex: hexOf(markPaint),
+      // A legend swatch KEEPS its box — an annotation dropped over the legend covers something the
+      // reader needs — but it is named for what it is, because "covers a filled data mark" sends the
+      // reader looking for a bar that is not there. The palette below drops it on the same grounds.
+      if (filled && mb0 && mb0.w > 0 && mb0.h > 0) markBoxes.push({ name: n.name, box: mb0,
+                                      why: insideLegend ? "a legend swatch" : "a filled data mark",
+                                      insidePlot, fromMap: !!insideMap, fromLegend: !!insideLegend, hex: hexOf(markPaint),
                                       translucent: dimmed || translucent(markPaint), cat: catAncestor || null });
     }
     if (/^datapoints__|^dot__|^value__/.test(n.name)) {
@@ -337,7 +386,7 @@ const checkFrame = async (frameId) => {
         if ("visible" in m && !m.visible) return;
         if ("children" in m && m.children.length) { m.children.forEach(pushLeafBoxes); return; }
         const b = rel(m);
-        if (b && b.w > 0 && b.h > 0) markBoxes.push({ name: n.name, box: b, why, insidePlot, fromMap: false });
+        if (b && b.w > 0 && b.h > 0) markBoxes.push({ name: n.name, box: b, why, insidePlot, fromMap: false, fromLegend: !!insideLegend });
       };
       pushLeafBoxes(n);
     }
@@ -346,13 +395,13 @@ const checkFrame = async (frameId) => {
     // the fixture models), so a bare node here loses it and the name-only filter below matches nothing —
     // every slope segment silently absent from `polylines`, and annotation-overlap unable to fail.
     if (n.type === "VECTOR" && insidePlot) vectors.push({ node: n, seriesOf });
-    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, nodeOpacity)); return; }
+    if ("children" in n && n.children.length) { n.children.forEach((c) => collect(c, insidePlot, inFurniture, seriesOf, furnitureGroup, insideMap, catAncestor, nodeOpacity, insideLegend)); return; }
     const b = rel(n);
     if (b && b.w > 0 && b.h > 0) leaves.push({ name: n.name, type: n.type, box: b, insidePlot, fromMap: !!insideMap });
   };
   for (const child of frame.children) {
     if (child === logo) continue;
-    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, frameOpacity);
+    collect(child, plotRoots.indexOf(child) !== -1, false, null, null, false, null, frameOpacity, false);
   }
 
   // ---------------------------------------------------------------- rows
@@ -1092,7 +1141,14 @@ const checkFrame = async (frameId) => {
     // need attention, and a marker's painted leaf is called `Ellipse 12`. Reporting a failing pair as
     // "Ellipse 12 vs Ellipse 12" identifies nothing. Fall back to the node's own name only when there
     // is no categorical ancestor. Map shapes keep their node names, which already carry the country.
-    const markSrc = markBoxes.filter((m) => m.insidePlot && m.hex);
+    // LEGEND SWATCHES are not categories, they are a picture OF the categories: a legend repeats the
+    // colours the marks already carry and adds none of its own. Audited as marks they turn every
+    // ordinary map into a "map plus chart marks" frame (the legend sits inside the chart group and
+    // outside `map`), get run against the wrong palette under `--separated`, and their names — grapher
+    // ids each swatch after its bin label, and a numeric legend's bins are unnamed rects — either
+    // impersonate a category or trip the import-default gate and drop `--names` for the whole run.
+    const markSrc = markBoxes.filter((m) => m.insidePlot && m.hex && !m.fromLegend);
+    const legendSrc = markBoxes.filter((m) => m.insidePlot && m.hex && m.fromLegend);
     const strokeSrc = stroked.filter((s) => s.insidePlot && !s.inFurniture && s.hex
                                             && (s.seriesKind === "line" || s.seriesKind === "slope"));
     // Translucent paints are held back rather than audited at their raw value (see `translucent`).
@@ -1119,6 +1175,24 @@ const checkFrame = async (frameId) => {
         + " this script cannot determine from inside the plot, so auditing its raw value would answer the"
         + " wrong question. Reset the opacity to 1 (GUIDELINES.md does this for grapher's non-focused"
         + " series) and re-run, or judge those by eye."
+      : "";
+    // Dropping them SILENTLY would be the same subset-reported-as-a-whole this file refuses elsewhere,
+    // and one legend colour genuinely can be missing from the marks: an empty bin nobody falls into is
+    // drawn in the legend and nowhere else. So the count is stated and any colour the palette does not
+    // already carry is named, rather than being quietly audited or quietly dropped.
+    const legendOnly = [...new Set(legendSrc.filter((m) => !m.translucent).map((m) => m.hex.toLowerCase()))];
+    const paletteHexes = new Set(paletteSrc.map((x) => x.hex.toLowerCase()));
+    const legendUnmatched = legendOnly.filter((h) => !paletteHexes.has(h));
+    const legendNote = legendSrc.length
+      ? ` ${legendSrc.length} legend swatch(es) are NOT in this palette — a legend repeats the`
+        + " categories' own colours rather than adding any, and grapher draws it inside the chart group"
+        + " and outside the map, so counting it made an ordinary map report a second, chart-side palette"
+        + " and audited its own furniture."
+        + (legendUnmatched.length
+            ? ` ${legendUnmatched.length} of its colour(s) appear ONLY in the legend and on no mark`
+              + ` (${legendUnmatched.slice(0, 4).join(", ")}) — an empty bin, or a mark this script could`
+              + " not read; judge those by eye."
+            : "")
       : "";
     // `--maps` swaps in the CATEGORICAL Maps palette, and the deltaE 20 all-pairs gate is a categorical
     // test. A SEQUENTIAL choropleth — Viridis, a ColorBrewer ramp — is ordered by construction and set
@@ -1226,17 +1300,13 @@ const checkFrame = async (frameId) => {
         + " fills an inset locator map's countries with their series colours)."
       : "";
     const how = paletteSrc.length
-      ? mixedNote + paletteRun(chartPal) + paletteRun(mapPal) + dimNote
-      // An all-translucent plot must not report "no data marks found" — that reads as an empty frame
-      // and sends the operator looking for missing nodes instead of at the opacity they set. A frame at
-      // effective opacity zero is the same trap one level up: every node under it returned early, so
-      // the count is zero for a reason that has nothing to do with what is on the frame.
-      : frameOpacity <= 0.01
-        ? " The FRAME itself is at effective opacity 0, so nothing on it paints any pixels and there is"
-          + " no palette to read — this is not an empty frame. Reset the frame's opacity (and any"
-          + " section or group above it) to 1 and re-run."
-      : dimNote
-        ? ` No auditable palette:${dimNote}`
+      ? mixedNote + paletteRun(chartPal) + paletteRun(mapPal) + dimNote + legendNote
+      // An all-translucent plot — or one whose only fills are its legend — must not report "no data
+      // marks found": that reads as an empty frame and sends the operator looking for missing nodes
+      // instead of at the opacity they set or the legend they are looking straight at. A frame that
+      // paints no pixels at all never reaches here: it returns one `frame-not-rendered` row instead.
+      : dimNote || legendNote
+        ? ` No auditable palette:${dimNote}${legendNote}`
         : " No data marks or series strokes found in the plot, so there is no palette to audit.";
     skip("colour-vision", "all-pairs deltaE 20 for deuteranopia/protanopia on CATEGORICAL fills." + how, "scripts/color_audit.py");
     skip("grayscale-seams", "adjacent pairs above ~1.6:1 — same command, same run as colour-vision." + how, "scripts/color_audit.py");

--- a/.claude/skills/create-figma-chart/scripts/verify_page.js
+++ b/.claude/skills/create-figma-chart/scripts/verify_page.js
@@ -336,7 +336,7 @@ const checkFrame = async (frameId) => {
                      styleId: n.textStyleId || "", box: rel(n), insidePlot, fill: tf, translucent: tfDim, mixedWeight, weights });
       }
     }
-    if (/^annotation__/.test(n.name)) annotations.push({ node: n, name: n.name, box: rel(n), type: n.type });
+    if (/^annotation__/.test(n.name)) annotations.push({ node: n, name: n.name, box: rel(n), type: n.type, opacity: nodeOpacity });
     if ("strokeWeight" in n && typeof n.strokeWeight === "number" && n.strokes && n.strokes.length) {
       // The stroke's COLOUR travels with it, picked the same way the knockout row picks one: the first
       // paint that actually RENDERS, not `strokes[0]`, which can be a switched-off or transparent decoy.
@@ -996,7 +996,7 @@ const checkFrame = async (frameId) => {
     if (!annotations.length) skip("annotation-knockout", "no annotation__* nodes on this frame");
     else if (!crossings) skip("annotation-knockout", "crossings not computed (no furniture and no readable polylines) — cannot decide the tier, so not judging the strokes either");
     else {
-      const bad = [];
+      const bad = [], unsure = [];
       for (const a of annotations) {
         const n = a.node;
         if (!("strokeWeight" in n) || typeof n.strokeWeight !== "number") continue;
@@ -1016,6 +1016,19 @@ const checkFrame = async (frameId) => {
           bad.push(`${a.name} crosses nothing yet carries a ${r(n.strokeWeight)}px knockout — an annotation over empty space takes no stroke and no frame`);
           continue;
         }
+        // A knockout works by PAINTING the frame's colour over what it crosses, so a translucent one
+        // does not do the job its 3px and OUTSIDE alignment are for: at 0.005 the crossing shows
+        // straight through, and the geometry checks below would still return ok. Zero is already
+        // handled above as no knockout at all; anything between is on the canvas but cannot be
+        // certified from here — how much it masks depends on what is behind it, which is the same
+        // question the palette refuses to guess at. So it is REVIEWED with the number named, rather
+        // than passed or failed: at 0.98 it masks fine, at 0.05 it does not, and this script cannot
+        // tell the reader which side of that they are on.
+        const knockoutAlpha = (a.opacity === undefined ? 1 : a.opacity)
+                              * (hasStroke && paint.opacity !== undefined ? paint.opacity : 1);
+        if (hasStroke && knockoutAlpha < 0.999) {
+          unsure.push(`${a.name} carries a knockout at effective opacity ${r(knockoutAlpha)} (paint x node), so it does not fully mask the ${crosses.length} thing(s) it crosses — a knockout paints the frame's colour OVER them, and a partly transparent one lets them through. Set it to 1, or judge this one by eye`);
+        }
         if (hasStroke && Math.abs(n.strokeWeight - 3) >= 0.05) {
           bad.push(`${a.name} knockout ${r(n.strokeWeight)}px (want 3)` + (n.strokeWeight < 1 ? " — sub-pixel means the stroke was set before a rescale()" : ""));
         }
@@ -1028,7 +1041,9 @@ const checkFrame = async (frameId) => {
           }
         }
       }
-      add("annotation-knockout", bad.length ? "FAIL" : "ok", bad.length ? bad.join("; ") : `all ${annotations.length} annotation(s) carry the tier their crossings require`);
+      add("annotation-knockout", bad.length ? "FAIL" : unsure.length ? "REVIEW" : "ok",
+          (bad.length ? bad.join("; ") : `all ${annotations.length} annotation(s) carry the tier their crossings require`)
+          + (unsure.length ? `. ${unsure.length} NOT certified: ${unsure.join("; ")}` : ""));
     }
   }
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Follow-ups to #6751, which left four things open. Three are closed here; the fourth turned out to be blocked on a credential rather than on anyone's time. Docs and scripts only — no ETL step is touched.

## The batching claim from #6751 was wrong, and is retracted

`BENCHMARK.md` shipped saying the benchmark run's **28 calls in 28 messages, peak in-flight 1** was its largest finding — the batch manifest ignored, a measured ~4.0× left on the table.

Reading the calls back, that does not hold. **22 of the 28 are `use_figma` writes to the DI page**, and SKILL.md's own rule is that writes batch only *across different pages*, because a script may switch pages once and two writes aimed at one page race each other. A build is one page. The three `upload_assets` are the two-pass export solve, serial by the documented `measure band → export embed → fit` chain; the two screenshots sat four minutes apart on different states. **Nothing in that run was batchable — zero was the correct number.**

The manifest's rows are surveys and checks (Step 5's page enumeration, the Step 8c pair, Step 9's renders, the palette harvest). This build had one Step 8c call and two renders. The ~4.0× is real and belongs to read-heavy passes; it was never available to the build spine.

The lesson is worth more than the claim was, so it stays in the file: **a zero is not a finding until you have checked that a non-zero was possible.** Measuring it was right; reading a verdict into it without asking whether the thing was even available is the same error as a check reporting PASS on input it could not measure.

What the number *does* say, with batching off the table: 28 calls against the **~14–18** a template should cost, at **~66 s per call** of which only ~4.4 s is the call itself. The lever on a build is **fewer, fatter calls**, not parallel ones — four of the 28 were pure diagnosis and rework.

## `colour-vision` and `grayscale-seams` now hand back a runnable command

`color_audit.py` cannot run inside a Figma plugin sandbox — there is no shell — but the palette it needs is already on the canvas. Both rows stay `SKIPPED` and now emit the invocation with the palette filled in, the interpreter spelled out, and `--names` attached when the node names allow it. A declared gap the operator has to reconstruct by hand is the one that actually gets skipped.

**The palette comes from identified data marks and line/slope series strokes.** The obvious source — the `fills` inventory the script already keeps — is the wrong one, and measurably so: `fills` holds every solid paint on an area node inside the plot, and a `TEXT` node has one, while a line chart's series colour is a **stroke** and is not in it at all. On this script's own test fixture that source emitted a one-entry palette consisting of a text label's fill, with the series colour missing. Furniture in, data out, in the same run. `outline__*` strokes are excluded with the text: that is the white halo grapher draws under a line so crossings stay readable, shared by every series rather than belonging to one.

**A legend is furniture too, and its swatches are not categories.** grapher draws the legend *inside* the chart group and *outside* the map — a map page reads `chart > numeric-color-legend > {lines, swatches, labels, swatch-hit-areas}` as a **sibling** of `map` — so every filled swatch reached the palette as an ordinary chart-side mark, and an ordinary choropleth came back holding "both a map and chart marks": the map audited under `--maps`, its own legend under `--separated`, with a `--suggest` rerun ready to recommend restyling the legend rather than the categories. On a line chart the harm landed on `--names` instead: a numeric legend's bins are unnamed rects, so one swatch in a colour of its own put an import default into the palette and dropped the flag for the whole run. A legend repeats the categories' colours and adds none of its own, so its swatches are excluded, **counted**, and any colour appearing *only* in the legend — an empty bin — is named rather than quietly lost. They keep their boxes for `annotation-overlap`, where an annotation dropped over the legend still covers something the reader needs, and are reported there as "a legend swatch" instead of "a filled data mark". The container names are read off grapher's own `makeFigmaId` calls: `numeric-color-legend`, `categorical-color-legend`, `vertical-color-legend`.

**Only paints that actually render are eligible.** Figma switches a paint off two independent ways — `visible: false` and `opacity: 0` — and the fill side tested only the first, so a mark left fully transparent handed the audit a category colour that paints no pixels and could be recommended a replacement for. The stroke collector already applied both tests, so the two sides disagreed about the same node. The predicate is now named once and used at every paint-selection site: the palette, the `off-palette` inventory, the frame fill that `label-contrast-on-background` measures against, and a text node's own fill.

**Partial opacity is a different problem, and it is declared rather than solved.** A half-opacity mark *is* on the canvas — it keeps its box, its stroke weight and its annotation-overlap — but it has no reportable colour: `hexOf` returns the paint's raw RGB while the reader sees that RGB composited onto whatever is behind it. This is documented behaviour in this very skill, twice: grapher exports non-focused series at `stroke-opacity="0.5"`, and the period band is a fill at 50%. `LABELING.md` works the same sum the other way round and sizes the error — a band composited onto the frame is `#ecebe8` where the frame alone gives `#fbf9f3`, "close enough to look deliberate and wrong enough to see". Compositing here is **refused**: it needs what is *directly* behind the mark, which inside a plot is usually another mark rather than the frame, plus every ancestor's opacity — guessing the frame would relocate the confident wrong answer rather than remove it. So translucent paints are held out of the palette and **named**, with their categories, because a silently shorter palette is a subset audit reported as a whole one. Node opacity is carried down the walk alongside paint opacity, since a group at 0.5 dims an opaque leaf just as effectively — as the accumulated **product**, so a node dimmed to nothing stays separable from one that is merely faint: effective zero paints no pixels and leaves every row, the same exit `visible: false` takes. A translucent *label* moves into `label-contrast`'s by-eye bucket for the same reason — compositing always lowers contrast, so scoring the raw value passes text that is genuinely too faint, the one direction that row must not fail in.

**A mark's category is read from its nearest `<kind>__<Entity>` ancestor, not from the painted node.** grapher puts the stable name on the group and the paint on its leaves — a `datapoints__<Entity>` marker is a filled leaf called `Ellipse 12` — so reading the leaf loses the category on exactly the shape the collector already goes out of its way to preserve. The walk now carries it down the way it already carries series identity. That category is also what **labels** the audit, so a failing pair reads `Peru vs Nepal` rather than `Ellipse 12 vs Ellipse 12`.

**But `<kind>__<name>` is two conventions, not one, and only one of them names a category.** Measured on the live file: grapher's SVG export emits `line__<Entity>` / `outline__<Entity>` / `label__<Entity>`, where the second token *is* the category — while a `static_viz` matplotlib step emits `f"{slug}__{part}"`, where it is a dataset slug repeated across every mark, and every paint-bearing leaf under it is called `Vector`. So `--names` was labelling three genuinely different colours `agriculture-share,agriculture-share,agriculture-share`: one row per colour, all under one name, which is worse than no label because it looks right. `--names` is therefore gated on the names being **distinct across the palette** and not import defaults (`Vector`, `Rectangle 12`) — the grapher case passes that gate and keeps its labels, the `static_viz` case fails it and the flag is dropped with the reason stated. Widening `CATEGORY_ANY` to tell the two apart is not available: they are ambiguous at the name level, and distinctness is the property `--names` actually promises.

**The mode flag is picked from what the palette was sourced from**, because it is not cosmetic: it also selects which palette a `--suggest` rerun searches. `--maps` for a map, `--line` for line/slope series (that is `--separated` *plus* the Line and Slope variants, the darker set for thin marks on white), `--separated` otherwise. All three mean "nothing shares an edge".

**And it is picked per palette, not per frame**, because one frame can hold both. `combination.md`'s exemplar is a line chart with an inset locator map whose countries are filled with **the same colours as their series** — so a frame-level flag let the map win and the line strokes were then audited under `--maps`, recommending fill colours for thin strokes. The two families are now deduped, named, flagged and emitted as two runs, with a note saying a colour appearing in both is prescribed rather than a clash. A frame with only one family is unchanged.

**A palette of one colour gets no command at all.** Both rows compare *pairs*, so a single colour has nothing to compare — and `color_audit.py` does not say so: handed one hex it prints an empty pair list and `overall: min dE inf`, then exits 0, which reads exactly like a clean audit. GUIDELINES.md already rules on this ("one categorical color against neutral grays has no pair to check, and reporting no failures from a two-color audit reads as coverage you don't have"), so the command is withheld, the colour named, and the two live checks handed over in its place: its contrast against the background, and its grayscale separation from the neutral grays. The clash note is computed *before* that exit and survives it — two categories painted one colour **are** a one-colour palette, so the branch that withholds the run is the branch that most needs to report what it found. A declared `highlightTreatment` gets the same rule attached to its command rather than the command withheld, because which entries are muting grays is a judgement this script cannot make: a category legitimately painted gray is still a category.

Four things it refuses to guess:

- On a **stacked or segmented** chart the mode flag must go and the colours must be reordered into stack order first, because the seam check reads adjacency off the order you supply. That is the only chart type with seams, so it is the only case where the emitted flag is wrong.
- On a **map** it says the row covers a categorical choropleth *only*. `--maps` selects the Categorical Maps palette and the ΔE 20 gate is a categorical test, so a **sequential ramp** — ordered by construction, and set in grapher — fails it by design, and the script's own "rerun with `--suggest`" would then offer an unordered palette in place of a correct ramp. Nothing inside the plugin can tell a ramp from a categorical choropleth off the fills, so the boundary is stated rather than guessed at.
- It drops `--names` wholesale — **stating which reason applies** — when a mark is unnamed, carries a comma that would split into two entries and misalign every label after it, carries an apostrophe that would end the single-quoted shell argument mid-name, repeats one name across distinct colours, or is an import default.
- The palette is deduplicated by **colour**, because the audit takes a palette and forty segments in six colours would bury every finding under ΔE 0 self-pairs. What that collapse hides is named rather than swallowed: two categories on one colour is the severest clash there is and the audit cannot see it, so the row reports the counts and lists the colliding categories. Ungraded and phrased as a question — a highlight treatment greys every unhighlighted series to one value on purpose — and map shapes are left out of it entirely, since a choropleth bin is one colour by definition.

## A frame that paints no pixels returns one row, not a sheet of them

Figma switches a node off two independent ways, and both are **inherited**: `visible: false` and opacity. The walk starts at the frame's *children*, whose own `visible: true` says nothing about whether they render — so a hidden frame, or one sitting under a hidden section, certified 31 rows of verdicts about a deliverable that is switched off, and signed them `no mechanical row failed`.

Both switches now meet one gate, because this file already treats them as one state everywhere else (`renders` for a paint, the zero-opacity return in the walk for a node) and the frame was the last place they were handled as two. Either way off, the frame returns a single `frame-not-rendered` **FAIL** naming which switch it is and where — hidden ancestors are collected as a **list**, since unhiding the nearest one is not enough when two are off — and the verdict reads `NOT CHECKED`. That also retires the frame-opacity branch inside the colour rows, which is now unreachable; leaving it would have been a branch that cannot fire.

## Twenty-one more false verdicts, the same shape as the seven Codex found on #6751

- **`solve_export.py`** took `nan` and `inf` straight through `if a <= 0` — neither is caught by a sign test — and died ~90 lines later inside `int(round(w / h * 1000))` as an uncaught traceback. Now rejected at the boundary, and swept **off the parser** rather than a hand-kept list: the first draft of that guard named two flags that do not exist while missing four that do, which is exactly the failure a hardcoded list invites.
- **`inline_script.py --check`** judged a sliceable script on its whole-file size rather than on what gets sent, failing anything over the 50,000-char cap. That stopped being hypothetical inside this PR: `verify_page.js` is now **60,937 chars stripped, past the cap**, and the old rule would fail a file that runs perfectly — the whole-file path is refused above 80% anyway.
- **…and then measured the wrong two calls.** "What gets sent" is not the largest single row group, since `--rows` combines groups and the documented pass is two calls — but minimising over *every* possible split is not it either. That can hold the check green by discovering a split nobody is told to send while the documented workflow is over the cap: padding `annotations` by 16,000 characters puts the documented `geometry,annotations` call at **50,314 and refused**, while the optimiser's best split peaks at 45,131 and reports 90%, exit 0. The two calls are now **declared** as `DOCUMENTED_CALLS` beside the script and measured directly, reporting **43,327 (87% of cap, against a 76% floor)** with the calls named in the output. The declaration is itself checked to cover every row group exactly once, so a `#region` added without a doc update fails rather than going unmeasured, and a sliceable script with no declaration is a failure rather than something to optimise a number for. The subset enumeration survives as advice: over the cap, the tool prints the split that would fit.
- **`strip_js` desynchronized on a nested template literal** — a backtick inside a `${}` closed the outer context — and silently stopped stripping comments for the rest of the file. It surfaced only as `--check` jumping 75% → 96% of cap on a 1.8 KB edit, i.e. as a number, not an error.
- **…and the guard that was added for it missed the balanced case.** Ending outside every literal is not proof the parse stayed in sync: in `` `outer ${`inner // keep` } tail` `` the inner backtick closes the outer context and the inner closing backtick reopens it, so the file ends clean while `// keep` has been **deleted from template text** — the emitted script differs from the file on disk, silently, which is the one thing this stripper exists to prevent. Measured both ways on that exact input. The context is a **stack** now: a `${` inside a template pushes a code level with its own brace depth, each literal closes its own level, nesting parses instead of being caught, and a comment inside a `${}` *is* stripped because there it really is a comment. The end-of-file check stays as the backstop for genuinely unterminated source.
- **A knockout that masks nothing was certified.** Dropping the `0.01` floor made "renders" true at `0.005`, and the knockout row reads presence off exactly that — so an annotation crossing a gridline with a nearly transparent stroke cleared the weight, alignment and colour checks and the row reported `all 1 annotation(s) carry the tier their crossings require`. A knockout masks by painting the frame's colour *over* the crossing; at that alpha it paints nothing. Zero is still "no knockout" and FAILs; anything short of opaque is **REVIEW** with its effective opacity (paint × node) named, because 0.98 masks fine and 0.05 does not, and how much survives depends on what is behind the annotation.
- **`--check` advertised a split that does not fit.** With the floor over the cap it printed "no split fits, move rows into a separate script" and then, unconditionally, the minimizing two-way split as "a 2-way split that fits" — a 58,514-character call against a 50,000 cap, in exactly the exhaustion case the floor exists to diagnose. The advice is a pure function now with three answers: a split that fits, no two-way split but a finer one would (the floor proves it), or nothing to add.
- **A transparent paint counted as a colour** — the palette entry above, which reports a category nobody can see.
- **A translucent paint was audited at its raw value** — also above. The audit's deltaE, grayscale and contrast verdicts, and any `--suggest` replacement, were answers about a colour that is not on the page.
- **A node the reader cannot see was reported as a translucent mark.** `opacity: 0` on a node paints no pixels — the same non-rendering state as `visible: false` and as a zero-opacity paint, both of which the walk already drops outright — but it was grouped with genuinely visible partial opacity, so the audit **named an invisible category** and told the operator to reset its opacity or judge it by eye. Node opacity is now the accumulated **product** rather than a boolean, because zero and partial are two different answers and a boolean cannot tell them apart — and the product is also what sees a group at zero holding an opaque leaf, which no single-node test can.
- **A mixed frame was audited under one palette.** `isMap` is frame-level, but which palette a mark belongs to is a property of the *mark*. On the combination chart above, the map won the flag and the line strokes were audited against the Categorical Maps set — and colour dedupe ran across both families too, so the series entry collapsed into the country that shares its colour and vanished from `--names` entirely. The overlap the guidelines *require* was what erased it.
- **The frame's own opacity was never read.** Node opacity accumulates *down* the tree, but the frame sits *above* the walk, which was seeded with a literal `1` — so the one ancestor every mark shares was the only node never examined. A frame (or a section holding it) left at reduced opacity dimmed every mark on the canvas while the raw paints went on being emitted as a paste-ready command. Now accumulated on the climb that already runs to find the `PAGE`.
- **The frame's own visibility was never read either** — the section above. The climb added for opacity tracked only opacity, so a hidden frame kept certifying a full sheet of rows.
- **A legend's swatches were audited as categories** — the section above: two palettes reported on an ordinary map, and `--names` lost to an unnamed legend bin on an ordinary chart.
- **`--names` labelled distinct colours with one name** — the two `__` conventions above. Three colours, one label, printed as a per-category verdict.
- **The chart group was reported as ungrouped when it was not.** `chartName` defaults to `chart`, and the live file uses three names: `chart` (a grapher import), `chart__<slug>` (a `static_viz` import) and `chart-desktop` / `chart-mobile` (a two-format page). An exact-only match fell through to the ungrouped branch, walked the right node anyway, and explained a correct answer with a wrong reason — which sends the next reader to fix a non-problem. Exact match first, then a `__` or `-` suffix, and the row names what it matched.
- **A faint node was treated as an absent one.** The non-rendering test was a `0.01` **floor**, on paints and on nodes, and the node gate is an early return from the walk — so a node under it took its whole subtree out of *every* inventory, not just the palette. An 8px label at opacity `0.005` was gone before `text-floor` saw it, and the row reported that all of its ranges cleared the floor. Both tests are now exactly **zero**, reached by the multiplication rather than by comparison to a threshold, and everything positive goes down the translucent path: held out of the palette, named there, and still judged by every geometry row. That reverses one earlier decision on this PR deliberately — a mark compounded to `0.0025` is now named rather than dropped, which is both consistent with "exclude nodes whose effective opacity is **zero**" and better advice, since resetting the opacity is exactly what it needs.
- **A one-colour palette still got a runnable command** — the section above. `color_audit.py` exits 0 on it with an empty pair list and `min dE inf`, which is a gate that cannot fail dressed as a clean pass. Eighteen harness cases were asserting on that command, which is how far the assumption had spread.
- **`--check` reported the wrong headroom.** It measured what today's two documented calls cost (`sent`), which re-splitting can always buy down, and said nothing about the floor — the preamble plus the largest single row group, the smallest any call can ever be. At 82% sent the script looked ~9,000 characters from trouble when re-splitting actually bought ~14,000. Both columns are reported now, `--check` fails when the *floor* passes the cap (slicing exhausted — the only move left is splitting the script into separate files) and warns past 85%.
- **`inline_script.py` had no harness at all**, which is the wrong shape for the tool that decides what is safe to send. It has one now (24 checks) — and it immediately caught a false positive in this PR's own corruption guard: the refuse-on-surviving-comment check flagged any `//` line, but a template literal may legitimately contain one and the stripper handles it correctly. The real signature is the **open context** at the end of the strip, which is what it checks.
- The new `--names` note asserted "contains a comma" even when the real cause was a missing name. Same habit, one level down.

## REST bulk-render: blocked, not pending

Checked today — **ETL carries no `FIGMA_API_KEY`**. Recorded in `GOTCHAS.md` with the reason not to pre-build the wrapper (an untested client for an API you cannot call is a thing that reports success it has not earned) and with the case for it narrowed: its niche is *cloud* bulk reads, and `measure_pixels.py` removed the reason most probes rendered at all.

## Verification

`test_verify_page.js` **276 checks**, up from 190. That includes a happy-path case proving `--names` *is* emitted — without it, the negative cases would pass on a build that never emits the flag at all — and paired cases for each colour rule that can fail in both directions: two series on one colour must be named while two map shapes sharing a bin colour must not; a line palette must ask for `--line` while a fill-only palette must get `--separated` and keep the stack-order warning; grapher's `line__<Entity>` must keep its labels on the same gate that drops `static_viz`'s repeated slug.

The ancestry case is built so it can only pass through the ancestor — two marker groups whose leaves are generically named and painted a colour nothing else in the fixture carries — and I checked it **fails** against the old leaf-name read rather than trusting that it passes. Every case added since has been checked the same way, by reverting the fix and watching the case go red: the transparent-paint and translucency cases emit the invisible or uncomposited `#12ab34`; the legend cases report "two separate runs" and a `--separated` command on a pure map, lose `--names 'A'` to a swatch's import-default name, and call a swatch a filled data mark; the hidden-frame cases emit 31 rows and an "ok" verdict; the opacity-floor cases lose the compounded mark's naming and drop an 8px label out of `text-floor`; the single-colour cases emit a command from a palette with no pair, and — reverted a second way — lose the clash note in the one branch that most needs it.

Negative controls are paired with each: an opaque plot must carry no translucency note, a mark compounded to 0.25 must keep both the note and its exclusion, a frame with only one colour family must produce exactly one run and no split note, a frame containing a hidden *child* — or sitting under a *visible* section — must stay fully checked, and an 8px label at opacity *exactly* zero must still not be judged, so neither new gate can start firing on ordinary pages or drift back into a threshold.

Three of my own cases were wrong first, all in the class this PR is about:
- One passed **vacuously**: it renamed an arbitrary filled node, but the emitter keeps the *first* name per distinct hex, so that colour was already registered under a clean earlier name.
- Its assertion then matched the substring `--names` inside the very note saying `--names` was omitted.
- The name-safety cases renamed **text** fills, which stopped feeding the palette once the source was corrected — they would have gone on passing while testing nothing. They now rename a filled data mark.

`test_inline_script.py` is **36 checks**, up from the 24 it was born with earlier tonight — the tool that decides what is safe to send had no harness at all until this PR, which is how a false positive shipped in its own corruption guard.

Also passing: `test_diff_against_template.js` (75), `test_replay_chart_edits.js` (52), `test_measure_fit.js`, `test_measure_pixels.py`, `test_figma_desktop_read.py`, `verify_docs.py --structure`, `inline_script.py --check`, `make check`, ruff (check and format), codespell with `-I .codespell-ignore.txt`. Every documented slice (`--rows type,series`, `--rows geometry,annotations`, and each group alone) was parsed after stripping, so a stripper desync cannot ship as a wrong verdict.

## Left open

- **`color_audit.py` has pre-existing `ruff format` drift on master.** Out of scope here; left alone to keep this PR scoped.
- **`verify_page.js` is at 87% sent against a 76% floor, and the trend is one way.** 60,937 chars stripped; the documented calls are `--rows type,series` **41,960** and `--rows geometry,annotations` **43,327** against a 50,000 cap. Sent was 69% at the start of the day. **Watch the floor, not `sent`**: `sent` is what today's split happens to cost and re-splitting always buys it down, while the floor — the preamble plus the largest single row group — is the smallest any call can ever be. At 75% there is real room left in re-splitting; when the floor itself passes the cap, slicing is exhausted and the only move left is splitting the script into separate files with their own preambles. `--check` fails on that and warns past 85%, so it will say so by going red rather than warning first, and `--whole` is already refused for this script while a hand-rolled subset is explicitly worse than skipping. Every fix on this PR adds reasoning to the file, and the reasoning is what makes the rows auditable, so the growth is not incidental.
- **CHECKS.md's slice figures are still hand-maintained.** The *calls* are declared once and cross-checked against the file, so the two-call workflow can no longer drift out of the doc unnoticed — but the **numbers** beside them (per-group percentages, the stripped total, the two-call sizes) are still copied by hand. Nothing regenerates them from `--check`, so they drift on any edit that changes the file's size — they were refreshed **nine times** inside this PR alone, which is the argument for generating them.
- **Sequential-ramp maps get a declaration, not a check.** The row tells the operator the command does not apply to a ramp; it does not detect that it is looking at one, and nothing verifies a ramp's lightness ordering.
- **The remaining `SKIPPED` rows are still skipped**: entity completeness (needs the effective selection from outside Figma), legend agreement (needs swatch→label geometry), direct-label pairing, `label-contrast-on-fill`, `leader-on-map`, `page-census`. Each is declared with its owner and reason; none is silently absent, and none is implemented.
- **Half of the naming assumption is now measured; the other half is not.** `child-mortality.svg?imType=uncaptioned` carries 7 `line__<Entity>`, 7 `outline__<Entity>` and 7 `label__<Entity>` ids with 7 distinct stroke colours, so grapher's half of the `<kind>__<Entity>` contract is confirmed against a live export rather than reasoned, and the chart-group and legend names come from counting the real Figma file and reading grapher's own `makeFigmaId` calls. What no run has confirmed is that those ids survive the **SVG → Figma import** as node names on a page built today, and the colour rows themselves have still only ever executed against the mock.
- **Nobody has re-run the skill end to end** since #6751's last three commits or these. The changes are guards, docs and a handoff, and the harnesses cover the guards — but the live run behind the benchmark predates all of it.
- **The `~14–18` calls-per-template figure now has one contradicting data point** (28) and no explanation beyond the four rework calls. Worth a second benchmark run to see whether 28 is the norm or that run was unlucky.
