### PR TITLE
📊 Remap remaining UN SDG charts

### DIFF
--- a/etl/indicator_upgrade/indicator_update.py
+++ b/etl/indicator_upgrade/indicator_update.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from structlog import get_logger
 
 import etl.grapher.model as gm
@@ -34,8 +34,16 @@ def find_charts_from_variable_ids(variable_ids: set[int]) -> list[gm.Chart]:
             .unique()
             .all()
         )
-        # Retrieve charts from a given list of chart IDs
-        charts = session.scalars(select(gm.Chart).where(gm.Chart.id.in_(chart_ids))).all()
+        # Retrieve charts from a given list of chart IDs. `patch_config` is lazy by default
+        # (see the relationship's comment in `gm.Chart`), and callers read it *after* this
+        # session closes, so eager-load it here rather than paying a detached lazy load.
+        charts = (
+            session.scalars(
+                select(gm.Chart).where(gm.Chart.id.in_(chart_ids)).options(selectinload(gm.Chart.patch_config))
+            )
+            .unique()
+            .all()
+        )
 
     # some charts don't have ID in config, fix that here (should be ideally fixed in the database)
     for chart in charts:

--- a/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
+++ b/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
@@ -48,3 +48,816 @@
   expect: {lt: 100}
   provider: International Labour Organization
   status: open
