### PR TITLE
📊 Blank broken UN WPP deaths-by-age for Australia 2022-2023

### DIFF
--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.corrections.yml
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.corrections.yml
@@ -1,0 +1,71 @@
+# Known errors in UN WPP 2024 that we blank locally until the provider fixes them.
+# See etl/data_corrections.py for the format; `etl corrections --charts` inventories them.
+#
+# Australia's deaths-by-age distribution is broken for 2022 and 2023. In the source file
+# (WPP2024_DeathsBySingleAgeSex_Medium_1950-2023.csv.gz) every single year of age from 9 to 39 is
+# pinned at a floor of 1-2 deaths in 2022 — for a country that has recorded roughly 460 deaths a year
+# among 15-19-year-olds for the past decade — while ages 55-64 and 70-94 absorb the difference:
+#
+#   age band   2019    2020    2021     2022     2023
+#   10-14       137     142     156       10       14
+#   15-19       460     474     463        8       43
+#   20-24       779     716     689       10      107
+#   25-29       903     916     818       10       40
+#   30-34     1,078   1,123   1,068       10       30
+#   35-39     1,471   1,461   1,404       10      189
+#   40-44     1,921   1,804   1,825       29      838
+#   45-49     3,007   2,911   2,839    1,152    2,173
+#   55-59     6,117   5,964   6,182    9,317    6,987
+#   60-64     8,440   8,294   8,401   19,781   12,671
+#
+# The 21 five-year bands still sum exactly to the annual total the UN publishes for Australia
+# (204,741 in 2022; 183,927 in 2023) — the deaths are misdistributed across brackets, not missing.
+# So the totals are kept and only the age-disaggregated rows are blanked; the step applies this file
+# to those rows only.
+#
+# The whole age distribution goes, not just the bands that are visibly too low. Blanking only those
+# would leave the inflated bands published alongside a profile that still sums to the correct total —
+# wrong data that looks internally coherent. There is also no clean intact subset to keep: the 0-4
+# band is off too in 2022 (1,370 vs 1,172 in 2021, driven by age 1 jumping from 45 to 153), 5-9
+# contains a floored age-9 value, and the 10-year bands and the 0 / 1-4 / 100+ groups are all summed
+# from the same single-age values.
+#
+# Confined to 2022-2023: 1950-2021 and the 2024+ projections have a normal age profile.
+#
+# The first two entries duplicate what the last one does, narrowed to a single band, purely to carry
+# an `expect` guard — `override` keeps the row, so without it a fixed upstream file would be silently
+# re-blanked. They must stay above the broad entry, which blanks the guarded cells too.
+
+- indicator: deaths
+  match: {country: Australia, year: 2022, age: 15-19}
+  action: override
+  value: null
+  expect: {lt: 200}
+  reason: >-
+    Deaths at ages 15-19 in Australia are reported as 8 for 2022, against 460-475 a year for
+    2015-2021; the guard for the 2022 age distribution below.
+  provider: United Nations, World Population Prospects
+  status: open
+
+- indicator: deaths
+  match: {country: Australia, year: 2023, age: 15-19}
+  action: override
+  value: null
+  expect: {lt: 200}
+  reason: >-
+    Deaths at ages 15-19 in Australia are reported as 43 for 2023, against 460-475 a year for
+    2015-2021; the guard for the 2023 age distribution below.
+  provider: United Nations, World Population Prospects
+  status: open
+
+- indicator: deaths
+  entity: Australia
+  years: [2022, 2023]
+  action: override
+  value: null
+  reason: >-
+    Australia's deaths-by-age distribution is unusable for 2022 and 2023 — every single year of age
+    from 9 to 39 is floored at 1-2 deaths while ages 55-64 and 70-94 are inflated by up to 135%,
+    though the bands still sum to the correct annual total.
+  provider: United Nations, World Population Prospects
+  status: open

