### PR TITLE
🔨 Say when a screenshot run found differences

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -94,11 +94,17 @@ def read_screenshots_status(path: Path) -> dict | None:
 
 
 def make_screenshots_line(status: dict | None, branch: str, head_sha: str | None) -> str:
-    """The Site-screenshots line: the compare link, plus how the run that produced it went.
+    """The Site-screenshots line: the compare link, plus what the run that produced it found.
 
     Worth stating because a failed run is invisible otherwise. The buildkite step soft
     fails, and a run that fails commits nothing, so the compare link keeps showing the
     previous run's diff - which reads exactly like a run that found no changes.
+
+    A finished run is not one state but two, and only one of them wants the reviewer's
+    attention: a branch that changes seven pages and a branch that changes none both used
+    to read as a plain tick. `changedPages` counts what the compare link shows, so the
+    branch that repaints the site says so. Absent from the status file - an ops host that
+    predates it, or a run that failed before committing - the line stays as it was.
 
     There is one status file for all branches, because every branch's screenshots are
     taken in the same working copy on lxc-manager-1. A run of another branch that landed
@@ -118,7 +124,13 @@ def make_screenshots_line(status: dict | None, branch: str, head_sha: str | None
         return f"⏳ the run for {pending} hasn't reported yet: {compare_url}"
 
     if status.get("status") == "ok":
-        return f"✅ {compare_url}"
+        changed_pages = status.get("changedPages")
+        if changed_pages is None:
+            return f"✅ {compare_url}"
+        if not changed_pages:
+            return f"✅ no changes: {compare_url}"
+        pages = "page" if len(changed_pages) == 1 else "pages"
+        return f"⚠️ {len(changed_pages)} {pages} changed: {compare_url}"
 
     return f"❌ the run failed, so {compare_url} is still the previous run's"
 

--- a/tests/apps/test_owidbot_grapher.py
+++ b/tests/apps/test_owidbot_grapher.py
@@ -22,7 +22,25 @@ def test_no_status_file_leaves_the_link_alone():
 
 
 def test_successful_run_is_marked():
+    # No changedPages: an ops host that predates the field, so the run is all we know
     assert make_screenshots_line(_status(), branch=BRANCH, head_sha=SHA) == f"✅ {COMPARE_URL}"
+
+
+def test_a_run_that_found_nothing_says_so():
+    line = make_screenshots_line(_status(changedPages=[]), branch=BRANCH, head_sha=SHA)
+    assert line == f"✅ no changes: {COMPARE_URL}"
+
+
+def test_changed_pages_are_worth_a_look():
+    # The case the plain tick used to hide: this branch repaints the site
+    status = _status(changedPages=["energy", "homepage", "life-expectancy-page"])
+    line = make_screenshots_line(status, branch=BRANCH, head_sha=SHA)
+    assert line == f"⚠️ 3 pages changed: {COMPARE_URL}"
+
+
+def test_one_changed_page_is_singular():
+    line = make_screenshots_line(_status(changedPages=["energy"]), branch=BRANCH, head_sha=SHA)
+    assert line == f"⚠️ 1 page changed: {COMPARE_URL}"
 
 
 def test_failed_run_says_the_link_is_stale():
@@ -64,6 +82,32 @@ def test_status_written_by_the_ops_script_parses(tmp_path):
     # The shape templates/lxc-manager/site-screenshots writes
     path = tmp_path / "site-screenshots-status.json"
     path.write_text(
-        json.dumps({"status": "ok", "branch": BRANCH, "grapherCommit": SHA, "finishedAt": "2026-08-21T08:00:00+00:00"})
+        json.dumps(
+            {
+                "status": "ok",
+                "branch": BRANCH,
+                "grapherCommit": SHA,
+                "finishedAt": "2026-08-21T08:00:00+00:00",
+                "changedPages": ["energy"],
+            }
+        )
     )
-    assert make_screenshots_line(read_screenshots_status(path), branch=BRANCH, head_sha=SHA) == f"✅ {COMPARE_URL}"
+    line = make_screenshots_line(read_screenshots_status(path), branch=BRANCH, head_sha=SHA)
+    assert line == f"⚠️ 1 page changed: {COMPARE_URL}"
+
+
+def test_a_failed_run_carries_no_changed_pages(tmp_path):
+    # The ops script leaves the field out rather than sending an empty list, which would
+    # claim the branch changes nothing
+    path = tmp_path / "site-screenshots-status.json"
+    path.write_text(
+        json.dumps(
+            {
+                "status": "failed",
+                "branch": BRANCH,
+                "grapherCommit": SHA,
+                "finishedAt": "2026-08-21T08:00:00+00:00",
+            }
+        )
+    )
+    assert make_screenshots_line(read_screenshots_status(path), branch=BRANCH, head_sha=SHA).startswith("❌")


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The Site-screenshots line in owidbot's comment said ✅ for every run that finished, so a branch that repaints all seven pages and a branch that changes nothing read the same, and the reviewer had to open the compare link to find out which they had.

owid/ops#640 records the pages each run changed in `site-screenshots-status.json`, counted as a three-dot diff against master so it matches what the compare link shows. A finished run now renders as one of three lines instead of one:

| status file | line |
|---|---|
| `changedPages: ["energy", "homepage", "life-expectancy-page"]` | ⚠️ 3 pages changed: *link* |
| `changedPages: []` | ✅ no changes: *link* |
| no `changedPages` (ops host predating the field, or a failed run) | ✅ *link* — unchanged behaviour |

One thing worth a nod: ⚠️ already prefixes "status file unreadable". The sentence after it separates the two, and the alternative was churning a rare state's emoji to free one up for a common one.

<details><summary>Details</summary>

`make_screenshots_line` reads `status.get("changedPages")` and distinguishes `None` (field absent → old behaviour) from `[]` (run finished, nothing changed). Ordering matters: the not-ours (⏳) and unreadable (⚠️) branches still come first, so a status file from another branch's run is never read for its page list.

Four tests added in `tests/apps/test_owidbot_grapher.py`: nothing changed, three pages changed, the singular "1 page changed", and a failed run carrying no field. `make check` and the file's 13 tests pass.

Deploy order doesn't matter: this handles a status file without the field, and ops#640 without this handles it as an unknown key.
</details>
