### PR TITLE
📊 Remap UN SDG fossil-fuel subsidy charts

### DIFF
--- a/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
+++ b/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
@@ -861,3 +861,126 @@
   expect: {gt: 1000000}
   provider: United Nations Statistics Division and United Nations Environment Programme
   status: open
+
+# ---------------------------------------------------------------------------------------------
+# Indicator 12.c.1 (fossil-fuel subsidies), series ER_FFS_CMPT_CD (billions of nominal USD),
+# ER_FFS_CMPT_GDP (% of GDP) and ER_FFS_CMPT_PC_CD (per capita): three unrelated defects in the
+# 2026 Q2 release, all three of which land on a published chart. The UN passes the
+# OECD/IEA/IMF figures straight through, so two are inherited from the OECD Inventory of
+# Support Measures for Fossil Fuels and one is introduced by UNSD. Full workup in
+# owid/owid-issues#2516.
+#
+#   1. Latvia 2022 = $21.58bn, against $0.22bn in 2021 and $0.42bn in 2023 -- 50 to 100 times
+#      its own neighbouring years. That is 59.3% of Latvian GDP and $11,470 per person, the
+#      largest per-capita value anywhere in the indicator by a factor of 2.5 (next highest:
+#      Kuwait 2022 at $4,510). The OECD's own SDMX API returns 21.57652 for Latvia 2022, so
+#      the UN copied it faithfully and the error is the OECD's.
+#
+#   2. Italy 2024 = exact 0 after $19.51bn in 2023. It is the only country in the release whose
+#      2024 value is 0 following a 2023 value above $50 per capita. The OECD reports $21.78bn
+#      for Italy 2024; the UN uses Italy's own ISTAT submission, which has no 2024 figure, and
+#      encodes the gap as a zero. The % of GDP series has no 2024 value for Italy at all, which
+#      is why only two of the three series are corrected here.
+#
+#   3. Venezuela 2010-2014 = exact 0 in all three series, where the 2023-08-16 release reported
+#      $744-1,185 per capita for those same years. Venezuela is still in the OECD-IEA
+#      82-country list, so this is not a coverage withdrawal -- the years are missing and
+#      encoded as zero.
+#
+# Zeros elsewhere in this indicator are NOT errors: 596 of them are genuine reports of no
+# subsidy and the count is stable across releases (the 2023-08-16 release had 562), so only
+# these two zero blocks are dropped. The Venezuela entries match on the zero itself rather than
+# on a year list, so an upstream fix trips the no-match assertion.
+#
+# What this cannot fix: the UN's regional and world aggregates are published by the UN, not
+# computed by us, so they still contain the bad Latvian value and the missing Italian and
+# Venezuelan ones. Latvia 2022 is ~1.3% of the 2022 world total ($21.58bn of $1,658.70bn).
+#
+# Also known and NOT corrected here: Norway 2019 ($0.58bn) and 2022 ($0.43bn) sit between
+# $7.79bn and $5.16bn neighbours because the OECD left those two years on the old basis. That
+# is a basis inconsistency rather than an impossible number, and dropping it would remove real
+# OECD data, so it is left in place and reported upstream instead.
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_CD, country: Latvia, year: 2022}
+  action: drop
+  reason: >-
+    Fossil-fuel subsidies of $21.58bn for Latvia in 2022, against $0.22bn in 2021 and $0.42bn
+    in 2023. Equivalent to 59.3% of GDP and $11,470 per person, 2.5x the largest per-capita
+    value anywhere else in the indicator. The OECD's SDMX API returns the same figure, so the
+    error is inherited rather than introduced by the UN.
+  expect: {gt: 20}
+  provider: Organisation for Economic Co-operation and Development
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Latvia, year: 2022}
+  action: drop
+  reason: >-
+    Fossil-fuel subsidies of 59.31% of GDP for Latvia in 2022, against 0.61% in 2021 and 1.17%
+    in 2023. Follows directly from the erroneous $21.58bn total; see the ER_FFS_CMPT_CD entry.
+  expect: {gt: 50}
+  provider: Organisation for Economic Co-operation and Development
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_PC_CD, country: Latvia, year: 2022}
+  action: drop
+  reason: >-
+    Fossil-fuel subsidies of $11,470 per person for Latvia in 2022, against $115 in 2021 and
+    $224 in 2023, and 2.5x the largest value anywhere else in the indicator (Kuwait 2022, at
+    $4,510). Follows directly from the erroneous $21.58bn total; see the ER_FFS_CMPT_CD entry.
+  expect: {gt: 10000}
+  provider: Organisation for Economic Co-operation and Development
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_CD, country: Italy, year: 2024}
+  action: drop
+  reason: >-
+    Italy's 2024 total is an exact 0 after $19.51bn in 2023, and the OECD reports $21.78bn for
+    that year. The UN uses Italy's ISTAT submission, which has no 2024 figure, and encodes the
+    missing year as zero rather than leaving it blank.
+  expect: {eq: 0}
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_PC_CD, country: Italy, year: 2024}
+  action: drop
+  reason: >-
+    Italy's 2024 per-capita value is an exact 0 after $327.86 in 2023. Missing year encoded as
+    zero; see the ER_FFS_CMPT_CD entry.
+  expect: {eq: 0}
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_CD, country: Venezuela, value: 0}
+  action: drop
+  reason: >-
+    Venezuela reports an exact 0 for 2010-2014 and $4.98-18.17bn for every year from 2015 on.
+    The 2023-08-16 release published $21.36-35.35bn for those same years, and Venezuela remains
+    in the OECD-IEA 82-country coverage list, so these are missing years encoded as zero rather
+    than a genuine absence of subsidies.
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Venezuela, value: 0}
+  action: drop
+  reason: >-
+    Venezuela reports an exact 0% of GDP for 2010-2014 and 1.61-15.74% for every year from 2015
+    on. Missing years encoded as zero; see the ER_FFS_CMPT_CD entry.
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_PC_CD, country: Venezuela, value: 0}
+  action: drop
+  reason: >-
+    Venezuela reports an exact $0 per person for 2010-2014 and $161-644 for every year from
+    2015 on, where the 2023-08-16 release published $744-1,185. Missing years encoded as zero;
+    see the ER_FFS_CMPT_CD entry.
+  provider: United Nations Statistics Division
+  status: open