--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.py
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.py
@@ -476,11 +476,21 @@ def process_deaths(tb: Table, tb_rate: Table) -> Table:
     tb_x = tb_x.groupby(COLUMNS_INDEX, as_index=False, observed=True)["deaths"].sum()
     tb_limits = tb.loc[tb["age"].isin(["0", "100+"])].copy()
 
-    # Combine
-    tb = pr.concat([tb_total, tb_5, tb_10, tb_x, tb_limits], ignore_index=True)
+    # Combine the age-disaggregated groups (the totals are added back after corrections, below)
+    tb = pr.concat([tb_5, tb_10, tb_x, tb_limits], ignore_index=True)
 
     # Scale
     tb["deaths"] *= 1000
+    tb_total["deaths"] *= 1000
+
+    # Blank known upstream errors in the age distribution (see un_wpp.corrections.yml). Applied to the
+    # age-disaggregated rows only, on purpose: the errors misdistribute a year's deaths across age
+    # brackets while preserving its total, so `tb_total` (summed from the same source rows) is correct
+    # and must keep its values.
+    tb = paths.apply_corrections(tb)
+
+    # Add the totals back
+    tb = pr.concat([tb_total, tb], ignore_index=True)
 
     # Merge
     tb = tb.merge(tb_rate, on=COLUMNS_INDEX, how="outer")


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Australia's deaths-by-age distribution in UN WPP 2024 is broken for 2022 and 2023: deaths at ages 10–44 collapse to near-zero while ages 55–64 inflate by up to 135%, though each year's bands still sum to the correct annual total. This is an error in the UN's published file, not in our processing, so it is declared in a `.corrections.yml` that blanks Australia's age-disaggregated deaths for those two years and keeps the (correct) totals. The affected chart is [annual-deaths-by-age](https://ourworldindata.org/grapher/annual-deaths-by-age).

*Deep review on the scope decision (which rows get blanked) and on the one non-trivial code change in `process_deaths`; the corrections file itself is declarative.*

## What's wrong, and where it comes from

The UN's own file is broken. In `WPP2024_DeathsBySingleAgeSex_Medium_1950-2023.csv.gz` (our snapshot `un/2024-07-12/un_wpp_deaths_estimates.csv`, md5 `579204084d4bb2c8acb520eeff1e7a47`, unchanged since ingestion), every single year of age from 9 to 39 is reported as `0.001` or `0.002` thousand for Australia in 2022 — one or two people, the smallest value the file can represent, for a country that has recorded ~460 deaths a year among 15–19-year-olds for a decade. **35 of the 101 single ages sit at that floor in 2022 and 9 of 101 in 2023**, against zero in every year from 1950 to 2021; ages 55–64 and 70–94 absorb the difference. Values at the representable minimum are a degenerate output rather than an estimate, which is the sharpest evidence that this is a source defect.

| Age | 2019 | 2020 | 2021 | 2022 | 2023 |
|---|---|---|---|---|---|
| 10–14 | 137 | 142 | 156 | 10 | 14 |
| 15–19 | 460 | 474 | 463 | 8 | 43 |
| 20–24 | 779 | 716 | 689 | 10 | 107 |
| 25–29 | 903 | 916 | 818 | 10 | 40 |
| 30–34 | 1,078 | 1,123 | 1,068 | 10 | 30 |
| 35–39 | 1,471 | 1,461 | 1,404 | 10 | 189 |
| 40–44 | 1,921 | 1,804 | 1,825 | 29 | 838 |
| 45–49 | 3,007 | 2,911 | 2,839 | 1,152 | 2,173 |
| 55–59 | 6,117 | 5,964 | 6,182 | 9,317 | 6,987 |
| 60–64 | 8,440 | 8,294 | 8,401 | 19,781 | 12,671 |

Our garden output reproduces a plain sum of those single-age values × 1000 exactly, so nothing in the pipeline introduces or amplifies it — `process_deaths` only sums single ages into 5- and 10-year bands. Reproduce with the appendix script.

## What the correction blanks

Garden `un/2024-07-12/un_wpp`, table `deaths`, column `deaths`: **Australia, 2022 and 2023, every `age` value except `all`** — the 20 five-year bands, the 10 ten-year bands, and the `0` / `1-4` / `100+` groups — for all three `sex` values. 198 cells. `variant` is `estimates` for both years (the only variant the UN publishes there), so it needs no separate scoping. 1950–2021 and the 2024+ projections have a normal age profile and are untouched.

**The whole distribution goes, not only the bands that are visibly too low.** Blanking just those would leave the inflated bands published next to a profile that still sums to the correct total — wrong data that looks internally coherent. There is also no clean intact subset to keep: 0–4 is off in 2022 too (1,370 vs 1,172 in 2021, driven by age 1 jumping 45 → 153), 5–9 contains a floored age-9 value, and the 10-year and special groups are summed from the same single-age numbers.

**The annual totals are kept.** They are unaffected — the error redistributes deaths across brackets rather than losing them — and they back a second, more-viewed chart, [number-of-deaths-per-year](https://ourworldindata.org/grapher/number-of-deaths-per-year). Blanking them would remove good data.

That is what the code change is for. `apply_corrections` locates rows by entity + years and would match the `age: all` rows too, so `process_deaths` now applies the corrections to the concatenation of the age-disaggregated groups *before* the totals are added back. The totals are summed from the raw single-age table earlier in the function, so they are computed from uncorrected values by construction.

## Death rates: checked, not affected

No death-rate-*by-age* indicator derives from these counts.

- `un_wpp/deaths#death_rate` is the **crude** death rate, present only at `age: all`, read from the Demographic Indicators XLSX (`Crude Death Rate`) — an independent source file, not computed from the counts.
- `un_wpp/mortality_rate` is infant and under-five mortality, also from that XLSX.
- `demography/2025-10-22/deaths` re-derives a death rate from UN WPP, but filters to `age == "all"` first (`estimate_death_rate_from_un`), so it uses the correct totals.

## Deliberately left alone, and why they need separate fixes

Four other entity-years show a co-occurring break across age bands in the same indicator. They are **not** all the same defect, and the mechanism identified above explains only Australia — so none of them is bundled in here.

The floor signature described above is specific to Australia: **none of the entity-years below has a single value at the representable minimum**, in either year. Whatever produced them is a different artifact, so each needs its own diagnosis before anything is blanked.

| Entity-year | Annual total | Age split | Signature |
|---|---|---|---|
| **Australia 2022–23** | correct | broken | 35 / 9 single ages at the representable floor |
| **Turkey 2023** | 555,768 → 551,598 (−0.8%), plausible | broken | smooth 2.4–9.9× jump at ages 5–24, flat at 45+ |
| **South Korea 2023** | 390,618 → 345,503 (−11.5%), plausible | broken | monotone age gradient, no floor |
| **Puerto Rico 2023** | 37,233 → 34,665, plausible | broken | same gradient as South Korea, smaller |
| **Central African Republic 2022–23** | **also broken** | broken | totals swing 106,790 → 281,036 → 48,531 |

- **Turkey 2023** is the closest analogue: the total barely moves while ages 5–24 inflate (5–9: 365 → 3,600; 10–14: 433 → 3,219; 15–19: 876 → 3,171; 20–24: 1,648 → 4,016) and 45+ stays flat. Redistribution within a correct total, same as Australia — so the same fix shape would apply, but the underlying artifact is different and worth understanding first.
- **South Korea 2023** drops on a gradient that tracks age: −51% at 15–19, −62% at 20–24, −65% at 25–29, −57% at 35–39, −44% at 45–49, −25% at 55–59, −8% at 60–64, +2% at 70–74. The one band that breaks the gradient is 5–9 (125 → 277). An 11.5% fall in the total is plausible post-COVID; a 65% fall confined to young adults is not. **Puerto Rico 2023** shows the same graded pattern at smaller scale.
- **Central African Republic is a different problem class.** Its *published annual totals* swing 66,647 → 106,790 → 281,036 → 48,531 — a 2.6× jump then an 83% collapse. The Australia fix (blank the age split, keep the total) would be **wrong** here, because the total is wrong too. Fixing CAR means deciding what to do about `number-of-deaths-per-year`, which is a bigger call than this PR.

Two controls that also break across several age bands at once and are **real**, which is why this can't be reduced to a threshold:

- **Ukraine 2022** — 15–19: 957 → 2,476; 20–24: 1,540 → 4,549; 25–29: 2,749 → 6,659, with the total *falling* 759,003 → 582,383 and older ages falling with it. Young-age mortality up while the total drops is the demographic signature of war plus mass emigration, not an artifact.
- **Palestine 2023** — young-age deaths rise ~11× (15–19: 213 → 2,311), reflecting the war in Gaza.

Nothing here touches either, and any future detector for this pattern must not.

Also untouched: the UN's own regional and world aggregates still carry Australia's misdistributed split. They are the UN's numbers, not ours to recompute.

## Verified

Ran the step and diffed the resulting `deaths.feather` (3,981,874 rows) cell-by-cell against the pre-change build:

```
newly NaN: 198 | NaN->value: 0 | value changed: 0
death_rate column identical: True
blanked: Australia 2022 -> 99 cells, Australia 2023 -> 99 cells
ages blanked: 33 | 'all' among them: False | sexes: all, female, male | variants: estimates
```

So the only change anywhere in the table is the 198 intended cells; every other country, year, age and sex is byte-identical, and no previously-missing value gained one. Australia's `age: all` totals still read 204,741 (2022) and 183,927 (2023) — matching both the sum of the 21 five-year bands in the source and what `number-of-deaths-per-year` publishes today.

The two downstream grapher steps (`un_wpp`, `un_wpp_full`) rebuild cleanly with the NaNs in place.

The `expect: {lt: 200}` guards were tested by setting the 2022 15–19 band back to a plausible 460 and re-applying: the step aborts with `expectation 'lt 200' failed for 3 of 3 matched rows`. So the correction cannot silently keep blanking good data if the UN fixes the file.

The defect is confined to the deaths file: Australia's `population` and `births` tables have smooth, plausible age profiles across 2019–2023 (population 15–19: 1.50M → 1.54M → 1.58M; births to mothers 15–19: 5,147 → 5,006 → 5,125).

**Not verified:** whether the UN knows. `status: open` — nobody has reported this upstream yet, and that should happen before this is considered closed.

<details>
<summary>Reproducing the finding from the snapshot</summary>

```bash
gzcat data/snapshots/un/2024-07-12/un_wpp_deaths_estimates.csv \
  | awk -F, 'NR==1 || $4=="AUS"' > /tmp/aus.csv
python3 - <<'PY'
import csv, collections
rows = list(csv.DictReader(open("/tmp/aus.csv", encoding="utf-8-sig")))
agg = collections.defaultdict(float)
for r in rows:
    a = int(r["AgeGrpStart"])
    band = "100+" if a >= 100 else f"{a//5*5}-{a//5*5+4}"
    agg[(int(r["Time"]), band)] += float(r["DeathTotal"])
bands = [f"{i}-{i+4}" for i in range(0, 100, 5)] + ["100+"]
for y in range(2019, 2024):
    print(y, {b: round(agg[(y, b)] * 1000) for b in bands})
PY
```

The single-age detail is where the defect is unmistakable — Australia 2022, `DeathTotal` in thousands: ages 9 through 39 are all `0.001` or `0.002`, male and female alike, while age 60 reports 3.576 against 1.527 in 2021.

And the published chart data, for the same numbers as OWID serves them:

```bash
curl -sL "https://ourworldindata.org/grapher/annual-deaths-by-age.csv?csvType=full&useColumnShortNames=true" \
  | grep '^Australia'
```

</details>