+
+# ---------------------------------------------------------------------------------------------
+# Indicator 12.4.2, series EN_HAZ_PCAP (hazardous waste generated, kg per capita): the 2026 Q2
+# release publishes the RECIPROCAL of the per-capita rate for 71 of the 116 countries that have
+# a usable total.
+#
+# The signature is algebraic, not statistical. For every affected country-year, the published
+# value multiplied by the rate implied by the country's own EN_HAZ_GENV total and its population
+# equals 100:
+#
+#     published_kg_per_capita  x  (EN_HAZ_GENV_tonnes * 1000 / population)  =  100
+#
+#   Russia 2018 : published 0.11    | implied 883      | product 100
+#   China  2023 : published 1.35    | implied 74.1     | product 100
+#   Belarus 2023: published 0.39    | implied 253      | product 100
+#
+# It runs in both directions, which is why it is easy to miss: where the true rate is small the
+# published value is enormous (Tanzania peaks at 211,720 "kg per capita"), and where the true
+# rate is large the published value collapses to hundredths of a kilogram. Where the true rate
+# is near 10 kg the two are numerically indistinguishable.
+#
+# EN_HAZ_GENV (the total, in tonnes) is unaffected and is byte-identical to the previous release
+# for every country checked, so the underlying national reporting is intact -- only the derived
+# per-capita series is wrong. EN_HAZ_GENGDP (per unit of GDP) is also unaffected.
+#
+# This is new in this release. Running the same test against the 2025-10-29 snapshot, the
+# reciprocal signature appears for 3 countries; here it appears for 71.
+#
+# The affected values are dropped rather than recomputed: deriving kg per capita ourselves from
+# EN_HAZ_GENV and our population series would silently publish an OWID-computed number under a
+# UN-attributed indicator. If we decide we want that series, it belongs in step code with its own
+# processing description, not here.
+#
+# LIMITATION: 25 of the entries carry no `expect` guard (Algeria, Azerbaijan, Bangladesh, Belarus,
+# Bermuda, China, Dominica, Fiji, French Guiana, Guadeloupe, Guatemala, Hong Kong, India, Jordan,
+# Martinique, Mauritius, Monaco, Oman, Palestine, Philippines, Qatar, Reunion, Thailand, Trinidad
+# and Tobago, Ukraine). Their published and implied values overlap in magnitude -- around 10 kg per
+# capita a number and its reciprocal-times-100 are the same size -- so no threshold separates a
+# corrupted value from a corrected one. The other 47 entries do carry a guard and will fail the
+# build once the UN corrects them; treat that failure as the signal to re-check all 71.
+#
+# Reported upstream: see the PR for the message sent to the SDG data team.
+# ---------------------------------------------------------------------------------------------
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Algeria}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2007: 10.52 kg/capita published
+    against 9.509 kg/capita implied by 325,100 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Andorra}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 7.12 kg/capita published
+    against 14.05 kg/capita implied by 1,136 tonnes; product = 100.0.
+  expect: {lt: 9.99548}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Argentina}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 4.87 kg/capita published
+    against 20.54 kg/capita implied by 930,850 tonnes; product = 100.0.
+  expect: {lt: 10.0037}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Armenia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.01 kg/capita published
+    against 1.087e+04 kg/capita implied by 32,000,570 tonnes; product = 108.7.
+  expect: {lt: 9.98198}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Azerbaijan}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 4.43 kg/capita published
+    against 22.57 kg/capita implied by 232,926 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Bahrain}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2019: 1.61 kg/capita published
+    against 62.25 kg/capita implied by 92,481 tonnes; product = 100.2.
+  expect: {lt: 9.99916}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Bangladesh}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 1.54 kg/capita published
+    against 64.82 kg/capita implied by 10,867,839 tonnes; product = 99.8.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Belarus}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.39 kg/capita published
+    against 253.3 kg/capita implied by 2,309,131 tonnes; product = 98.8.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Belize}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2000: 31.07 kg/capita published
+    against 3.218 kg/capita implied by 775 tonnes; product = 100.0.
+  expect: {gt: 9.99966}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Benin}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2002: 452.03 kg/capita published
+    against 0.2212 kg/capita implied by 1,698 tonnes; product = 100.0.
+  expect: {gt: 10}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Bermuda}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2019: 3.56 kg/capita published
+    against 28.07 kg/capita implied by 1,800 tonnes; product = 99.9.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Bhutan}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2019: 213.26 kg/capita published
+    against 0.4689 kg/capita implied by 359 tonnes; product = 100.0.
+  expect: {gt: 10}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Burkina Faso}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2011: 91048.7 kg/capita published
+    against 0.001098 kg/capita implied by 18 tonnes; product = 100.0.
+  expect: {gt: 10}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Cameroon}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2009: 219.28 kg/capita published
+    against 0.456 kg/capita implied by 8,717 tonnes; product = 100.0.
+  expect: {gt: 10.0001}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Cape Verde}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2014: 14.44 kg/capita published
+    against 6.927 kg/capita implied by 3,549 tonnes; product = 100.0.
+  expect: {gt: 10.0013}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: China}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 1.35 kg/capita published
+    against 74.14 kg/capita implied by 105,465,000 tonnes; product = 100.1.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Cuba}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 4.72 kg/capita published
+    against 21.17 kg/capita implied by 235,498 tonnes; product = 99.9.
+  expect: {lt: 10.001}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Dominica}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 8.75 kg/capita published
+    against 11.42 kg/capita implied by 768 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Ecuador}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2020: 125.5 kg/capita published
+    against 0.7968 kg/capita implied by 13,981 tonnes; product = 100.0.
+  expect: {gt: 10.0002}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: El Salvador}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 0.44 kg/capita published
+    against 228.4 kg/capita implied by 1,428,520 tonnes; product = 100.5.
+  expect: {lt: 10.0147}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Fiji}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 4.82 kg/capita published
+    against 20.73 kg/capita implied by 19,158 tonnes; product = 99.9.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: French Guiana}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 17.98 kg/capita published
+    against 5.56 kg/capita implied by 1,687 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Guadeloupe}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 2.86 kg/capita published
+    against 34.94 kg/capita implied by 13,157 tonnes; product = 99.9.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Guatemala}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2017: 106.45 kg/capita published
+    against 0.9394 kg/capita implied by 15,564 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Hong Kong}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 26.81 kg/capita published
+    against 3.73 kg/capita implied by 27,765 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: India}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 9.18 kg/capita published
+    against 10.89 kg/capita implied by 15,657,711 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Iraq}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 124.59 kg/capita published
+    against 0.8026 kg/capita implied by 36,178 tonnes; product = 100.0.
+  expect: {gt: 9.99987}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Jamaica}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2006: 27.01 kg/capita published
+    against 3.702 kg/capita implied by 10,000 tonnes; product = 100.0.
+  expect: {gt: 10.0003}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Jordan}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 14.62 kg/capita published
+    against 6.842 kg/capita implied by 75,715 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Kazakhstan}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.05 kg/capita published
+    against 2159 kg/capita implied by 43,894,188 tonnes; product = 108.0.
+  expect: {lt: 10.3243}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Kenya}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2017: 128.3 kg/capita published
+    against 0.7795 kg/capita implied by 38,347 tonnes; product = 100.0.
+  expect: {gt: 10.0002}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Kyrgyzstan}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2017: 0.05 kg/capita published
+    against 2033 kg/capita implied by 12,648,247 tonnes; product = 101.7.
+  expect: {lt: 10.191}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Lebanon}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2002: 4.44 kg/capita published
+    against 22.51 kg/capita implied by 100,492 tonnes; product = 100.0.
+  expect: {lt: 9.99814}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Lesotho}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2019: 782.7 kg/capita published
+    against 0.1278 kg/capita implied by 282 tonnes; product = 100.0.
+  expect: {gt: 10.0001}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Liechtenstein}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.44 kg/capita published
+    against 228.3 kg/capita implied by 9,047 tonnes; product = 100.5.
+  expect: {lt: 10.0034}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Macao}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 60.91 kg/capita published
+    against 1.642 kg/capita implied by 1,172 tonnes; product = 100.0.
+  expect: {gt: 9.99938}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Madagascar}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2007: 44.21 kg/capita published
+    against 2.262 kg/capita implied by 45,957 tonnes; product = 100.0.
+  expect: {gt: 9.99975}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Malaysia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.6 kg/capita published
+    against 166.3 kg/capita implied by 5,841,597 tonnes; product = 99.8.
+  expect: {lt: 10.003}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Martinique}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 8.04 kg/capita published
+    against 12.44 kg/capita implied by 4,304 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Mauritius}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2017: 5.98 kg/capita published
+    against 16.72 kg/capita implied by 21,576 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Moldova}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 60.29 kg/capita published
+    against 1.659 kg/capita implied by 5,015 tonnes; product = 100.0.
+  expect: {gt: 10.0007}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Monaco}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.86 kg/capita published
+    against 115.7 kg/capita implied by 4,512 tonnes; product = 99.5.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Mongolia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.79 kg/capita published
+    against 126.4 kg/capita implied by 433,903 tonnes; product = 99.9.
+  expect: {lt: 9.99244}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Morocco}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2013: 11.68 kg/capita published
+    against 8.562 kg/capita implied by 289,284 tonnes; product = 100.0.
+  expect: {gt: 10.0001}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Myanmar}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 6101.38 kg/capita published
+    against 0.01639 kg/capita implied by 875 tonnes; product = 100.0.
+  expect: {gt: 10}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Niger}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2005: 2.48 kg/capita published
+    against 40.27 kg/capita implied by 554,000 tonnes; product = 99.9.
+  expect: {lt: 10.005}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Oman}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2024: 5.06 kg/capita published
+    against 19.75 kg/capita implied by 104,285 tonnes; product = 99.9.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Palestine}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2016: 0.65 kg/capita published
+    against 152.8 kg/capita implied by 707,791 tonnes; product = 99.3.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Panama}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2011: 119.35 kg/capita published
+    against 0.8379 kg/capita implied by 3,095 tonnes; product = 100.0.
+  expect: {gt: 10}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Peru}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 1.58 kg/capita published
+    against 63.14 kg/capita implied by 2,093,460 tonnes; product = 99.8.
+  expect: {lt: 10.007}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Philippines}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2019: 2.3 kg/capita published
+    against 43.53 kg/capita implied by 4,823,160 tonnes; product = 100.1.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Qatar}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 1.64 kg/capita published
+    against 60.92 kg/capita implied by 181,477 tonnes; product = 99.9.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Reunion}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 4.97 kg/capita published
+    against 20.1 kg/capita implied by 17,589 tonnes; product = 99.9.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Russia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 0.18 kg/capita published
+    against 557.6 kg/capita implied by 81,093,016 tonnes; product = 100.4.
+  expect: {lt: 10.0181}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Saint Vincent and the Grenadines}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2002: 75564.7 kg/capita published
+    against 0.001323 kg/capita implied by 0 tonnes; product = 100.0.
+  expect: {gt: 9.99921}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Saudi Arabia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2020: 1.79 kg/capita published
+    against 55.97 kg/capita implied by 1,734,527 tonnes; product = 100.2.
+  expect: {lt: 9.99831}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Seychelles}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 190.65 kg/capita published
+    against 0.5245 kg/capita implied by 65 tonnes; product = 100.0.
+  expect: {gt: 9.99952}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Singapore}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2020: 1.56 kg/capita published
+    against 63.91 kg/capita implied by 359,170 tonnes; product = 99.7.
+  expect: {lt: 9.9982}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: South Africa}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2017: 0.11 kg/capita published
+    against 903.6 kg/capita implied by 52,076,716 tonnes; product = 99.4.
+  expect: {lt: 10.0031}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Suriname}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 62888.6 kg/capita published
+    against 0.00159 kg/capita implied by 1 tonnes; product = 100.0.
+  expect: {gt: 9.99994}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Syria}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2003: 38889.8 kg/capita published
+    against 0.002571 kg/capita implied by 46 tonnes; product = 100.0.
+  expect: {gt: 10}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Tanzania}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2021: 92086.2 kg/capita published
+    against 0.001086 kg/capita implied by 68 tonnes; product = 100.0.
+  expect: {gt: 9.99982}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Thailand}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 30.11 kg/capita published
+    against 3.321 kg/capita implied by 238,135 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Togo}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2013: 621.53 kg/capita published
+    against 0.1724 kg/capita implied by 1,172 tonnes; product = 107.2.
+  expect: {gt: 10.3755}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Trinidad and Tobago}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2022: 4617.04 kg/capita published
+    against 0.02166 kg/capita implied by 32 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Tunisia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2020: 3.57 kg/capita published
+    against 28 kg/capita implied by 335,227 tonnes; product = 99.9.
+  expect: {lt: 10.0009}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Ukraine}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 20.07 kg/capita published
+    against 4.984 kg/capita implied by 188,048 tonnes; product = 100.0.
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: United Arab Emirates}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 1.24 kg/capita published
+    against 80.94 kg/capita implied by 861,330 tonnes; product = 100.4.
+  expect: {lt: 9.99942}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Uzbekistan}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 28.39 kg/capita published
+    against 3.523 kg/capita implied by 125,593 tonnes; product = 100.0.
+  expect: {gt: 10.0005}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Vietnam}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2023: 7.27 kg/capita published
+    against 13.76 kg/capita implied by 1,381,027 tonnes; product = 100.0.
+  expect: {lt: 10.0024}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Zambia}
+  action: drop
+  reason: >-
+    Published per-capita value is the reciprocal of the rate implied by EN_HAZ_GENV and
+    population (see the block comment above). 2005: 14.65 kg/capita published
+    against 6.827 kg/capita implied by 80,000 tonnes; product = 100.0.
+  expect: {gt: 10.0005}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open
+# Brunei is broken differently: its total (EN_HAZ_GENV) reads 0.00-0.01 tonnes while the
+# per-capita series reads 8.7-36 million "kg per capita". The two series look transposed or
+# mis-scaled against each other; either way no per-capita value here is usable.
+- indicator: value
+  match: {seriescode: EN_HAZ_PCAP, country: Brunei}
+  action: drop
+  reason: >-
+    Hazardous waste of 8.7-36 million kg per capita is physically impossible (the highest
+    credible national rate in the series is ~2,200 kg). Brunei's own EN_HAZ_GENV total reads
+    0.00-0.01 tonnes over the same years, so the two series are inconsistent by ~12 orders of
+    magnitude.
+  expect: {gt: 1000000}
+  provider: United Nations Statistics Division and United Nations Environment Programme
+  status: open


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