--- a/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
+++ b/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
@@ -986,27 +986,57 @@
   status: open
 
 # ---------------------------------------------------------------------------------------------
-# Indicator 12.c.1, series ER_FFS_CMPT_GDP: the ratio series outruns its own numerator. Denmark
-# and Poland are the only two entities in the whole indicator with 2025 and 2026 values, and
-# both are exact carry-forwards of their 2024 figure (SDG API, ER_FFS_CMPT_GDP: Denmark
-# 2024 = 2025 = 2026 = 0.23775; Poland 2024 = 2025 = 2026 = 0.00215). The subsidy total
-# ER_FFS_CMPT_CD stops at 2024 for every country including these two, so there is no numerator
-# from which a 2025 or 2026 share could have been measured.
+# Indicator 12.c.1, series ER_FFS_CMPT_GDP (fossil-fuel subsidies as a share of GDP): two more
+# defects, both confined to this one series of the three.
 #
-# Left in, they push the time axis of every chart on this series two years past the data: the
-# map lands on 2026 with two entities reporting, and the timeline runs to 2026 while the World
-# series ends in 2024.
+#   1. Poland's whole series is published as a FRACTION while labelled PERCENT, so it is ~100x
+#      too small. The SDG API returns 0.00089-0.00557 for 2015-2024, which renders as 0.00-0.01%
+#      on our charts, while Poland's own reported total is $0.62-2.71bn. Dividing that total by
+#      Poland's nominal GDP reproduces the published number as a fraction almost exactly --
+#      2020: 2.71/599.4 = 0.452% against a published 0.00448; 2022: 0.62/688 = 0.090% against
+#      0.00089 -- and Poland is the only entity in the indicator whose total exceeds $0.1bn
+#      while its share reads 0. Denmark, by contrast, is in percent (1.00931/424 = 0.238%
+#      against a published 0.23775), as is every other country checked. Poland's per-capita
+#      series agrees with its total (25.32 $/capita x 38.5m = $0.975bn against a reported
+#      $0.98bn), so the total is intact and only the share is mis-scaled.
 #
-# The guard can only be a value band, not "the total is missing" -- the corrections grammar
-# cannot compare against another series. A genuine 2025 figure that happens to land inside the
-# band would still be dropped; a revised one outside it fails the build.
+#      Dropped rather than rescaled. Multiplying by 100 would publish an OWID-adjusted number
+#      under a UN-attributed indicator, which is the trade #6760 declined for EN_HAZ_PCAP; and
+#      2024 does not fit the pattern as cleanly as 2015-2023 (implied GDP $456bn against
+#      Poland's actual ~$915bn), so at least one year may be wrong for a second reason. Poland
+#      keeps its total and per-capita series, which are unaffected.
+#
+#   2. Denmark and Poland are the only two entities in the indicator with 2025 and 2026 values,
+#      and both are exact carry-forwards of their 2024 figure (SDG API: Denmark
+#      2024 = 2025 = 2026 = 0.23775; Poland 2024 = 2025 = 2026 = 0.00215). The subsidy total
+#      ER_FFS_CMPT_CD stops at 2024 for every country, so there is no numerator from which a
+#      2025 or 2026 share could have been measured. Left in, they push the time axis of every
+#      chart on this series two years past the data: the map lands on 2026 with two entities
+#      reporting, while the World series ends in 2024.
+#
+#      The guard here can only be a value band, not "the total is missing" -- the corrections
+#      grammar cannot compare one series against another. A genuine 2025 figure that happened to
+#      land inside the band would still be dropped; a revised one outside it fails the build.
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Poland}
+  action: drop
+  reason: >-
+    Published as a fraction while labelled PERCENT: 0.00089-0.00557 for 2015-2024, i.e. ~100x
+    too small, against a reported subsidy total of $0.62-2.71bn. Poland is the only entity in
+    the indicator whose total exceeds $0.1bn while its share reads 0, and its own per-capita
+    series is consistent with the total, so only this series is mis-scaled. Also covers the 2025
+    and 2026 carry-forwards, for which no subsidy total is published.
+  expect: {lt: 0.01}
+  provider: United Nations Statistics Division
+  status: open
+
 - indicator: value
   match: {seriescode: ER_FFS_CMPT_GDP, country: Denmark, year: 2025}
   action: drop
   reason: >-
