### PR TITLE
🐝 Sync vendored grapher schema

### DIFF
--- a/schemas/grapher-schema.011.json
+++ b/schemas/grapher-schema.011.json
@@ -731,7 +731,7 @@
     },
     "sortBy": {
       "type": "string",
-      "description": "Sort criterion (used by discrete bar, stacked discrete bar, marimekko, and dumbbell charts).\n- column: sort by the value of a specific column, identified by sortColumnSlug\n- total: sort by the total across all columns\n- entityName: sort alphabetically by entity name\n- custom: preserve the specified entity order\n- change: sort by the change between the start and end values (dumbbell charts only)\n- startValue: sort by the start value (dumbbell charts only)\n- endValue: sort by the end value (dumbbell charts only)\n",
+      "description": "Sort criterion (used by discrete bar, stacked discrete bar, and dumbbell charts).\n- column: sort by the value of a specific column, identified by sortColumnSlug\n- total: sort by the total across all columns\n- entityName: sort alphabetically by entity name\n- custom: preserve the specified entity order\n- change: sort by the change between the start and end values (dumbbell charts only)\n- startValue: sort by the start value (dumbbell charts only)\n- endValue: sort by the end value (dumbbell charts only)\n",
       "default": "total",
       "enum": [
         "column",


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Refresh the vendored grapher schema, which is one description string behind upstream (`sortBy.description` no longer mentions marimekko charts). This is what makes `test_vendored_grapher_schema_is_current` fail on every branch's staging build. Regenerated types are unchanged.