## Summary

Second pass on the UN SDG chart remap. #6579 landed the `2025-10-29` → `2026-07-31` update,
but 28 charts were rejected in chart-diff over conflicts with production, so they fell back to
old indicators. This PR re-runs the indicator upgrader from a fresh staging clone of production,
and — along the way — catches an upstream data error serious enough to justify its own correction.

Two committed changes, both small; most of the work reaches production through chart-diff.

| | charts before | charts after |
|---|---|---|
| `2026-07-31` (current) | 242 | **262** |
| `2025-10-29` | 20 | 6 |
| `2024-08-27` | 9 | 5 |
| `2023-08-16` | 6 | 3 |

Plus **2 narrative charts** (`share-of-workers-in-informal-employment`, `informal-unemployment-di`).

## 1. The remap

`wiz__variable_mapping` was rebuilt from scratch on this staging server (the previous PR's
mappings lived on its own staging server, which is gone). Old→new pairs match on the part of
`catalogPath` after the version, not on `shortName`: a handful of `_1`-suffixed tables share a
`shortName` within one dataset, so `shortName` alone is not a unique key.

| old dataset | old variables | paired | unmatched |
|---|---|---|---|
| `2023-08-16` (6193) | 4,295 | 3,082 | 1,213 |
| `2024-08-27` (6761) | 6,582 | 5,417 | 1,165 |
| `2025-10-29` (7278) | 8,328 | 8,145 | 183 |