-    Fossil-fuel subsidies as a share of GDP for a year in which the subsidy total is not
-    published for any country. The value is an exact carry-forward of Denmark's 2024 figure
-    (0.23775), not a measured 2025 observation.
+    Share of GDP for a year in which the subsidy total is not published for any country. The
+    value is an exact carry-forward of Denmark's 2024 figure (0.23775), not a measured 2025
+    observation.
   expect: {gt: 0.23, lt: 0.24}
   provider: United Nations Statistics Division
   status: open
@@ -1020,39 +1050,3 @@
   expect: {gt: 0.23, lt: 0.24}
   provider: United Nations Statistics Division
   status: open
-
-- indicator: value
-  match: {seriescode: ER_FFS_CMPT_GDP, country: Poland, year: 2025}
-  action: drop
-  reason: >-
-    As for Denmark: an exact carry-forward of Poland's 2024 figure (0.00215) in a year with no
-    published subsidy total. Poland's whole share series is also affected by the unit problem
-    noted below.
-  expect: {gt: 0.001, lt: 0.003}
-  provider: United Nations Statistics Division
-  status: open
-
-- indicator: value
-  match: {seriescode: ER_FFS_CMPT_GDP, country: Poland, year: 2026}
-  action: drop
-  reason: >-
-    As for 2025: an exact carry-forward of Poland's 2024 figure (0.00215) in a year with no
-    published subsidy total.
-  expect: {gt: 0.001, lt: 0.003}
-  provider: United Nations Statistics Division
-  status: open
-
-# NOT corrected, but known and reported: Poland's ER_FFS_CMPT_GDP is published as a FRACTION
-# while labelled PERCENT, so it is ~100x too small. The SDG API returns 0.00089-0.00557 for
-# 2015-2024, which renders as 0.00-0.01% on our charts, while Poland's own reported total is
-# $0.62-2.71bn. Dividing the total by Poland's nominal GDP reproduces the published number as a
-# fraction almost exactly -- 2020: 2.71/599.4 = 0.452% against a published 0.00448; 2022:
-# 0.62/688 = 0.090% against 0.00089 -- and Poland is the only entity in the indicator whose
-# total is above $0.1bn while its share reads 0. Denmark, by contrast, is in percent
-# (1.00931/424 = 0.238% against a published 0.23775), as is every other country checked.
-# Poland's per-capita series agrees with its total (25.32 $/capita x 38.5m = $0.975bn against a
-# reported $0.98bn), so the total is fine and only the share is mis-scaled.
-#
-# Left uncorrected pending a decision on whether to rescale (x100) or drop: rescaling publishes
-# an OWID-adjusted number under a UN-attributed indicator, which is the trade #6760 declined for
-# EN_HAZ_PCAP.

--- a/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
+++ b/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
@@ -984,3 +984,75 @@
     see the ER_FFS_CMPT_CD entry.
   provider: United Nations Statistics Division
   status: open
