### PR TITLE
🐛 Servers dashboard: count deliberate wakes, not LXD restarts

### DIFF
--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -116,10 +116,10 @@ with st.container(horizontal=True, vertical_alignment="bottom", horizontal_align
         **Last commit**: age of the newest ETL/Grapher commit. This is reference info only — it does **not** by itself decide when a server is stopped.
 
         **Auto-stop** — when (and why) the reaper will stop a server:
-        - A running server is auto-stopped once **max(last commit, last _start_) is older than 14 days**. Stopping just idles it (data preserved); it's not destroyed.
-        - Because *last start* counts, **waking or restarting a server resets the clock** — so a server with an old commit can still be far from being stopped. The column shows the reason (e.g. *restarted Jun 19* vs *commit Jun 19*).
+        - A running server is auto-stopped once **max(last commit, last _wake_) is older than 14 days**. Stopping just idles it (data preserved); it's not destroyed.
+        - Because a *wake* counts, **using the Wake button resets the clock** — so a server with an old commit can still be far from being stopped. The column shows the reason (e.g. *woken Jun 19* vs *commit Jun 19*).
         - 🟢 healthy · 🟡 stops within a few days · 🔴 stops on the next nightly run · ⏸️ already idle · ♾️ persistent (`master`, never auto-stopped) · ❓ can't be judged (commit unreadable).
-        - ⚠️ A **host restart bumps every container's last-start at once**, resetting the timer fleet-wide — so right after a `gaia-1` reboot most servers will read the same countdown regardless of commit age.
+        - Only a **deliberate** wake counts. The weekly `gaia-1` reboot restarts every container, but it does not reset anyone's countdown.
 
         **Destroy** (frees the disk) only happens after the **PR is merged/closed** (~3 days later) — auto-stop never destroys.
 
@@ -449,8 +449,8 @@ else:
             "Auto-stop": st.column_config.TextColumn(
                 "Auto-stop",
                 help="When the reaper will stop this server, and why it's still alive. A server is "
-                "auto-stopped once max(last commit, last start) exceeds 14 days — so a recent "
-                "restart keeps an old-commit server running. 🟢 healthy · 🟡 stops soon · "
+                "auto-stopped once max(last commit, last wake) exceeds 14 days — so a recent "
+                "wake keeps an old-commit server running. 🟢 healthy · 🟡 stops soon · "
                 "🔴 stops tonight · ⏸️ already idle · ♾️ persistent.",
                 width="medium",
             ),

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -22,9 +22,9 @@ LXC_HOST = "gaia-1"
 
 # Auto-stop lifecycle, mirrored from the ops reaper cron
 # (ops/templates/lxc-manager/stop_staging_containers.py). A running container is stopped (idled,
-# data preserved) once its most recent sign of activity — max(latest commit, last *start*) — is
-# older than STOP_AFTER_DAYS. We recompute that here so the dashboard's "Auto-stop" column agrees
-# with what the cron will actually do. Keep these in sync with that script.
+# data preserved) once its most recent sign of activity — max(latest commit, last deliberate
+# *wake*) — is older than STOP_AFTER_DAYS. We recompute that here so the dashboard's "Auto-stop"
+# column agrees with what the cron will actually do. Keep these in sync with that script.
 STOP_AFTER_DAYS = 14
 # Container the reaper skips explicitly — never auto-stopped.
 PERSISTENT_CONTAINERS = {"staging-site-master"}
@@ -191,13 +191,18 @@ def _process_server_data(df: pd.DataFrame) -> pd.DataFrame:
     df["etl_commit_parsed"] = pd.to_datetime(df["etl_last_commit"], errors="coerce")
     df["grapher_commit_parsed"] = pd.to_datetime(df["grapher_last_commit"], errors="coerce")
 
-    # Last *start* time (bumped by LXC only on container start, not exec/ssh). This is what the
-    # reaper counts alongside commits, so a freshly-woken server isn't stopped the same night.
-    if "last_used_at" not in df.columns:
-        df["last_used_at"] = None
-    # format="ISO8601" handles LXC's variable fractional-second precision (and None) without the
-    # per-element dateutil fallback that pandas warns about.
-    df["last_used_parsed"] = pd.to_datetime(df["last_used_at"], errors="coerce", format="ISO8601")
+    # Last deliberate wake, stamped on the container by `owid-lxc start` (which is what the Wake
+    # button runs). This is what the reaper counts alongside commits, so a freshly-woken server
+    # isn't stopped the same night.
+    #
+    # Not LXD's own `last_used_at`: that is bumped by *any* start, and the weekly gaia-1 reboot
+    # restores every running container, so it read as "restarted last Monday" fleet-wide and the
+    # reaper could never reach the 14-day threshold for anything.
+    if "woken_at" not in df.columns:
+        df["woken_at"] = None
+    # format="ISO8601" handles both the plain "…Z" stamp we write and any fractional-second
+    # variant (and None) without the per-element dateutil fallback that pandas warns about.
+    df["woken_parsed"] = pd.to_datetime(df["woken_at"], errors="coerce", format="ISO8601")
 
     # Calculate days since last commit
     df["etl_days_old"] = _calculate_days_since_commit(df["etl_commit_parsed"])
@@ -412,9 +417,9 @@ def _format_last_commit_neutral(row: pd.Series) -> str:
 def _compute_auto_stop(row: pd.Series, now: datetime) -> str:
     """When (and why) the reaper will stop this server, mirroring stop_staging_containers.py.
 
-    The cron stops a running container once max(latest commit, last start) is older than
+    The cron stops a running container once max(latest commit, last wake) is older than
     STOP_AFTER_DAYS. We surface the countdown plus the reason it's still alive, so an old commit
-    next to a recent restart no longer reads as "should be dead".
+    next to a recent wake no longer reads as "should be dead".
     """
     # Idle servers are already stopped — the action is Wake, not a countdown.
     if row["status"] != "Running":
@@ -427,8 +432,8 @@ def _compute_auto_stop(row: pd.Series, now: datetime) -> str:
         return "❓ won't auto-stop (commit unreadable)"
 
     commit_date = _latest_commit_date(row)
-    last_used = _as_utc(row["last_used_parsed"]) if pd.notna(row["last_used_parsed"]) else pd.NaT
-    candidates = [d for d in (commit_date, last_used) if pd.notna(d)]
+    woken = _as_utc(row["woken_parsed"]) if pd.notna(row["woken_parsed"]) else pd.NaT
+    candidates = [d for d in (commit_date, woken) if pd.notna(d)]
     # No commit date at all → cron can't judge and skips it; mirror that rather than guess.
     if pd.isna(commit_date) or not candidates:
         return "❓ won't auto-stop (no commit date)"
@@ -436,9 +441,9 @@ def _compute_auto_stop(row: pd.Series, now: datetime) -> str:
     last_activity = max(candidates)
     days_left = STOP_AFTER_DAYS - (now - last_activity).days
 
-    # Which signal is keeping it alive — a recent restart or a recent commit?
-    if pd.notna(last_used) and last_used >= commit_date:
-        reason = f"restarted {last_used.strftime('%b %-d')}"
+    # Which signal is keeping it alive — a recent wake or a recent commit?
+    if pd.notna(woken) and woken >= commit_date:
+        reason = f"woken {woken.strftime('%b %-d')}"
     else:
         reason = f"commit {commit_date.strftime('%b %-d')}"
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Dashboard half of owid/ops#646. Read that one for the actual bug.

Short version: the reaper kept a server alive on `max(latest commit, last_used_at)`, but LXD's `last_used_at` is bumped by *any* start — including the weekly `gaia-1` reboot restoring every container. So no server's clock ever passed 7 days, the 14-day threshold was unreachable, and nothing has been auto-stopped since the reboot timer went in. This dashboard mirrors the reaper's logic, so it faithfully reported "in 13d · restarted Aug 31" for all 110 running servers.

`owid-lxc start` now stamps `user.owid.woken_at` and the reaper reads that. Here:

- `_compute_auto_stop` uses `woken_at` instead of `last_used_at`, and the reason reads `woken Jun 19` rather than `restarted Jun 19`.
- The About popover carried a ⚠️ noting that a host restart resets the timer fleet-wide. That was an accurate description of the bug, so it now says the opposite: only a deliberate wake counts.
- `last_used_at` is gone from the dashboard entirely — it was only ever feeding this calculation.

## How to test it

Open the servers dashboard on the staging server. Every running server should now show `commit <date>` as the reason (nothing has a wake stamp yet), with countdowns that track commit age instead of all reading the same number. Wake an idle server from the dashboard and it should flip to `woken <today>` with a fresh 14 days — that part needs owid/ops#646 merged and pulled onto `etl-prod-2` first, since the stamp is written by `owid-lxc start`.

## Still open

- Merge order: this is safe to merge alone (no stamp anywhere → column falls back to commit date, which is conservative), but the Wake button only becomes durable again once ops#646 is on `etl-prod-2`.
- Nobody has checked the 21 servers the ops dry run would stop against who is actually using them.
