### PR TITLE
Escape generated schema annotation keys

### DIFF
--- a/scripts/generate_schema_types.py
+++ b/scripts/generate_schema_types.py
@@ -205,7 +205,7 @@ class TypedDictGenerator:
                     lines.append(f"    # {desc_line.strip()}")
 
         if quoted:
-            lines.append(f'        "{prop_name}": {python_type},')
+            lines.append(f"        {prop_name!r}: {python_type},")
         else:
             lines.append(f"    {prop_name}: {python_type}")
         return lines

--- a/tests/test_schema_types_generation.py
+++ b/tests/test_schema_types_generation.py
@@ -28,3 +28,24 @@ def test_schema_types_is_up_to_date():
         "(hand-written types belong in etl/collection/model/params.py, not in the generated file).\n\n"
         f"{result.stdout}\n{result.stderr}"
     )
+
+
+def test_special_property_names_are_escaped_in_generated_annotations(tmp_path):
+    """Special JSON-schema property names must not become executable Python."""
+    from typing import TypedDict
+
+    from scripts.generate_schema_types import TypedDictGenerator
+
+    marker = tmp_path / "schema_codegen_pwned"
+    malicious_name = f'poc": __import__("pathlib").Path({str(marker)!r}).write_text("pwned") #\''
+
+    generated = TypedDictGenerator().generate_typeddict(
+        class_name="ExploitConfig",
+        properties={malicious_name: {"type": "string"}},
+    )
+
+    namespace = {"TypedDict": TypedDict}
+    exec(generated, namespace)
+
+    assert not marker.exists()
+    assert namespace["ExploitConfig"].__annotations__[malicious_name] is str


### PR DESCRIPTION
> _Written by Claude Code — @codex at the wheel._

### Motivation
- Prevent untrusted JSON-schema property names from being embedded as executable Python in the generated `etl/collection/model/schema_types.py` (codegen previously interpolated raw property names into source, allowing import-time execution).

### Description
- Emit annotation keys with Python string escaping using `repr()` (`{prop_name!r}`) in `scripts/generate_schema_types.py` so quoted/non-identifier property names are safe when written into the generated `__annotations__` block.
- Add a regression test `test_special_property_names_are_escaped_in_generated_annotations` in `tests/test_schema_types_generation.py` that generates a `TypedDict` with a malicious property name, executes the generated definition, asserts no payload file is created, and verifies the annotation key is preserved.

### Testing
- Ran `.venv/bin/pytest tests/test_schema_types_generation.py` and both tests passed.
- Ran `.venv/bin/python scripts/generate_schema_types.py --check` which reported the generated file is up to date.
- Ran `git diff --check` with no issues reported for the changes made.
- Ran `make check` which failed on an existing, unrelated typing diagnostic in `apps/wizard/app_pages/expert_agent/agent.py` (pre-existing issue about `call_tool` signature and deprecation warnings), not caused by this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21737d3e3c83288d8496b37373db6b)