+
+# ---------------------------------------------------------------------------------------------
+# Indicator 12.c.1, series ER_FFS_CMPT_GDP: the ratio series outruns its own numerator. Denmark
+# and Poland are the only two entities in the whole indicator with 2025 and 2026 values, and
+# both are exact carry-forwards of their 2024 figure (SDG API, ER_FFS_CMPT_GDP: Denmark
+# 2024 = 2025 = 2026 = 0.23775; Poland 2024 = 2025 = 2026 = 0.00215). The subsidy total
+# ER_FFS_CMPT_CD stops at 2024 for every country including these two, so there is no numerator
+# from which a 2025 or 2026 share could have been measured.
+#
+# Left in, they push the time axis of every chart on this series two years past the data: the
+# map lands on 2026 with two entities reporting, and the timeline runs to 2026 while the World
+# series ends in 2024.
+#
+# The guard can only be a value band, not "the total is missing" -- the corrections grammar
+# cannot compare against another series. A genuine 2025 figure that happens to land inside the
+# band would still be dropped; a revised one outside it fails the build.
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Denmark, year: 2025}
+  action: drop
+  reason: >-
+    Fossil-fuel subsidies as a share of GDP for a year in which the subsidy total is not
+    published for any country. The value is an exact carry-forward of Denmark's 2024 figure
+    (0.23775), not a measured 2025 observation.
+  expect: {gt: 0.23, lt: 0.24}
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Denmark, year: 2026}
+  action: drop
+  reason: >-
+    As for 2025: an exact carry-forward of Denmark's 2024 figure (0.23775) in a year with no
+    published subsidy total.
+  expect: {gt: 0.23, lt: 0.24}
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Poland, year: 2025}
+  action: drop
+  reason: >-
+    As for Denmark: an exact carry-forward of Poland's 2024 figure (0.00215) in a year with no
+    published subsidy total. Poland's whole share series is also affected by the unit problem
+    noted below.
+  expect: {gt: 0.001, lt: 0.003}
+  provider: United Nations Statistics Division
+  status: open
+
+- indicator: value
+  match: {seriescode: ER_FFS_CMPT_GDP, country: Poland, year: 2026}
+  action: drop
+  reason: >-
+    As for 2025: an exact carry-forward of Poland's 2024 figure (0.00215) in a year with no
+    published subsidy total.
+  expect: {gt: 0.001, lt: 0.003}
+  provider: United Nations Statistics Division
+  status: open
+
+# NOT corrected, but known and reported: Poland's ER_FFS_CMPT_GDP is published as a FRACTION
+# while labelled PERCENT, so it is ~100x too small. The SDG API returns 0.00089-0.00557 for
+# 2015-2024, which renders as 0.00-0.01% on our charts, while Poland's own reported total is
+# $0.62-2.71bn. Dividing the total by Poland's nominal GDP reproduces the published number as a
+# fraction almost exactly -- 2020: 2.71/599.4 = 0.452% against a published 0.00448; 2022:
+# 0.62/688 = 0.090% against 0.00089 -- and Poland is the only entity in the indicator whose
+# total is above $0.1bn while its share reads 0. Denmark, by contrast, is in percent
+# (1.00931/424 = 0.238% against a published 0.23775), as is every other country checked.
+# Poland's per-capita series agrees with its total (25.32 $/capita x 38.5m = $0.975bn against a
+# reported $0.98bn), so the total is fine and only the share is mis-scaled.
+#
+# Left uncorrected pending a decision on whether to rescale (x100) or drop: rescaling publishes
+# an OWID-adjusted number under a UN-attributed indicator, which is the trade #6760 declined for
+# EN_HAZ_PCAP.

--- a/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
+++ b/etl/steps/data/garden/un/2026-07-31/un_sdg.corrections.yml
@@ -992,18 +992,19 @@
 #   1. Poland's whole series is published as a FRACTION while labelled PERCENT, so it is ~100x
 #      too small. The SDG API returns 0.00089-0.00557 for 2015-2024, which renders as 0.00-0.01%
 #      on our charts, while Poland's own reported total is $0.62-2.71bn. Dividing that total by
-#      Poland's nominal GDP reproduces the published number as a fraction almost exactly --
-#      2020: 2.71/599.4 = 0.452% against a published 0.00448; 2022: 0.62/688 = 0.090% against
+#      Poland's nominal GDP (World Bank, NY.GDP.MKTP.CD) reproduces the published number as a
+#      fraction almost exactly --
+#      2020: 2.71/605.9 = 0.447% against a published 0.00448; 2022: 0.62/695.6 = 0.089% against
 #      0.00089 -- and Poland is the only entity in the indicator whose total exceeds $0.1bn
-#      while its share reads 0. Denmark, by contrast, is in percent (1.00931/424 = 0.238%
+#      while its share reads 0. Denmark, by contrast, is in percent (1.00931/424.5 = 0.238%
 #      against a published 0.23775), as is every other country checked. Poland's per-capita
 #      series agrees with its total (25.32 $/capita x 38.5m = $0.975bn against a reported
 #      $0.98bn), so the total is intact and only the share is mis-scaled.
 #
 #      Dropped rather than rescaled. Multiplying by 100 would publish an OWID-adjusted number
 #      under a UN-attributed indicator, which is the trade #6760 declined for EN_HAZ_PCAP; and
-#      2024 does not fit the pattern as cleanly as 2015-2023 (implied GDP $456bn against
-#      Poland's actual ~$915bn), so at least one year may be wrong for a second reason. Poland
+#      2024 does not fit the pattern as cleanly as 2015-2023 (implied GDP $455.8bn against
+#      Poland's actual $917.8bn), so that year may be wrong for a second reason. Poland
 #      keeps its total and per-capita series, which are unaffected.
 #
 #   2. Denmark and Poland are the only two entities in the indicator with 2025 and 2026 values,

--- a/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
@@ -869,7 +869,7 @@ tables:
           - "{definitions.description_key_fossil_fuel_subsidies_united_states}"
           - "{definitions.description_key_fossil_fuel_subsidies_northern_america}"
         description_processing: |-
