### PR TITLE
🐛 Follow grapher's chart column renames for the ETL layer

### DIFF
--- a/apps/chart_config_id/cli.py
+++ b/apps/chart_config_id/cli.py
@@ -134,8 +134,8 @@ def lookup(config_file: Path, slug: str | None, chart_id: int | None, env_name: 
     console.print(f"Looking up {target} in [bold]{owid_env.conf.DB_NAME}[/bold] on {owid_env.conf.DB_HOST}")
 
     # Deliberately a plain SELECT of the columns we need rather than loading the ORM `Chart`: some
-    # environments (production, until the grapher release lands) lack the `catalogPath` /
-    # `configIdETL` columns the model declares, and selecting those would fail with "Unknown column".
+    # environments (production, until the grapher release lands) lack the `etlConfigCatalogPath` /
+    # `patchConfigIdETL` columns the model declares, and selecting those would fail with "Unknown column".
     if chart_id is not None:
         # `charts.id` is the primary key, so this matches at most one row — no ambiguity to resolve.
         query = (

--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -258,8 +258,8 @@ def cli(
                         cross_env_twin = diff.source_chart.id != diff.target_chart.id and (
                             same_config_uuid(diff.source_chart.configId, diff.target_chart.configId)
                             or (
-                                diff.source_chart.catalogPath
-                                and diff.source_chart.catalogPath == diff.target_chart.catalogPath
+                                diff.source_chart.etlConfigCatalogPath
+                                and diff.source_chart.etlConfigCatalogPath == diff.target_chart.etlConfigCatalogPath
                             )
                         )
 
@@ -304,7 +304,7 @@ def cli(
                                     target_api.upsert_chart_etl_config(
                                         chart_config_id=diff.target_chart.configId,
                                         grapher_config=migrated_etl_config,
-                                        catalog_path=diff.source_chart.catalogPath,
+                                        catalog_path=diff.source_chart.etlConfigCatalogPath,
                                         user_id=user_id,
                                     )
                                 target_api.update_chart(target_chart_id, migrated_config, user_id=user_id)
@@ -346,7 +346,7 @@ def cli(
                                     resp = target_api.upsert_chart_etl_config(
                                         chart_config_id=source_config_id,
                                         grapher_config=migrated_etl_config,
-                                        catalog_path=diff.source_chart.catalogPath,
+                                        catalog_path=diff.source_chart.etlConfigCatalogPath,
                                         user_id=user_id,
                                     )
                                     target_api.update_chart(resp["chartId"], migrated_config, user_id=user_id)

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -143,7 +143,7 @@ class ArticleRef:
 
 
 # TODO: Remove this guard (and the defer() in _get_target_charts) once
-# owid-grapher #6553 — which adds charts.catalogPath and charts.configIdETL — is
+# owid-grapher #6826 — which adds charts.etlConfigCatalogPath and charts.patchConfigIdETL — is
 # merged to master and deployed. Until then PRODUCTION's charts table lacks those
 # columns, so chart-diff (which queries prod) must not select or match on them.
 # We detect their presence at runtime instead of using a manual flag, so the
@@ -159,7 +159,7 @@ def _charts_table_has_etl_columns(engine) -> bool:
             text(
                 "SELECT COUNT(*) FROM information_schema.COLUMNS "
                 "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'charts' "
-                "AND COLUMN_NAME IN ('catalogPath', 'configIdETL')"
+                "AND COLUMN_NAME IN ('etlConfigCatalogPath', 'patchConfigIdETL')"
             )
         ).scalar()
     return n == 2
@@ -198,8 +198,8 @@ def _same_chart_across_envs(source_chart: gm.Chart, target_chart: gm.Chart) -> b
         return True
     if (
         _target_has_etl_columns(target_chart)
-        and source_chart.catalogPath
-        and source_chart.catalogPath == target_chart.catalogPath
+        and source_chart.etlConfigCatalogPath
+        and source_chart.etlConfigCatalogPath == target_chart.etlConfigCatalogPath
     ):
         return True
     # Legacy fallback for charts synced before config UUIDs were carried
@@ -216,7 +216,9 @@ def _is_cross_env_twin(source_chart: gm.Chart, target_chart: gm.Chart | None) ->
         return True
     if not _target_has_etl_columns(target_chart):
         return False
-    return bool(source_chart.catalogPath and source_chart.catalogPath == target_chart.catalogPath)
+    return bool(
+        source_chart.etlConfigCatalogPath and source_chart.etlConfigCatalogPath == target_chart.etlConfigCatalogPath
+    )
 
 
 def _target_updated_at_for_review(source_chart: gm.Chart, target_chart: gm.Chart | None) -> dt.datetime | None:
@@ -730,14 +732,14 @@ class ChartDiff:
                 if target_has_cols:
                     target_charts_list = gm.Chart.load_charts(target_session, chart_ids=chart_ids)
                 else:
-                    # prod doesn't have charts.catalogPath/configIdETL yet, so don't
+                    # prod doesn't have charts.etlConfigCatalogPath/patchConfigIdETL yet, so don't
                     # SELECT them (it would raise "Unknown column"). See
                     # _charts_table_has_etl_columns.
                     target_charts_list = list(
                         target_session.scalars(
                             select(gm.Chart)
                             .where(gm.Chart.id.in_(list(chart_ids)))
-                            .options(defer(gm.Chart.catalogPath), defer(gm.Chart.configIdETL))
+                            .options(defer(gm.Chart.etlConfigCatalogPath), defer(gm.Chart.patchConfigIdETL))
                         ).all()
                     )
                     if not target_charts_list:
@@ -761,16 +763,16 @@ class ChartDiff:
 
                 stmt = select(gm.Chart).where(gm.Chart.configId == source_chart.configId)
                 if not target_has_cols:
-                    stmt = stmt.options(defer(gm.Chart.catalogPath), defer(gm.Chart.configIdETL))
+                    stmt = stmt.options(defer(gm.Chart.etlConfigCatalogPath), defer(gm.Chart.patchConfigIdETL))
                 twin = target_session.scalars(stmt).one_or_none()
                 if twin is not None:
                     target_charts[source_chart_id] = twin
                     continue
 
-                if target_has_cols and source_chart.catalogPath:
+                if target_has_cols and source_chart.etlConfigCatalogPath:
                     try:
                         target_charts[source_chart_id] = gm.Chart.load_chart(
-                            target_session, catalog_path=source_chart.catalogPath
+                            target_session, catalog_path=source_chart.etlConfigCatalogPath
                         )
                     except NoResultFound:
                         pass

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -392,9 +392,11 @@ class Chart(Base):
     configId: Mapped[str] = mapped_column(CHAR(36))
     # The authored layer, as its own chart_configs row. `configId` is what renders.
     patchConfigId: Mapped[bytes] = mapped_column(CHAR(36))
-    configIdETL: Mapped[bytes | None] = mapped_column(CHAR(36), init=False)
-    # ETL step that authored this chart (mirrors multi_dim_data_pages.catalogPath); NULL for hand-authored charts.
-    catalogPath: Mapped[str | None] = mapped_column(VARCHAR(767), init=False)
+    # The ETL-authored layer, as its own chart_configs row (mirrors variables.patchConfigIdETL, per chart).
+    patchConfigIdETL: Mapped[bytes | None] = mapped_column(CHAR(36), init=False)
+    # ETL step that authored this chart's ETL layer (mirrors multi_dim_data_pages.catalogPath); NULL for
+    # hand-authored charts. Not an identifier: it records the current owner and may change on a step rename.
+    etlConfigCatalogPath: Mapped[str | None] = mapped_column(VARCHAR(767), init=False)
     isInheritanceEnabled: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'1'"))
     forceDatapage: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'0'"))
     createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), init=False)
@@ -464,7 +466,7 @@ class Chart(Base):
         elif slug:
             cond = cls.slug == slug
         elif catalog_path:
-            cond = cls.catalogPath == catalog_path
+            cond = cls.etlConfigCatalogPath == catalog_path
         elif config_id:
             cond = cls.configId == config_id
         else:
@@ -532,7 +534,7 @@ class Chart(Base):
         """Load the chart's ETL-authored config layer, if it has one."""
         assert self.id, "Chart must come from a database"
         etl_config = session.scalar(
-            select(ChartConfig.config).join(Chart, ChartConfig.id == Chart.configIdETL).where(Chart.id == self.id)
+            select(ChartConfig.config).join(Chart, ChartConfig.id == Chart.patchConfigIdETL).where(Chart.id == self.id)
         )
         return copy.deepcopy(etl_config) if etl_config else None
 

--- a/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
@@ -15,7 +15,7 @@ def _chart(chart_id: int, created_at: datetime, catalog_path: str | None = None,
         id=chart_id,
         createdAt=created_at,
         updatedAt=created_at + timedelta(hours=1),
-        catalogPath=catalog_path,
+        etlConfigCatalogPath=catalog_path,
         configId=config_id or f"config-uuid-{chart_id}",
     )
 


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Stacked on [#6511 "Charts as first-class citizens in ETL, addressed by chart config UUID"](https://github.com/owid/etl/pull/6511). One commit, no behaviour change.

[owid/owid-grapher#6826 "ETL-authored chart configs, addressed by chart config UUID"](https://github.com/owid/owid-grapher/pull/6826) renamed two columns of the `charts` table after the ETL branch was last refreshed:

- `charts.configIdETL` → `charts.patchConfigIdETL` (an authored layer, like `charts.patchConfigId` and `variables.patchConfigIdETL`)
- `charts.catalogPath` → `charts.etlConfigCatalogPath` (the step that owns the ETL layer; not an identifier)

Without this, the ETL branch cannot load a chart from a grapher running that PR: chart-diff fails with `Unknown column 'charts.configIdETL'` as soon as a chart is listed (observed on `staging-site-chart-diff-layers`).

This renames the ORM columns and every read of them in chart-diff, chart-sync and `etl chart-config-id`, and makes the probe that checks whether production already has the columns look for the new names.

## Test plan

- Unit tests for chart-diff, the grapher model and the chart-config-id CLI pass; `make check` clean.
- Against a staging server running the grapher branch, chart-diff and chart-sync (dry run) were exercised end to end on the chick-culling chart: unrelated production edits are not listed, a rebuild or a staging admin edit is listed, a production edit after the staging server was created shows as a conflict, and an approval expires when production is edited afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)