### PR TITLE
✨ Rework the download-package readme

### DIFF
--- a/etl/collection/download_package.py
+++ b/etl/collection/download_package.py
@@ -827,13 +827,53 @@ def _zip_timestamp(build_date: date) -> tuple[int, int, int, int, int, int]:
     return (build_date.year, build_date.month, build_date.day, 0, 0, 0)
 
 
-def _readme(title: str, page_url: str, column_sections: list[str], sources_section: str = "") -> str:
+def _time_column_lines(time_header: str, frequency_column: bool) -> str:
+    """The bullet describing the CSV's time column(s), for the shape this package
+    actually has.
+
+    Upstream hedges -- "the third column is either Year or Day" -- because a chart
+    download's readme is one static string. This one is built per package, so it can
+    just say which it is, and can describe the Frequency/Time pair that a
+    mixed-resolution collection gets and no chart download has.
+    """
+    if frequency_column:
+        return (
+            '- "Frequency" and "Time" — the resolution a row is reported at ("annual", "monthly", ...) and '
+            'the timepoint at that resolution ("2025", "2026-06"). Collections that report the same metric at '
+            "more than one resolution keep it in a single column and tell the rows apart here."
+        )
+    if time_header == "Day":
+        return '- "Day" — the timepoint, as a date string in the form "YYYY-MM-DD".'
+    return '- "Year" — the timepoint, as an integer year.'
+
+
+def _readme(
+    title: str,
+    page_url: str,
+    column_sections: list[str],
+    sources_section: str = "",
+    time_header: str = "Year",
+    frequency_column: bool = False,
+) -> str:
     """Ported from `constructReadme`'s multi-column branch (readmeTools.ts),
     with the tolerance-column paragraph dropped (a complete-dataset package has
     no tolerance columns) and three MDIM-only additions that have no counterpart
     there: that the package covers every dimension combination, that column
     headers shouldn't be parsed, and how to read metadata.json's "dimensions"
     and per-column "dimensions"/"url" keys instead.
+
+    Two changes to the boilerplate. The CSV section is a bulleted list rather than a
+    paragraph per column, and names the time column this package actually has instead of
+    hedging between "Year" and "Day". And "About the data" is gone as a heading: it
+    announced a description of *this* dataset and then delivered generic text about how
+    OWID processes data, so that is what it is now called -- taking with it the
+    sub-heading of the same name, which was the only thing under it. The wording of
+    those paragraphs, and of the metadata.json section, is upstream's untouched.
+
+    Sources come last, after the indicators. What a reader opens this file for is the
+    column they are looking at; the source list is reference material they consult from
+    a citation, and putting it first pushed the indicators below several screens of
+    producer descriptions.
 
     Detail-on-demand links are stripped from the whole document. `[terawatt-hours](#dod:watt-hours)`
     renders as a tooltip on our site and as a dead link in a downloaded markdown file, so it is noise
@@ -846,17 +886,16 @@ def _readme(title: str, page_url: str, column_sections: list[str], sources_secti
     """
     return strip_detail_on_demand_links(f"""# {title} - Data package
 
-This data package contains the data that powers the chart ["{title}"]({page_url}) on the Our World in Data website. It includes every dimension combination of this multidimensional dataset -- all metric/breakdown choices, not just the view selected on the chart.
+This data package contains the data that powers the chart ["{title}"]({page_url}) on the Our World in Data website. It covers every dimension combination of this multidimensional dataset, not just the view the chart opens on.
 
-## CSV Structure
+## CSV structure
 
-The high level structure of the CSV file is that each row is an observation for an entity (usually a country or region) and a timepoint (usually a year).
+Each row is an observation for an entity (usually a country or region) at a timepoint.
 
-The first two columns in the CSV file are "Entity" and "Code". "Entity" is the name of the entity (e.g. "United States"). "Code" is the OWID internal entity code that we use if the entity is a country or region. For most countries, this is the same as the [iso alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the entity (e.g. "USA") - for non-standard countries like historical countries these are custom codes.
-
-The third column is either "Year" or "Day". If the data is annual, this is "Year" and contains only the year as an integer. If the column is "Day", the column contains a date string in the form "YYYY-MM-DD".
-
-The remaining columns are the data columns, each of which is a time series corresponding to one dimension combination of this dataset. Their headers are human-readable names; don't parse them to work out which dimension combination a column belongs to, use the .metadata.json file described below instead.
+- "Entity" — the name of the entity, e.g. "United States".
+- "Code" — our internal entity code. For most countries this is the [ISO alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code, e.g. "USA"; historical and other non-standard entities get a custom code.
+{_time_column_lines(time_header, frequency_column)}
+- Every remaining column is one time series, corresponding to one dimension combination. Their headers are human-readable names — don't parse them to work out which combination a column belongs to, use the .metadata.json file for that.
 
 ## Metadata.json structure
 
@@ -866,19 +905,17 @@ The "dimensions" key lists this dataset's dimensions and the choices available f
 
 A few columns belong to more than one combination, which happens when a dimension makes no difference to that particular indicator. Those carry an extra "otherViews" key listing the remaining combinations in the same shape; if you need every combination a column appears under, read both keys.
 
-## About the data
+## How we process data at Our World in Data
 
 Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stich together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
 
-### How we process data at Our World In Data
 All data and visualizations on Our World in Data rely on data sourced from one or several original data providers. Preparing this original data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
 [Read about our data pipeline](https://docs.owid.io/projects/etl/)
-
-{sources_section}
 
 ## Detailed information about each time series
 
 {chr(10).join(column_sections)}
+{sources_section}
 """)
 
 
