### PR TITLE
🐛 Sandbox the metadata Jinja environment

### DIFF
--- a/lib/catalog/owid/catalog/core/jinja.py
+++ b/lib/catalog/owid/catalog/core/jinja.py
@@ -3,6 +3,7 @@ from functools import cache
 from typing import Any
 
 import jinja2
+from jinja2.sandbox import SandboxedEnvironment
 
 from owid.catalog.core.utils import remove_details_on_demand
 
@@ -22,7 +23,19 @@ _AS_VALUE_MARKER = "__OWID_AS_VALUE__:"
 # `_expand_jinja_text` for the split.
 _REMOVE_KEY = object()
 
-jinja_env = jinja2.Environment(
+# Sandboxed, not a plain Environment: most of the text rendered here is metadata we
+# did not write. `description_from_producer` and friends are assembled from producer
+# files — WDISeries.csv inside the World Bank WDI zip, for one — and any value that
+# happens to contain `<<` or `<%` reaches `.render()` below. In a plain Environment a
+# crafted value can walk `__class__`/`__subclasses__` to arbitrary code execution on
+# whatever runs the ETL. The sandbox blocks that attribute traversal and renders our
+# own templates identically, so it costs nothing here.
+#
+# It is not the only line of defence and shouldn't be treated as one: snapshots are
+# pinned by content hash in their `.dvc` file, so a producer file cannot change under
+# us after the snapshot is taken, and `StrictUndefined` below turns an accidental
+# `<< foo >>` in producer prose into a loud failure rather than a silent render.
+jinja_env = SandboxedEnvironment(
     block_start_string="<%",
     block_end_string="%>",
     variable_start_string="<<",

--- a/lib/catalog/tests/test_jinja.py
+++ b/lib/catalog/tests/test_jinja.py
@@ -1,3 +1,6 @@
+import jinja2
+import pytest
+
 from owid.catalog.core import jinja, meta
 
 
@@ -133,3 +136,43 @@ def test_empty_jinja_in_grapher_config_preserves_empty_string():
         dim_dict={"variant": "estimates"},
     )
     assert out == {"subtitle": "", "note": "", "originUrl": "https://example.org"}
+
+
+def test_jinja_sandbox_blocks_attribute_traversal():
+    """Producer-supplied metadata must not be able to reach arbitrary code.
+
+    `description_from_producer` and friends are assembled from producer files (e.g.
+    WDISeries.csv inside the World Bank WDI zip), so any value containing `<<` or `<%`
+    reaches `.render()`. Under a plain `jinja2.Environment` the payload below walks
+    `__class__`/`__subclasses__` to arbitrary callables; the SandboxedEnvironment in
+    `jinja.py` must refuse it. Failing loudly is the intended outcome — the exception
+    is not caught in `_expand_jinja_text`, so a poisoned field stops the ETL run.
+    """
+    payload = "<< ''.__class__.__mro__[1].__subclasses__() | length >>"
+
+    with pytest.raises(jinja2.exceptions.SecurityError):
+        jinja._expand_jinja_text(payload, dim_dict={})
+
+    m = meta.VariableMeta(description_from_producer=payload)
+    with pytest.raises(jinja2.exceptions.SecurityError):
+        m.render({})
+
+
+def test_jinja_sandbox_still_renders_our_own_templates():
+    """The sandbox must not change how the templates we write behave.
+
+    Covers the pieces the sandbox could plausibly break: custom delimiters, the
+    `as_value` filter, the `raise` global, and dimension substitution.
+    """
+    out = jinja._expand_jinja(
+        {
+            "title": "Emissions from << sector >>",
+            "min": "<% if sector == 'transport' %><< 90 | as_value >><% endif %>",
+            "isProjection": "<% if sector == 'transport' %>true<% else %>false<% endif %>",
+        },
+        dim_dict={"sector": "transport"},
+    )
+    assert out == {"title": "Emissions from transport", "min": 90, "isProjection": True}
+
+    with pytest.raises(Exception, match="uh oh"):
+        jinja._expand_jinja_text('<< raise("uh oh") >>', dim_dict={})


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Swaps the metadata Jinja environment for `jinja2.sandbox.SandboxedEnvironment`. One line, plus a regression test.

## Why

Metadata fields are rendered as Jinja, and most of the text going through that renderer isn't ours. `description_from_producer` is assembled from producer files — `WDISeries.csv` inside the World Bank WDI zip, for one — and `_uses_jinja` sends any value containing `<<` or `<%` to `.render()`. On a plain `jinja2.Environment` a crafted value can walk `__class__` / `__subclasses__` to arbitrary code execution on whatever runs the ETL.

`jinja_env` is the only Jinja environment in the repo, so this covers every render path at once — including `lib/catalog/owid/catalog/schema_org.py`, which renders through the same helper into the JSON-LD we publish.

## Why now, and why not higher priority

Found by the Codex security scan (finding `b1367526`), filed as **high** against the commit that started reading WDI rich metadata from `WDISeries.csv`. That rating is too high for the path it names, for two reasons the finding doesn't mention:

- **The snapshot is pinned by content.** `snapshots/worldbank_wdi/2026-02-27/wdi.zip.dvc` carries `md5: 3a0c7ce19ad8e7158330d70be0538086`. The ETL reads that object from our own store, never `databankfiles.worldbank.org`, so a compromise upstream cannot change what we process — that needs a human creating a new snapshot version, which for WDI is roughly annual.
- **The payload needs our non-standard delimiters,** and `undefined=StrictUndefined` means producer prose that accidentally contains `<<...>>` raises instead of rendering. Only a deliberate payload executes.

What the finding gets right is its own aside: the sink pre-existed. ~58 ETL steps and 173 metadata YAMLs feed `description_from_producer`, so WDI is one source among many and only got filed because a commit happened to touch it. Fixing the sink is cheaper than reasoning about each producer's download cadence, which is why this is worth doing at low severity rather than closing.

## Behaviour

No change to how our own templates render. Verified against the real config (custom `<<`/`<%` delimiters, `as_value` filter, `raise` global, dimension substitution) — all covered by `test_jinja_sandbox_still_renders_our_own_templates`. The introspection chain now raises `SecurityError`, which is deliberately **not** caught in `_expand_jinja_text`: a poisoned field stops the run rather than rendering to something odd.

`make check` and `make test` clean at the root and in `lib/catalog` (395 passed).

## Still open

- **Not audited: whether any rendered field can be edited by someone without repo write.** The paths I checked all originate in a content-pinned snapshot or a committed YAML. If variable metadata becomes editable through the grapher admin and that text is rendered, the sandbox stops being defence-in-depth and becomes the control — worth re-checking when that lands.
- `update_wdi_metadata.py update-sources` writes metadata via GPT-4o-mini from producer text. The output is committed and reviewed before it renders, so it's not a live path, but it is a chain from producer text to rendered text that nobody has looked at.
- Not measured: sandbox overhead on a full metadata render. Attribute checks are per-access and templates are compile-cached, so I'd expect it in the noise, but I didn't benchmark it.