Full coverage, not only the charted indicators, so Anomalist's upgrade detectors see everything.
17 charts and 2 narrative charts were remapped from those pairs.

**Four more mapped by hand.** These had no exact-path successor because the UN added or removed a
*dimension level*, not because the series was retired. Each was checked by pulling both indicators
off the staging API and comparing overlapping country-years before storing the mapping:

| Chart | Old → new | Evidence |
|---|---|---|
| `material-footprint-per-capita` | `EN_MAT_FTPRPC` → `… - Total or no breakdown` | World series agrees within ~4%; 1 → 17 entities |
| `material-footprint-per-unit-of-gdp` | `EN_MAT_FTPRPG` → `… - Total or no breakdown` | same, and the UN rebased the denominator from constant 2015 to constant 2020 USD |
| `share-of-the-population-reporting-having-felt-discriminated-against` | `VC_VOV_GDSD` → same series with age/education/quantile levels added | 95.6% of 136 overlapping points identical; 68 → 92 entities |
| `share-of-people-with-disputes-using-a-dispute-resolution-mechanism` | `SP_DISP_RESOL` → same series with `All areas` added | 100% of 14 overlapping points identical |

## 2. Bug fix: the upgrader CLI could not run

`indicator-upgrade upgrade` crashed on the first chart with
`DetachedInstanceError: ... lazy load operation of attribute 'patch_config' cannot proceed`.
`find_charts_from_variable_ids` closes its session before returning, and `_update_single_chart`
then reads `chart.patch_config.config` for the inheritance-pruning baseline (added in
c64f821b1a). `patch_config` is deliberately lazy on `gm.Chart`, and the relationship's own comment
says bulk callers should `selectinload` it — which the query now does. This is also why the
previous PR's upgrader run "was interrupted".

