### PR TITLE
Drop "(on- and off-grid)" from total geothermal capacity description

### DIFF
--- a/etl/steps/data/garden/irena/2025-07-18/renewable_energy_statistics.meta.yml
+++ b/etl/steps/data/garden/irena/2025-07-18/renewable_energy_statistics.meta.yml
@@ -58,7 +58,7 @@ tables:
       geothermal__total:
         title: Geothermal capacity (total)
         description_short: |-
-          Total geothermal (on- and off-grid) electricity installed capacity, measured in megawatts.
+          Total geothermal electricity installed capacity, measured in megawatts.
         display:
           name: Geothermal (total)
         presentation:


### PR DESCRIPTION
> _Written by Claude Opus 4.7 — @pabloarosado at the wheel._

Comment on the chart `installed-geothermal-capacity` (field `descriptionShort`, comment id 104):

> @claude remove the on and off grid

Thread: http://staging-site-internal-comments-2/admin/grapher/installed-geothermal-capacity

This drops `(on- and off-grid)` from the `description_short` of `geothermal__total` in `etl/steps/data/garden/irena/2025-07-18/renewable_energy_statistics.meta.yml`. The sibling on-grid/off-grid indicators and the other `*__total` indicators (bioenergy, hydropower, solar, wind, renewables) still spell out the split — left untouched as out of scope.

This PR was opened automatically by the comment agent and needs human review.