-          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; Venezuela from 2010 to 2014, where missing data is reported as zero; and Denmark and Poland in 2025 and 2026, where the source repeats their 2024 value in years for which no subsidy total is published.
+          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; Venezuela from 2010 to 2014, where missing data is reported as zero; Poland's whole series, which the source publishes as a fraction rather than a percentage, making it around 100 times too small; and Denmark in 2025 and 2026, where the source repeats its 2024 value in years for which no subsidy total is published.
         presentation:
           grapher_config:
             note: "{definitions.note_fossil_fuel_subsidies_united_states}"

--- a/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
@@ -87,6 +87,15 @@ definitions:
   description_key_ilo_national_estimates: |-
     This data comes from the International Labour Organization’s ILOSTAT database, which compiles labor statistics from national sources. Underlying national surveys differ in design and coverage, so cross-country comparisons should be made with some caution.
 
+  description_key_fossil_fuel_subsidies_united_states: |-
+    Figures for the United States exclude the fossil-fuel support measures recorded in the OECD's Inventory of Support Measures for Fossil Fuels. In December 2025, the United States asked the OECD to remove its data from that inventory, and the OECD removed it for every year, not only recent ones. Only a small residual reported by other sources remains, so figures for the United States are not comparable with other countries, and are much lower than in earlier versions of this data.
+
+  description_key_fossil_fuel_subsidies_northern_america: |-
+    The figure for Northern America excludes the same OECD support measures for the United States, so it is not comparable with other regions or with earlier versions of this data.
+
+  note_fossil_fuel_subsidies_united_states: |-
+    Data for the United States excludes OECD subsidy data, removed at the request of the United States. It is not comparable with other countries, and is lower than in earlier versions of this data.
+
   note_icls_13: |-
     Employment is defined in line with the [13th ICLS](#dod:13-icls) and includes the production of goods for own use, such as subsistence farming.
 
@@ -834,3 +843,45 @@ tables:
         display:
           numDecimalPlaces: 1
           tolerance: 5
+
+  # 12.c.1 -- fossil-fuel subsidies. The three series share a caveat that is invisible in the
+  # data: the OECD deleted the United States from its Inventory of Support Measures for Fossil
+  # Fuels at the US's request in December 2025, retroactively for all years, so the US series is
+  # flat at roughly one-eighth of its former level with no break to signal it. See
+  # owid/owid-issues#2516, and un_sdg.corrections.yml for the separate Latvia/Italy/Venezuela
+  # source errors in the same indicator.
+  _12_c_1__er_ffs_cmpt_cd:
+    variables:
+      _12_c_1__er_ffs_cmpt_cd:
+        description_key:
+          - "{definitions.description_key_fossil_fuel_subsidies_united_states}"
+          - "{definitions.description_key_fossil_fuel_subsidies_northern_america}"
+        description_processing: |-
+          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; and Italy in 2024 and Venezuela from 2010 to 2014, where missing data is reported as zero.
+        presentation:
+          grapher_config:
+            note: "{definitions.note_fossil_fuel_subsidies_united_states}"
+
+  _12_c_1__er_ffs_cmpt_gdp:
+    variables:
+      _12_c_1__er_ffs_cmpt_gdp:
+        description_key:
+          - "{definitions.description_key_fossil_fuel_subsidies_united_states}"
+          - "{definitions.description_key_fossil_fuel_subsidies_northern_america}"
+        description_processing: |-
+          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; and Venezuela from 2010 to 2014, where missing data is reported as zero.
+        presentation:
+          grapher_config:
+            note: "{definitions.note_fossil_fuel_subsidies_united_states}"
+
+  _12_c_1__er_ffs_cmpt_pc_cd:
+    variables:
+      _12_c_1__er_ffs_cmpt_pc_cd:
+        description_key:
+          - "{definitions.description_key_fossil_fuel_subsidies_united_states}"
+          - "{definitions.description_key_fossil_fuel_subsidies_northern_america}"
+        description_processing: |-
+          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; and Italy in 2024 and Venezuela from 2010 to 2014, where missing data is reported as zero.
+        presentation:
+          grapher_config:
+            note: "{definitions.note_fossil_fuel_subsidies_united_states}"

--- a/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
@@ -94,7 +94,7 @@ definitions:
     The figure for Northern America excludes the same OECD support measures for the United States, so it is not comparable with other regions or with earlier versions of this data.
 
   note_fossil_fuel_subsidies_united_states: |-
-    Data for the United States excludes OECD subsidy data, removed at the request of the United States. It is not comparable with other countries, and is lower than in earlier versions of this data.
+    Data for the US excludes OECD subsidy data, which the US asked the OECD to remove. It is not comparable with other countries, and is lower than in earlier versions of this data.
 
   note_icls_13: |-
     Employment is defined in line with the [13th ICLS](#dod:13-icls) and includes the production of goods for own use, such as subsistence farming.

--- a/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
@@ -848,8 +848,8 @@ tables:
   # data: the OECD deleted the United States from its Inventory of Support Measures for Fossil
   # Fuels at the US's request in December 2025, retroactively for all years, so the US series is
   # flat at roughly one-eighth of its former level with no break to signal it. See
-  # owid/owid-issues#2516, and un_sdg.corrections.yml for the separate Latvia/Italy/Venezuela
-  # source errors in the same indicator.
+  # owid/owid-issues#2516, and un_sdg.corrections.yml for the five separate source errors in the
+  # same indicator (Latvia, Italy, Venezuela, Poland, Denmark).
   _12_c_1__er_ffs_cmpt_cd:
     variables:
       _12_c_1__er_ffs_cmpt_cd:

--- a/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2026-07-31/un_sdg.meta.yml
@@ -869,7 +869,7 @@ tables:
           - "{definitions.description_key_fossil_fuel_subsidies_united_states}"
           - "{definitions.description_key_fossil_fuel_subsidies_northern_america}"
         description_processing: |-
-          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; and Venezuela from 2010 to 2014, where missing data is reported as zero.
+          Values we consider erroneous are not shown: Latvia in 2022, which the source reports as 50 to 100 times its own values for 2021 and 2023; Venezuela from 2010 to 2014, where missing data is reported as zero; and Denmark and Poland in 2025 and 2026, where the source repeats their 2024 value in years for which no subsidy total is published.
         presentation:
           grapher_config:
             note: "{definitions.note_fossil_fuel_subsidies_united_states}"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

## Summary

The three fossil-fuel subsidy charts were held back from #6760's remap while
[owid-issues#2516](https://github.com/owid/owid-issues/issues/2516) was open: the 2026 Q2 release
cuts US subsidies by ~85% in every year back to 2010, because the OECD removed the United States
from its Inventory of Support Measures for Fossil Fuels at the US's request and stripped all back
years, and the resulting series is flat with no break to tell a reader the US is measured
differently. That issue now has a decision, so this PR remaps the three charts and ships the
annotations agreed there.

Verifying the remapped charts surfaced two more defects in indicator 12.c.1, neither of them
mentioned in the original issue. Together with three of the four it did list, eleven correction
entries drop them.

| Chart | id | was on | now on |
|---|---|---|---|
| [`fossil-fuel-subsidies`](https://ourworldindata.org/grapher/fossil-fuel-subsidies) | 3856 | `2025-10-29` | `2026-07-31` |
| [`fossil-fuel-subsidies-gdp`](https://ourworldindata.org/grapher/fossil-fuel-subsidies-gdp) | 3854 | `2023-08-16` | `2026-07-31` |
| [`fossil-fuel-subsidies-per-capita`](https://ourworldindata.org/grapher/fossil-fuel-subsidies-per-capita) | 3855 | `2023-08-16` | `2026-07-31` |

No narrative charts use these indicators. These were the last three charts on an old `un_sdg`
version with a mechanical successor; the 14 that remain are all replace-or-retire cases carried
over from #6760.

## 1. The annotations

The decision on the issue, implemented as agreed:

- **`description_key` on all three indicators** — one entry saying US figures exclude the OECD
  Inventory support measures, removed at the US's own request for every year, so they are not
  comparable with other countries or with earlier versions of this data; one saying the same for
  the Northern America aggregate.
- **A footnote on all three charts** — "Data for the US excludes OECD subsidy data, which the US
  asked the OECD to remove. It is not comparable with other countries, and is lower than in
  earlier versions of this data."
- **The US dropped from `fossil-fuel-subsidies-per-capita`'s default selection**, which was Iran,
  World, **United States**, India and Saudi Arabia.

All three charts have `isInheritanceEnabled = 0`, so the footnote set on the indicators in ETL does
not reach them; it is also set at chart level on each of the three. The ETL copy stays so that any
future chart built on these indicators inherits it.

## 2. Chart text that contradicted the data

Both pre-existing, both on charts this PR already touches:

- **`fossil-fuel-subsidies-per-capita`** said the data is "expressed in US dollars, adjusted for
  inflation". The series is `ER_FFS_CMPT_PC_CD` — *nominal* United States dollars. The dimension's
  `display.unit` said `constant US $` for the same reason; both now say nominal.
- **`fossil-fuel-subsidies`** said "measured in millions of nominal US dollars". The indicator is
  in billions and the chart's `conversionFactor` of 1e9 renders it in dollars, so the subtitle was
  wrong by six orders of magnitude.

## 3. Source errors dropped

Eleven entries in `un_sdg.corrections.yml`. The first three rows below were already known from the
issue; the last two came out of checking the remapped charts. Every entry carries an `expect` guard
except the three that match on the erroneous zero itself, where the row vanishing is the guard.

| What | Series affected | Owner |
|---|---|---|
| **Latvia 2022** = $21.58bn, 50–100× its own 2021 ($0.22bn) and 2023 ($0.42bn). 59.3% of GDP and $11,470 per person — 2.5× the largest per-capita value anywhere else in the indicator. | all three | **OECD** — its SDMX API returns 21.57652; the UN copied it |
| **Italy 2024** = exact 0 after $19.51bn in 2023. The only country in the release whose 2024 value is 0 after a 2023 value above $50 per capita; the OECD reports $21.78bn. | total, per capita | **UNSD** — uses Italy's ISTAT submission, which has no 2024 figure, and encodes the gap as zero |
| **Venezuela 2010–2014** = exact 0, where `2023-08-16` reported $21.36–35.35bn ($744–1,185 per capita). Still in the OECD–IEA 82-country list, so not a coverage withdrawal. | all three | **UNSD** |
| **Poland, whole series** published as a fraction while labelled `PERCENT` — 0.00089–0.00557 for 2015–2024, i.e. ~100× too small, against a reported total of $0.62–2.71bn. | share of GDP | **UNSD** |
| **Denmark 2025 and 2026** = exact carry-forwards of its 2024 figure (0.23775 in all three years) in years where no country has a published subsidy total. | share of GDP | **UNSD** |

Two are worth a second look, because they are the ones where a different call was available:

**Poland** is the only entity in the indicator whose total exceeds $0.1bn while its share reads 0,
and its own per-capita series agrees with its total (25.32 $/capita × 38.5m = $0.975bn against a
reported $0.98bn), so the total is intact and only the share is mis-scaled. Dividing the total by
Poland's nominal GDP (World Bank, `NY.GDP.MKTP.CD`) reproduces the published number as a fraction
almost exactly — 2020: 2.71/605.9 = 0.447% against a published 0.00448; 2022: 0.62/695.6 = 0.089%
against 0.00089. Denmark, by contrast, is in percent (1.00931/424.5 = 0.238% against a published
0.23775), as is every other country checked. Only 2024 fails to fit, implying a GDP of $455.8bn
against Poland's actual $917.8bn, so that year may be wrong for a second reason. It is **dropped rather than rescaled by 100**: that would publish an OWID-adjusted
number under a UN-attributed indicator, the trade #6760 declined for `EN_HAZ_PCAP`. Poland keeps its
total and per-capita series.

**Denmark and Poland's 2025–2026 values** are the only ones past 2024 in the whole indicator, and
the subsidy total stops at 2024 for every country — so no share for those years could have been
measured. Left in, they pushed the map to 2026 with two entities reporting while the World series
ended in 2024. Their guard can only be a value band: the corrections grammar cannot express "drop
while the numerator is missing", so a genuine 2025 figure landing inside the band would still be
dropped, and a revised one outside it fails the build.

Effect on the three indicators, read off the rebuilt staging server:

| Series | rows | entities | years |
|---|---|---|---|
| `ER_FFS_CMPT_CD` (billions) | 2,911 → 2,904 | 210 | 2010–2024 |
| `ER_FFS_CMPT_GDP` (% of GDP) | 2,914 → 2,894 | 210 → **209** | 2010–**2026 → 2024** |
| `ER_FFS_CMPT_PC_CD` (per capita) | 2,911 → 2,904 | 210 | 2010–2024 |

**Deliberately not corrected:** Norway 2019 ($0.58bn) and 2022 ($0.43bn) sit between $7.79bn and
$5.16bn neighbours because the OECD left those two years on the old basis. That is a basis
inconsistency rather than an impossible number, and dropping it would remove real OECD data.

**What the corrections cannot fix:** the UN publishes its own regional and world aggregates rather
than us computing them, so those still contain every value dropped above. Latvia 2022 is ~1.3% of
the 2022 world total ($21.58bn of $1,658.70bn); Poland stays inside `Europe (UN)` on the
share-of-GDP series.

## 4. `fossil-fuel-subsidies` was rendering half its regions

Not caused by the remap, but caught by it. Chart 3856 selects eight regions by default, and four of
them — `Northern Africa (UN)`, `Central and Southern Asia (UN)`, `Sub-Saharan Africa (UN)` and
`Eastern and South-Eastern Asia (UN)` — stopped existing in the **`2025-10-29`** release, which
production already uses. The chart has therefore been drawing four lines instead of eight since that
update landed; production's own legend has only Europe, Latin America and the Caribbean, Northern
America and Oceania. This is the same `(UN)` → `(UN SDG)` rename #6760 found on `labor-share-of-gdp`.

Three of the four have an exact `(UN SDG)` successor. `Northern Africa (UN)` has none — the new
scheme publishes `Northern Africa and Western Asia (UN SDG)`, a different composition — so no
rename-only fix restores the chart as it was.

The selection is now the **SDG eight-region scheme**, which the mixed set never was: mutually
exclusive, exhaustive, and summing to the World total in every year of the series.

| 2024, $bn | |
|---|---|
| Europe and Northern America | 286.15 |
| Central and Southern Asia | 216.22 |
| Eastern and South-Eastern Asia | 185.15 |
| Northern Africa and Western Asia | 156.49 |
| Latin America and the Caribbean | 53.01 |
| Sub-Saharan Africa | 15.93 |
| Australia and New Zealand | 8.26 |
| Oceania | 0.00 |
| **sum** | **921.21** |
| World | 921.22 |

The residual is ±0.01bn in every year from 2015 to 2024. `Oceania (UN SDG)` excludes Australia and
New Zealand and reports $0.00–0.03bn throughout, so it draws a flat line at zero; it is kept because
dropping it would break the partition.

## 5. The upgrader left two stale map slugs

`indicator-upgrade upgrade` updated `map.columnSlug` on chart 3856 but not on 3854 and 3855, where
it still pointed at variables `108109` and `108108` — legacy `ER_FFS_PRTSPR` / `ER_FFS_PRTSPC`
indicators with no `catalogPath`, which have not been in these charts' dimensions for several
releases. The upgrader only rewrites a slug that names one of the variables being mapped, and these
name neither. Harmless in practice (a single-`y` chart falls back to its only column) but dead
cruft, so both are set to the new variable ids by hand, matching what the upgrader did on 3856.

## What to look at in chart-diff

- **`fossil-fuel-subsidies-per-capita`** spans two releases, since the chart was stranded on
  `2023-08-16`. The US line drops from $20–31 per capita to $3–7 across the whole series (2021:
  $28.16 → $4.94) — that is the OECD withdrawal, and it is the reason for the footnote rather than a
  bug.
- **`fossil-fuel-subsidies-gdp`** also spans two releases, and loses Poland entirely.
- **`fossil-fuel-subsidies`** moves one release and gains 2024, and its default selection changes
  wholesale — see section 4. Four of the eight lines were already empty in production, so the diff
  looks larger than the data change behind it.

## Still open

**Waiting on someone else**

- **The article.** [How much are fossil fuels subsidised?](https://ourworldindata.org/how-much-subsidies-fossil-fuels)
  no longer matches the data — @HannahRitchie said on the issue that she will amend it once the new
  data is live. The specific sentences that break are listed there, including "European, North
  American, South American, and East Asian nations typically provide under $100 per capita" (Norway
  is now $1,440, the Netherlands $869, Japan $341) and "The dataset reflects 2021 figures" (the
  chart has no time pin, so the map moves to 2024 on deploy).
- **Chart-diff approval** for the three charts, which is how any of this reaches production.

**Nothing reported upstream yet.** All eleven entries carry `status: open`. The OECD owns Latvia
2022 and the Norway basis break; UNSD owns Italy 2024, Venezuela 2010–2014, Poland's unit and
Denmark's carry-forward. Neither has been contacted — and #6760's `EN_HAZ_PCAP` report to
`statistics@un.org` is still unsent too, so these can go in one message.

**Still undecided, from the issue.** What the residual $1–2.3bn the UN still reports for the US
actually is (the IEA price gap doesn't cover the US, so presumably the IMF Energy Subsidy Template —
unconfirmed, and it affects how the caveat should be worded), and whether to source US figures from
somewhere else (pre-2025 OECD vintages still exist; IISD/Earth Track publish US estimates) or accept
the gap and annotate. The issue also flags that the Netherlands now tops the 2024 per-capita ranking
at $1,735, above Kuwait, Qatar and Saudi Arabia, which undercuts the article's "large fossil fuel
producers allocate the most support" framing and is worth verifying before anyone writes around it.

**Nobody checked**

- **Nothing was rendered in a browser.** All six views (chart and map tab of each of the three) were
  checked by reading the text nodes out of the server-side SVG: titles, subtitles, footnote, axis
  ticks, legend bins and entity labels are all as intended, and the per-capita chart tab has the US
  line gone with the axis running to 2024. Note that `/grapher/<slug>.svg` is cached on staging —
  the first render after a config change served the old image, so any re-check needs a cache-busting
  query param.
- **Source attribution is inconsistent across the three charts and was left alone.**
  `fossil-fuel-subsidies` and `fossil-fuel-subsidies-gdp` credit "United Nations Environment
  Programme"; `fossil-fuel-subsidies-per-capita` credits "IEA, OECD and IMF via United Nations
  Global SDG Database". The cause is in the step, not the charts: the total and share series carry
  per-country national source strings (Poland's is "Central Statistical Office of Poland"), so
  `clean_source_name` falls back to `un_sdg.sources_additional.json`'s `12.c.1 → United Nations
  Environment Programme`, while the per-capita series has a single source string and keeps it. UNEP
  is a custodian agency for 12.c.1, so this is not plainly wrong, but the three charts should
  probably agree. Pre-existing, and an editorial call about citation.
- The 14 charts still on older `un_sdg` versions. Unchanged from #6760, where each was judged a
  replace-or-retire case; consequently the `2023-08-16`, `2024-08-27` and `2025-10-29` DAG entries
  still cannot be archived.