## 3. Upstream data error: 12.4.2 hazardous waste per capita

The 2026 Q2 release publishes `EN_HAZ_PCAP` as the **reciprocal** of the per-capita rate for
**71 of the 116** countries that have a usable total. The signature is algebraic, not statistical:

```
published_kg_per_capita  x  (EN_HAZ_GENV_tonnes * 1000 / population)  =  100
```

holds in every affected country-year. It runs in both directions, which is why it is easy to
miss — where the true rate is high the published value collapses (Russia 2023: 0.18 kg per
person against 558 implied by its own reported total), and where the true rate is low it becomes
enormous (Tanzania 2004: 211,720 kg per person against 0.00047 implied).

Confirmed to be upstream three independent ways:

1. The **raw snapshot** carries the values before any OWID processing (Russia 2023 = `0.17935`,
   Tanzania 2004 = `211720.3993`), and all 1,298 published country-years match a snapshot row 1:1.
2. The **SDG API** returns them today, labelled `units=KG`.
3. The garden step contains no handling for 12.4.2 — it is a straight passthrough.

Running the same test against the `2025-10-29` snapshot finds the signature for 3 countries, not
71, so it is new in this release. `EN_HAZ_GENV` (the total) and `EN_HAZ_GENGDP` are unaffected, as
are the sibling e-waste per-capita series — so the national reporting is intact and only this
derived series is wrong.