@@ -1070,7 +1107,14 @@ def build_download_package_for_collection(
     # MDIM overwhelmingly share their sources, so repeating them per column is nearly all
     # duplication -- 354 blocks describing 7 sources on electricity-mix.
     sources_section = "\n".join(sources_section_lines(collect_unique_sources([c.col for c in columns])))
-    readme = _readme(title, page_url, readme_sections, sources_section)
+    readme = _readme(
+        title,
+        page_url,
+        readme_sections,
+        sources_section,
+        time_header=wide_table.time_header,
+        frequency_column=wide_table.frequency_column is not None,
+    )
 
     #
     # The CSV, in its final downloadable shape: Entity/Code/Year, long

--- a/etl/collection/download_package.py
+++ b/etl/collection/download_package.py
@@ -899,7 +899,7 @@ Each row is an observation for an entity (usually a country or region) at a time
 
 ## Metadata.json structure
 
-The .metadata.json file contains metadata about the data package. The "chart" key contains information to recreate the chart, like the title, subtitle etc.. The "columns" key contains information about each of the columns in the csv, like the unit, timespan covered, citation for the data etc..
+The .metadata.json file contains metadata about the data package. The "chart" key contains information to recreate the chart, like the title, subtitle etc. The "columns" key contains information about each of the columns in the csv, like the unit, timespan covered, citation for the data etc.
 
 The "dimensions" key lists this dataset's dimensions and the choices available for each, as a stable slug plus a display name. Every column entry then carries its own "dimensions" key naming the combination of choices that column belongs to, by slug, plus a "url" that opens that combination on our website. Together those let you go from a CSV column to its dimension choices, and back, without parsing column headers.
 
@@ -907,10 +907,10 @@ A few columns belong to more than one combination, which happens when a dimensio
 
 ## How we process data at Our World in Data
 
-Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stich together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
+Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stitch together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
 
-All data and visualizations on Our World in Data rely on data sourced from one or several original data providers. Preparing this original data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
-[Read about our data pipeline](https://docs.owid.io/projects/etl/)
+Preparing this data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
+[Read about our data pipeline](https://docs.owid.io/projects/etl/).
 
 ## Detailed information about each time series
 

--- a/etl/collection/download_package_format.py
+++ b/etl/collection/download_package_format.py
@@ -62,10 +62,27 @@ from typing import Any
 # shift a day depending on where ETL happens to run.
 MONTH_NAMES = list(calendar.month_name)[1:]
 
+# `OWID_ATTRIBUTION` (metadataHelpers.ts). A constant rather than a literal per use
+# site: the port had three of them and one said "Our World In Data", so a readme
+# credited us two different ways within four lines.
+OWID_ATTRIBUTION = "Our World in Data"
+
 
 # ---------------------------------------------------------------------------
 # Small helpers standing in for lodash / dayjs
 # ---------------------------------------------------------------------------
+
+
+def format_attributions(attributions: list[str]) -> str:
+    """`formatAttributions` (metadataHelpers.ts) -- semicolons, not commas.
+
+    Producer fragments carry commas of their own ("Department for Business, Energy &
+    Industrial Strategy of the UK (2023)"), so joining them with commas makes one list
+    indistinguishable from the next. Upstream moved to semicolons; this port kept
+    commas in `get_attribution` while already using semicolons in the citations, so the
+    Source line and the citation four lines below it disagreed.
+    """
+    return "; ".join(attributions)
 
 
 def _uniq(values: list[str]) -> list[str]:
@@ -318,8 +335,8 @@ def get_citation_short(origins: list[dict], attributions: list[str] | None, proc
     phrase = get_phrase_for_processing_level(processing_level)
 
     fragments = attributions if attributions is not None else producers_with_year
-    shortened = f"{fragments[0]} and other sources" if len(fragments) > 3 else "; ".join(fragments)
-    return f"{shortened} – {phrase} by Our World in Data"
+    shortened = f"{fragments[0]} and other sources" if len(fragments) > 3 else format_attributions(fragments)
+    return f"{shortened} – {phrase} by {OWID_ATTRIBUTION}"
 
 
 def get_citation_long(
@@ -348,7 +365,7 @@ def get_citation_long(
     phrase = get_phrase_for_processing_level(processing_level)
 
     fragments = attributions if attributions is not None else producers_with_year
-    citation_longer = f"{'; '.join(fragments)} – {phrase} by Our World in Data"
+    citation_longer = f"{format_attributions(fragments)} – {phrase} by {OWID_ATTRIBUTION}"
     title_with_fragments = " – ".join(_exclude_undefined([indicator_title.get("title"), source_short_name]))
     origins_long = "; ".join(
         _uniq(
@@ -514,17 +531,17 @@ def get_title(col: IndicatorColumn) -> str:
 
 def get_attribution(col: IndicatorColumn) -> str:
     """`getAttribution`."""
-    attribution = ", ".join(col.attribution_fragments)
+    attribution = format_attributions(col.attribution_fragments)
     if attribution == "":
         return col.source_name or ""
     return attribution
 
 
 def get_source(attribution: str, col: IndicatorColumn) -> str:
-    """`getSource`."""
-    if attribution.lower() != "our world in data":
+    """`getSource`, now `getAttributionWithProcessing` upstream."""
+    if attribution.lower() != OWID_ATTRIBUTION.lower():
         phrase = get_phrase_for_processing_level(col.processing_level)
-        return f"{attribution} – {phrase} by Our World In Data"
+        return f"{attribution} – {phrase} by {OWID_ATTRIBUTION}"
     return attribution
 
 
@@ -639,7 +656,7 @@ def _sources_lines(col: IndicatorColumn) -> list[str]:
     if not sources:
         return []
 
-    lines = ["", "#### Source" if len(sources) == 1 else "#### Sources"]
+    lines = ["", "#### Sources"]
     for source in sources:
         lines += ["", f"##### {source['label']}"]
         if source.get("dataPublishedBy"):
@@ -745,7 +762,9 @@ def sources_section_lines(sources: list[dict]) -> list[str]:
     """
     if not sources:
         return []
-    lines = ["", "## Source" if len(sources) == 1 else "## Sources", ""]
+    # Always plural: the sentence below is written that way and a section heading naming
+    # a category reads fine over one item, so the branch decided nothing.
+    lines = ["", "## Sources", ""]
     lines.append(
         "These are the sources behind the data in this package. Each time series above names the ones "
         "it draws on in its citation."

--- a/etl/collection/download_package_format.py
+++ b/etl/collection/download_package_format.py
@@ -31,6 +31,16 @@
     -- a chart download and an MDIM complete-dataset download are supposed to
     be the same format, and nothing automated will notice if they drift.
 
+    The readme half of the port has deliberately moved ahead of upstream,
+    following a review of an MDIM package (owid/etl#6668): headings shifted a
+    level so an indicator is a child of the section introducing it, the full
+    citation dropped (it survives in metadata.json), sources listed once for the
+    document instead of per indicator, "Next expected update" rather than "Next
+    update", a plural descriptionFromProducer heading with no producer names in
+    it, the Source line moved in with the other per-indicator facts, and DoD
+    links stripped. None of it is MDIM-specific -- it should land in
+    readmeTools.ts too, at which point these notes can go.
+
 Input shape: every function here takes the public indicator metadata dict as
 served at `api.ourworldindata.org/v1/indicators/<id>.metadata.json` (the same
 JSON the Cloudflare Function fetches, obtained here via
@@ -536,7 +546,9 @@ def _key_data_lines(col: IndicatorColumn, today: date) -> list[str]:
 
     next_update = get_next_update_from_variable(col.meta, today)
     if next_update:
-        lines.append(f"Next update: {format_source_date(next_update, 'MMMM YYYY')}" + MARKDOWN_NEWLINE_ENDING)
+        # "Next expected update", not "Next update": the date is the producer's stated
+        # update period added to our last update, so it's our expectation, not a promise.
+        lines.append(f"Next expected update: {format_source_date(next_update, 'MMMM YYYY')}" + MARKDOWN_NEWLINE_ENDING)
 
     timespan = col.meta.get("timespan")
     date_range = get_date_range(timespan) if timespan else None
@@ -562,7 +574,16 @@ def _format_js_number(value: float) -> str:
 
 
 def _citation_lines(col: IndicatorColumn) -> list[str]:
-    """`getCitationLines`.
+    """`getCitationLines`, minus the full citation.
+
+    Upstream prints both the short in-line citation and a full one that spells out
+    every origin. The full one is several lines of the same producer names already
+    listed, with far more detail, in the document-level Sources section -- across 46
+    indicators it was a fifth of the readme for something a reader is unlikely to copy
+    out of a data package. The short citation is what a chart or a sentence needs, and
+    each source's own requested citation is in the Sources section verbatim. Nothing is
+    lost either way: `metadata_column_entry` still emits `citationLong`, so the full
+    string is in metadata.json for anyone who wants it.
 
     Note the upstream quirk faithfully reproduced here: this block rebuilds the
     attribution fragments from `{...def, source: {name: def.sourceName}}` --
@@ -578,36 +599,36 @@ def _citation_lines(col: IndicatorColumn) -> list[str]:
     )
     return [
         "",
-        "### How to cite this data",
+        "#### How to cite this data",
         "",
-        "#### In-line citation",
-        "If you have limited space (e.g. in data visualizations), you can use this abbreviated in-line citation:"
-        + MARKDOWN_NEWLINE_ENDING,
         citation_short,
-        "",
-        "#### Full citation",
-        col.citation_long(),
     ]
 
 
-def _description_section_lines(col: IndicatorColumn, attribution: str) -> list[str]:
-    """`getDescriptionLines`."""
+def _description_section_lines(col: IndicatorColumn) -> list[str]:
+    """`getDescriptionLines`.
+
+    Upstream names the producer in the descriptionFromProducer heading, which for an
+    indicator combining several of them runs to a full line of names and reads as a
+    question about a list. The plural heading says the same thing and works for one
+    producer as well as seven.
+    """
     lines = []
     description_key = col.description_key
     if description_key:
-        lines += ["", "### What you should know about this data", description_key.strip()]
+        lines += ["", "#### What you should know about this data", description_key.strip()]
 
     description_from_producer = col.meta.get("descriptionFromProducer")
     if description_from_producer:
         lines += [
             "",
-            f"### How is this data described by its producer - {attribution}?",
+            "#### How this data is described by its producers",
             description_from_producer.strip(),
         ]
 
     additional_info = col.meta.get("additionalInfo")
     if additional_info:
-        lines += ["", "### Additional information about this data", additional_info.strip()]
+        lines += ["", "#### Additional information about this data", additional_info.strip()]
 
     return lines
 
@@ -618,9 +639,9 @@ def _sources_lines(col: IndicatorColumn) -> list[str]:
     if not sources:
         return []
 
-    lines = ["", "### Source" if len(sources) == 1 else "### Sources"]
+    lines = ["", "#### Source" if len(sources) == 1 else "#### Sources"]
     for source in sources:
-        lines += ["", f"#### {source['label']}"]
+        lines += ["", f"##### {source['label']}"]
         if source.get("dataPublishedBy"):
             lines.append(f"Data published by: {source['dataPublishedBy'].strip()}" + MARKDOWN_NEWLINE_ENDING)
         if source.get("retrievedOn"):
@@ -631,7 +652,12 @@ def _sources_lines(col: IndicatorColumn) -> list[str]:
 
 
 def _data_processing_lines(col: IndicatorColumn) -> list[str]:
-    """`getDataProcessingLines`."""
+    """`getDataProcessingLines`.
+
+    The only heading not shifted a level: upstream already prints it at `####`, one
+    deeper than its siblings, so it read as a child of whatever came last (the final
+    source block). At the new sibling level it is where it belongs.
+    """
     description_processing = col.meta.get("descriptionProcessing")
     if not description_processing:
         return []
@@ -654,17 +680,25 @@ def column_readme_text(
     that lists the sources once up front instead. Repeating them per indicator is
     what the TypeScript does and is bearable for a chart's handful of columns; at
     46 columns drawn from 7 sources it is 354 blocks, and most of the file.
+
+    Every heading here sits one level deeper than upstream's, because these sections
+    are children of the document's "Detailed information about each time series" -- at
+    the upstream levels an indicator was a sibling of the heading introducing it, so
+    the whole per-indicator half of the document was flat.
     """
     attribution = get_attribution(col)
     return [
         "",
-        f"## {heading or get_title(col)}",
+        f"### {heading or get_title(col)}",
         *_description_lines(col),
         *_key_data_lines(col, today),
-        "",
+        # Upstream prints this immediately after the full citation, where it reads as a
+        # trailing fragment of it. It is a fact about the indicator like the ones above,
+        # so it goes with them -- and next to the citation it now looks like a
+        # duplicate, since with the full citation gone both lines are attributions.
+        f"Source: {get_source(attribution, col)}" + MARKDOWN_NEWLINE_ENDING,
         *_citation_lines(col),
-        f"Source: {get_source(attribution, col)}",
-        *_description_section_lines(col, attribution),
+        *_description_section_lines(col),
         *(_sources_lines(col) if include_sources else []),
         *_data_processing_lines(col),
         "",
@@ -698,7 +732,9 @@ def collect_unique_sources(cols: list[IndicatorColumn]) -> list[dict]:
 def sources_section_lines(sources: list[dict]) -> list[str]:
     """The document-level Sources section, rendered one level shallower than the
     per-indicator blocks it replaces (`##`/`###` rather than `###`/`####`), because it
-    now sits alongside the other top-level sections rather than inside one.
+    now sits alongside the other top-level sections rather than inside one -- last of
+    them, since it is reference material a reader arrives at from a citation rather than
+    something to read past on the way to the indicators.
 
     Each source gets what someone re-using the data actually needs, rather than the
     retrieval date and URL the per-indicator blocks were limited to: what the source is,
@@ -711,7 +747,7 @@ def sources_section_lines(sources: list[dict]) -> list[str]:
         return []
     lines = ["", "## Source" if len(sources) == 1 else "## Sources", ""]
     lines.append(
-        "These are the sources behind the data in this package. Each time series below names the ones "
+        "These are the sources behind the data in this package. Each time series above names the ones "
         "it draws on in its citation."
     )
     for source in sources:

--- a/tests/collections/test_download_package.py
+++ b/tests/collections/test_download_package.py
@@ -223,6 +223,20 @@ def test_readme_strips_detail_on_demand_links():
     assert "Measured in terawatt-hours of energy." in out, "the label survives, only the link goes"
 
 
+def test_readme_puts_the_sources_section_after_the_indicators():
+    """Test _readme - Sources is the last section, not the one before the indicators.
+
+    It is reference material a reader arrives at from a citation. Ahead of the
+    indicators it pushed the column they opened the file for below several screens of
+    producer descriptions.
+    """
+    from etl.collection.download_package import _readme
+
+    out = _readme("Energy mix", "https://example.org", ["## Total generation"], sources_section="## Sources\n\nEmber")
+
+    assert out.index("## Detailed information") < out.index("## Sources")
+
+
 def test_zip_entries_are_stamped_with_the_build_date():
     """Test _zip_timestamp - entries carry the build date, not 1980.
 
@@ -239,3 +253,94 @@ def test_zip_entries_are_stamped_with_the_build_date():
     # Same day in, same stamp out -- this is what keeps a same-day rebuild byte-identical.
     assert _zip_timestamp(date(2026, 8, 27)) == _zip_timestamp(date(2026, 8, 27))
     assert _zip_timestamp(date(2026, 8, 28)) != _zip_timestamp(date(2026, 8, 27))
+
+
+def _indicator_meta() -> dict:
+    """An indicator's public metadata JSON, cut down to the fields the readme reads."""
+    return {
+        "name": "Total electricity generation",
+        "unit": "terawatt-hours",
+        "timespan": "1900-2025",
+        "processingLevel": "major",
+        "updatePeriodDays": 365,
+        "descriptionShort": "Total electricity generated, measured in terawatt-hours.",
+        "descriptionKey": ["Covers utility-scale generation only."],
+        "descriptionFromProducer": "Ember compiles this from national statistics.",
+        "descriptionProcessing": "We stitch Ember onto the Energy Institute's earlier years.",
+        "origins": [
+            {
+                "producer": "Ember",
+                "title": "Yearly Electricity Data",
+                "datePublished": "2026-04-21",
+                "dateAccessed": "2026-04-24",
+                "urlMain": "https://ember-energy.org/data/yearly-electricity-data/",
+            }
+        ],
+    }
+
+
+def test_indicator_section_sits_under_the_heading_that_introduces_it():
+    """Test column_readme_text - per-indicator headings are one level deeper than upstream's.
+
+    The document puts these sections under "## Detailed information about each time
+    series"; upstream's levels made each indicator a sibling of that heading rather
+    than a child, so the second half of the readme had no structure at all.
+    """
+    from datetime import date
+
+    from etl.collection.download_package_format import IndicatorColumn, column_readme_text
+
+    lines = column_readme_text(
+        IndicatorColumn(_indicator_meta()), date(2026, 8, 27), heading="Electricity - TWh", include_sources=False
+    )
+    headings = [line for line in lines if line.startswith("#")]
+
+    assert headings == [
+        "### Electricity - TWh",
+        "#### How to cite this data",
+        "#### What you should know about this data",
+        "#### How this data is described by its producers",
+        "#### Notes on our processing step for this indicator",
+    ]
+
+
+def test_indicator_section_drops_the_full_citation_and_softens_the_update_date():
+    """Test column_readme_text - the short citation stands alone, next update is expected.
+
+    The full citation restated producer names the Sources section already gives in
+    detail, and was a fifth of electricity-mix's readme. The next-update date is our
+    last update plus the producer's stated period, so it is an expectation, not a date
+    we can promise.
+    """
+    from datetime import date
+
+    from etl.collection.download_package_format import IndicatorColumn, column_readme_text
+
+    col = IndicatorColumn(_indicator_meta())
+    text = "\n".join(column_readme_text(col, date(2026, 8, 27), heading="Electricity - TWh", include_sources=False))
+
+    assert "Next expected update:" in text
+    assert "Next update:" not in text
+    assert col.citation_short() in text
+    assert "[original data]" not in text, "the full citation is gone"
+    assert "#### In-line citation" not in text, "nothing left to contrast the citation with"
+    # The full attribution moves in with the other facts about the indicator, above the
+    # citation rather than trailing it.
+    assert text.index("Source: ") < text.index("#### How to cite this data")
+
+
+def test_readme_describes_the_time_columns_the_package_actually_has():
+    """Test _readme - the CSV section names this package's time columns, not both options.
+
+    Upstream's readme is one static string, so it has to hedge ("either Year or Day").
+    This one is built per package, and a package that mixes resolutions has a
+    Frequency/Time pair that the hedge does not describe at all.
+    """
+    from etl.collection.download_package import _readme
+
+    annual = _readme("Energy mix", "https://example.org", [], time_header="Year")
+    assert '"Year" — the timepoint, as an integer year.' in annual
+    assert "Frequency" not in annual
+
+    stacked = _readme("Energy mix", "https://example.org", [], time_header="Time", frequency_column=True)
+    assert '"Frequency" and "Time"' in stacked

--- a/tests/collections/test_download_package.py
+++ b/tests/collections/test_download_package.py
@@ -344,3 +344,40 @@ def test_readme_describes_the_time_columns_the_package_actually_has():
 
     stacked = _readme("Energy mix", "https://example.org", [], time_header="Time", frequency_column=True)
     assert '"Frequency" and "Time"' in stacked
+
+
+def test_source_line_matches_the_citation_it_sits_next_to():
+    """Test get_source - semicolon-joined attributions, and one spelling of our name.
+
+    The port kept `getAttribution`'s old comma join and a hand-written "Our World In
+    Data" after upstream had moved to semicolons and a constant, so a readme credited
+    us two ways four lines apart and joined producers with a comma that several
+    producer names contain themselves.
+    """
+    from etl.collection.download_package_format import IndicatorColumn, get_attribution, get_source
+
+    col = IndicatorColumn(
+        {
+            "processingLevel": "major",
+            "origins": [
+                {"producer": "Ember", "datePublished": "2026-04-21"},
+                {
+                    "producer": "Department for Business, Energy & Industrial Strategy of the UK",
+                    "datePublished": "2023-01-01",
+                },
+            ],
+        }
+    )
+    attribution = get_attribution(col)
+
+    assert attribution == "Ember (2026); Department for Business, Energy & Industrial Strategy of the UK (2023)"
+    assert get_source(attribution, col).endswith("– with major processing by Our World in Data")
+    assert "Our World In Data" not in get_source(attribution, col)
+
+
+def test_owid_alone_is_not_credited_as_processing_its_own_data():
+    """Test get_source - no processing phrase when we are the sole attribution."""
+    from etl.collection.download_package_format import IndicatorColumn, get_source
+
+    col = IndicatorColumn({"processingLevel": "major"})
+    assert get_source("Our World in Data", col) == "Our World in Data"


### PR DESCRIPTION
## 👨 Summary

Rework data download readme following pablo's suggestions. The best way to see what's going on is to check side-by-side comparison [here](https://claude.ai/code/artifact/772f26df-08f3-40cf-8285-277ffd7f434c).

I haven't changed `.metadata.json` or added Excel format (created a separate issue from it).


> _Written by Claude Opus 5 — @Marigold at the wheel._

**The reworked readme, rendered before/after:** https://claude.ai/code/artifact/772f26df-08f3-40cf-8285-277ffd7f434c

Applies the review feedback in #6668 to the complete-dataset readme. On electricity-mix it goes from 85 kB to 54 kB over the same 46 indicators.

- **Per-indicator headings shift a level.** An indicator was `##`, a sibling of the `## Detailed information about each time series` that introduces it, so the whole second half of the document was flat. They are now `###`, their sub-sections `####`. `#### Notes on our processing step` is the one heading left alone — it was already a level too deep, reading as a child of the last source block, and now lines up with its siblings.
- **The full citation is gone.** It restated producer names the Sources section already gives in far more detail, and across 46 indicators it was a fifth of the file. `metadata_column_entry` still emits `citationLong`, so it stays in `metadata.json`. What is left under `#### How to cite this data` is the in-line citation.
- **`Source:` moves up** with `Last updated`, `Date range` and `Unit`. Upstream prints it immediately after the full citation, where it reads as a trailing fragment of it; with the full citation gone it sat next to the short one looking like a duplicate.
- **Sources come last, after the indicators.** It is reference material a reader arrives at from a citation, not something to read past on the way to the column they opened the file for.
- **"Next update" → "Next expected update".** The date is the producer's stated update period added to our last update — our expectation, not a promise.
- **"How is this data described by its producer - Ember (2026), Energy Institute … (2026), Pinto et al. (2023)?"** → **"How this data is described by its producers"**.
- **"About the data" → "How we process data at Our World in Data"**, and the sub-heading of that name goes away. The old heading announced a description of the dataset and delivered generic text about OWID's processing; that text is what the section is now called.
- **The CSV section is a bulleted list** and says which time columns this package has, rather than hedging "either Year or Day". A chart download's readme is one static string and has to hedge; this one is built per package, and a mixed-resolution collection has a `Frequency`/`Time` pair the hedge does not describe at all.

The `metadata.json` paragraphs and the processing text keep their existing wording — only the headings around them changed.

Two of Pablo's items are deliberately not here: `metadata.json` stays in the zip, and the Excel variant is on hold until we know whether anyone would use it.

## Keeping in sync with grapher

`download_package_format.py` is a port of `readmeTools.ts`, and the readme half has now deliberately moved ahead of it. None of these changes are MDIM-specific, so the same rework is in owid/owid-grapher#7136 for the chart download; the module docstring lists the divergences so they can be deleted once that lands.

## Testing

Six unit tests cover the heading levels, the dropped full citation and moved `Source:` line, the Sources section's position, the per-package time-column description, and the DoD stripping.

Checked end to end against the real thing: the published `electricity-mix.complete-dataset.zip` readme was reproduced byte-for-byte from the same indicator metadata through this code path, then regenerated with the changes applied and diffed side by side.

## What's left open

The published packages keep their old readmes until a forced production run — the deploy's `build_mdims_and_explorers` runs without `--force`, and ETL's change detection cannot see library-code changes.
