### PR TITLE
Rework the download-package readme, and stamp zip entries with the build date

### DIFF
--- a/etl/collection/download_package.py
+++ b/etl/collection/download_package.py
@@ -811,10 +811,20 @@ def _download_package_location(filename: str) -> tuple[str, str]:
     )
 
 
-# Fixed timestamp for every zip entry, so rebuilding an unchanged package
-# produces byte-identical output instead of a new object on every ETL run.
-# 1980-01-01 is the earliest date the zip format can represent.
-_ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
+def _zip_timestamp(build_date: date) -> tuple[int, int, int, int, int, int]:
+    """The modification time stamped on every zip entry.
+
+    It has to be fixed rather than "now", or an unchanged package would produce a
+    different object on every ETL run. It was 1980-01-01, the earliest the zip format
+    can represent -- which is deterministic but shows up in a file listing as a date no
+    file could plausibly have, and someone downloading the package noticed.
+
+    The build date is fixed in exactly the same way and means something. It costs no
+    reproducibility either: `metadata.json` already carries the same date as
+    `dateDownloaded`, so a package rebuilt on a later day was never byte-identical to
+    begin with. Same-day rebuilds still are.
+    """
+    return (build_date.year, build_date.month, build_date.day, 0, 0, 0)
 
 
 def _readme(title: str, page_url: str, column_sections: list[str], sources_section: str = "") -> str:
@@ -1113,7 +1123,7 @@ def build_download_package_for_collection(
             (f"{page_slug}.csv", csv_path.read_bytes()),
             ("readme.md", readme.encode()),
         ]:
-            info = zipfile.ZipInfo(name, date_time=_ZIP_EPOCH)
+            info = zipfile.ZipInfo(name, date_time=_zip_timestamp(build_date))
             # A ZipInfo carries its own compress_type, defaulting to ZIP_STORED,
             # and it silently wins over the ZipFile's -- so this has to be set
             # explicitly or the whole package ships uncompressed.

--- a/tests/collections/test_download_package.py
+++ b/tests/collections/test_download_package.py
@@ -221,3 +221,21 @@ def test_readme_strips_detail_on_demand_links():
 
     assert "#dod:" not in out
     assert "Measured in terawatt-hours of energy." in out, "the label survives, only the link goes"
+
+
+def test_zip_entries_are_stamped_with_the_build_date():
+    """Test _zip_timestamp - entries carry the build date, not 1980.
+
+    The stamp has to be fixed rather than "now", or an unchanged package would be a new
+    object on every ETL run. It used to be 1980-01-01, the earliest a zip can represent,
+    which is deterministic but shows up in a file listing as a date no file could have.
+    The build date is fixed in the same way and is true.
+    """
+    from datetime import date
+
+    from etl.collection.download_package import _zip_timestamp
+
+    assert _zip_timestamp(date(2026, 8, 27)) == (2026, 8, 27, 0, 0, 0)
+    # Same day in, same stamp out -- this is what keeps a same-day rebuild byte-identical.
+    assert _zip_timestamp(date(2026, 8, 27)) == _zip_timestamp(date(2026, 8, 27))
+    assert _zip_timestamp(date(2026, 8, 28)) != _zip_timestamp(date(2026, 8, 27))


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Entries inside the `.zip` were stamped `1980-01-01`, the earliest date the zip format can represent, which shows up in a file listing as a date no file could have — someone downloading a package noticed.

The stamp has to be fixed rather than "now", or an unchanged package would be a new R2 object on every ETL run. The build date is fixed in exactly the same way and means something. It costs no reproducibility either: `metadata.json` already carries the same date as `dateDownloaded`, so a package rebuilt on a later day was never byte-identical to begin with. Same-day rebuilds still are.

## Testing

A unit test covers the stamp itself. Verified end to end against the real zip writer: entry timestamps are the build date, two same-day builds are byte-identical, a next-day build differs, and entries stay `ZIP_DEFLATED`.

## What's left open

The published packages keep their 1980 stamps until a forced production run — the deploy's `build_mdims_and_explorers` runs without `--force`, and ETL's change detection cannot see library-code changes.