**Fix: drop, don't recompute.** `un_sdg.corrections.yml` gains 72 `drop` entries (the 71 countries
plus Brunei, whose per-capita reads 8.7–36 million kg against a total of 0.00–0.01 tonnes). The
indicator goes from 1,298 country-years over 117 countries to 445 over 45; Germany, France and
most of the EU are unaffected and are kept. Deriving kg per capita ourselves from the intact totals
would publish an OWID-computed number under a UN-attributed indicator; if we want that series it
belongs in step code with its own `description_processing`.

47 of the entries carry an `expect` guard and will fail the build once the UN corrects the values.
The other 25 cannot: around 10 kg per capita a number and its reciprocal-times-100 are the same
size, so no threshold separates them. That limitation is written into the file header, and the 47
guarded entries are enough to signal that all 71 need re-checking.

`hazardous-waste-generated-per-capita` (chart 5267) was therefore **reverted** to the `2025-10-29`
variable and its stored mapping deleted, so production keeps the last correct values rather than
showing a chart stripped of 72 countries.

## 4. Chart text

`material-footprint-per-capita` and `material-footprint-per-unit-of-gdp` said the total is the sum
of "biomass, fossil fuels, metal ores, and **non-metal ores**". That is not the producer's category
name and is close to a contradiction — the category is UNEP's *non-metallic minerals*, mostly sand,
gravel and crushed stone rather than ore. Both subtitles now read "non-metallic minerals such as
sand and gravel", matching the wording our own article on this metric already uses. Chart-config
edits on staging; no ETL change.

## What to look at in chart-diff

- **`material-footprint-per-unit-of-gdp`** — the UN rebased the denominator from constant 2015 to
  constant 2020 USD, so values drop ~5%. Any footnote naming "2015 US$" is now wrong.
- **`material-footprint-per-capita`** — the world series ends at 13.8 t instead of 12.3 t in 2022,
  with a step up after 2019. The chart was stranded on the `2024-08-27` vintage, so this diff spans
  two releases; the step came in with `2025-10-29`, not with this update, and is entirely
  non-metallic minerals (5.61 → 7.57 t/capita over 2018–22 while the other three materials stay
  flat within 0.1 t). Worth a glance: a +16% jump in global per-capita extraction in 2020, a COVID
  year, is odd, and the `2025-10-29` vintage published a 2023 point that this release withdrew.
- **`labor-share-of-gdp`** — 94 countries and 8 regional aggregates disappear against production.
  Not this update: the ILO cut the series from 204 to 107 entities in the **`2024-08-27`** release
  and the chart, stranded on `2023-08-16`, is absorbing that now. Confirmed upstream — the SDG API
  returns 0 observations for Afghanistan on `SL_EMP_GTOTL` and 22 for Germany. The 8 aggregates are
  only the `(UN)` → `(UN SDG)` rename and return under the new names.

## Still open

**Deliberately not updated**

