### PR TITLE
Say "installed" in the IRENA total geothermal capacity indicator title

### DIFF
--- a/etl/steps/data/garden/irena/2025-07-18/renewable_energy_statistics.meta.yml
+++ b/etl/steps/data/garden/irena/2025-07-18/renewable_energy_statistics.meta.yml
@@ -56,13 +56,13 @@ tables:
         presentation:
           title_public: Geothermal capacity (off-grid)
       geothermal__total:
-        title: Geothermal capacity (total)
+        title: Installed geothermal capacity (total)
         description_short: |-
           Total geothermal (on- and off-grid) electricity installed capacity, measured in megawatts.
         display:
           name: Geothermal (total)
         presentation:
-          title_public: Total geothermal capacity
+          title_public: Total installed geothermal capacity
       hydropower:
         title: Hydropower capacity (on-grid)
         description_short: |-


### PR DESCRIPTION
> _Written by Claude Opus 5 — @pabloarosado at the wheel._

Fixes an internal chart comment on [`installed-geothermal-capacity`](http://staging-site-internal-comments-2/admin/grapher/installed-geothermal-capacity) (comment 79):

> @claude the indicator's title should make it clear that it's **installed** capacity

## Change

In `etl/steps/data/garden/irena/2025-07-18/renewable_energy_statistics.meta.yml`, for `geothermal__total`:

- `title`: `Geothermal capacity (total)` → `Installed geothermal capacity (total)`
- `presentation.title_public`: `Total geothermal capacity` → `Total installed geothermal capacity`

`description_short` already said "installed capacity", so it is unchanged.

## Open items

- Only the commented indicator was changed. Every other indicator in this table (`renewables__total`, `solar__total`, `wind__total`, the per-technology on-/off-grid ones, ...) still has a title of the form `<technology> capacity`, so the table is now inconsistent. If the intent is to say "installed" everywhere, that is a much larger edit and should be done deliberately in one pass — please confirm which you want.
- The grapher step appends `" (GW)"` to titles for the gigawatt variants, so `geothermal__total_gw` becomes `Installed geothermal capacity (total) (GW)`. Nobody has eyeballed that rendering.
- Needs `etlr` re-run of the garden/grapher steps plus a `grapher://` upsert for the new titles to reach the DB; not done here.

This PR was opened automatically by the comment agent and needs human review.