- **`countries-reporting-progress-in-multi-stakeholder-development-effectiveness-monitoring-frameworks`
  (5574)** — to be rejected. Two causes, only one fixable. The chart follows `minTime: latest` and
  jumped 2018 → 2026, but 2026 is a partial reporting round (recipients: 20 countries across 10
  entities, against 148 across 49 in 2018). Separately, the UN withdrew every regional aggregate
  from the *providers* series `SG_PLN_MSTKSDG_P` — the API returns 0 observations for Europe,
  Northern America and Oceania, while the recipients series still returns them — so the chart's
  Providers panel is empty in every year, not just 2026, and pinning the year cannot bring it back.
  Restoring it would mean redesigning the panel around individual countries. Left for after the
  2026 round closes.

**13 charts need a replace-or-retire decision** — #6579's open item 1, unchanged. None can be
remapped mechanically; the UN retired or restructured the series, so picking a successor is an
editorial call.

| Chart | Stale indicator | What the new release offers |
|---|---|---|
| `prevalence-of-hepatitis-b-surface-antigen` | `SH_HAP_HBSAG` | `SH_HAP_HBSAG_26` is the obvious successor but is a **new methodology** — only 1% of overlapping points unchanged. Extends 2020 → 2024, 205 → 236 entities. |
| `death-rate-road-traffic-injuries` | `SH_STA_TRAF - Both sexes` | `SH_STA_TRAF` survives but the sex breakdown is gone **and it now carries only 2021** (chart runs 2000–2019). `SH_STA_TRAFN` also exists. |
| `nationally-determined-contributions` | `EN_NAD_CONTR - First` / `- Second` | Now a single series with one year (2025); the two-series structure has no successor. |
| `alcohol-consumption-per-capita-men-women` | `SH_ALC_CONSPT - Male` / `- Female` | Sex breakdown gone; a male-vs-female chart cannot survive it. |
| `share-of-students-achieving-minimum-proficiency-…` | `SE_TOT_PRFL - Grades 2/3` ×2 | The other four dimensions already moved; that education level is no longer published. Probably just drop the two dimensions. |
| `large-household-expenditures-health` | `SH_XPD_EARN25` | Successor family is `SH_OOP_XPD_EARNNET40` (net, 40%) — not 1:1 with the 25% gross series. |
| `share-of-population-with-large-household-expenditures-on-health-10pc` | `SH_XPD_EARN10` | Same family, same problem. |
| `numeracy-rate-in-adult-women-sdg` / `numeracy-rate-in-adult-men` | `SE_ADT_FUNS - … - Numeracy` | Retired; the new `SE_ADT_LITR` family has no numeracy equivalent. |
| `beach-litter` | `EN_MAR_BEALITSQ` | Retired; the new `EN_MAR_BEALIT_*` family is a different decomposition. |
| `countries-with-a-signed-bilateral-investment-treaty` / `…-an-inforce-…` | `SG_CPA_SIGN_BIT` / `SG_CPA_INFORCE_BIT` | Stranded since `2023-08-16`. 17.5.1 now publishes only `SG_CPA_OFDI`, a different concept. |
| `share-of-government-spending-…-monetary-poor` (unpublished) | `SD_XPD_MNPO` | 1.b.1 now publishes `SG_XPD_PR{,_EDUC,_HLTH,_SOC}`. |

Consequently the `2023-08-16`, `2024-08-27` and `2025-10-29` DAG entries still cannot be archived.

**Owed to the producer.** A report of the `EN_HAZ_PCAP` inversion is drafted for
`statistics@un.org` (UNSD maintains the database; UNEP, UNSD and UNITAR are the joint custodians
for 12.4.2) but **not yet sent**. The corrections carry `status: open` until it is.

**Carried over from #6579**, untouched here and independent of this remap: the 19 charts with an
upper time bound below the new data max, the stale narrative-chart subtitle on
`share-of-people-who-said-they-were-asked-for-a-bribe-or-paid-one`, the four near-miss
harmonization targets, `Asia (UN)` omitting Palestine, and the comms posts.

**Nobody checked.** The rendered output of the 20 remapped charts, beyond what chart-diff shows.
The four hand-mapped charts were verified on values, not on how they render.
