### PR TITLE
📜🤖 create-figma-chart: move Steps 1 and 3 into reference/, holding the spine's 64 KB cap

### DIFF
--- a/.claude/skills/create-figma-chart/SKILL.md
+++ b/.claude/skills/create-figma-chart/SKILL.md
@@ -81,10 +81,12 @@ Two more sibling files own a route each, and both replace rather than supplement
 
 This page is the **spine**: the step order, the checkpoints, and the routing. The detail for each
 step lives in [`reference/`](reference/) and is read *at* that step, not up front — the whole set is
-~180 KB and no run needs all of it.
+~510 KB and no run needs all of it.
 
 | Read | When | Covers |
 |---|---|---|
+| [reference/RESOLVING-THE-CHART.md](reference/RESOLVING-THE-CHART.md) | Step 1 | Every input form's route to an SVG URL and the trap in each, where each template text comes from, and the entity-completeness check with the right baseline. |
+| [reference/EXPORTING.md](reference/EXPORTING.md) | Step 3, before the embed export | The canvas-versus-chart aspect solve and its per-axis insets, `imFontSize`, the `imType=square` alternative and when it wins, and the silent `tab=` fallback. |
 | [reference/NODE-MAP.md](reference/NODE-MAP.md) | Step 5, before cloning anything | The yearly Charts file's node ids, the ten templates, per-family slot sizes, header sizing and the band table. Run `scripts/verify_templates.js` from here **every run** — a `DRIFT` verdict stops the run. |
 | [reference/TEXTS.md](reference/TEXTS.md) | Step 6 | Filling the template's text slots, and the header reflow that makes the band measurable. |
 | [reference/FITTING.md](reference/FITTING.md) | Step 7 | Measuring the band, importing the embed, unwrapping and scaling. The local-SVG restyle route. |
@@ -100,7 +102,9 @@ its per-chart-type conventions are now one file each under
 under 145 KB.** (Raised from 62/140 on 2026-08-28, once, to land the benchmark's second-run lessons — the
 spine was already 925 bytes over before they were added, so the old figure had stopped describing the file.
 A cap that moves whenever it is hit is not a cap: the discipline below is unchanged, and the next addition
-pays for itself by deduplicating rather than by another raise.) Both are read on every run, so a paragraph added here costs every future
+pays for itself by deduplicating rather than by another raise.) **Held at 64 KB on 2026-09-02**, with 19 bytes
+left, by moving Steps 1 and 3 into `reference/` — the remedy this paragraph names, and the one Steps 6 to 8c
+already model: the spine routes, the step's own file carries the detail. Both are read on every run, so a paragraph added here costs every future
 chart — and moving one from this file into GUIDELINES.md saves a run nothing, which is why the pair
 is capped and not just each file. New detail belongs in the
 reference file for its step, which is read only at that step. After editing any doc in this skill:
@@ -209,61 +213,24 @@ TEXT node dropped beside your frame — as the feedback it is.
 
 ## Step 1 — Resolve the chart and gather its text
 
-Get an SVG URL for the chart, whatever form the reference takes:
+Get an SVG URL for the chart, then pull its texts. **[reference/RESOLVING-THE-CHART.md](reference/RESOLVING-THE-CHART.md) carries the full routing table and the trap in each route** — read the row for the input you were handed, not the whole table.
 
 | Input | SVG URL |
 |---|---|
-| Slug or default grapher link | `https://ourworldindata.org/grapher/<slug>.svg` |
-| Customized grapher link (query params) | insert `.svg` before the `?`, keep the query verbatim: `https://ourworldindata.org/grapher/<slug>.svg?country=USA~CHN&time=1990..latest` — `country`, `time`, `tab`, `stackMode`, `region`, `focus`, … are all honored, and slug redirects work |
-| MDim view | same — the dimension params select the view: `.../energy-mix.svg?metric=per_capita&source=coal` |
-| **Explorer view** | `https://ourworldindata.org/explorers/<slug>.svg?<view params>` — `EXPLORER_DYNAMIC_THUMBNAIL_URL` in `settings/clientSettings.ts`. **Carry the view's full param set:** requested bare it returns an axis and nothing else, at HTTP 200 (2 texts, no series). Verified on the `imType=thumbnail` route; untested for the other `imType`s. |
-| **Bespoke component** (no slug, no `.svg`) | there is no endpoint — render and serialize the component yourself. See [BESPOKE-SVG.md](BESPOKE-SVG.md). |
-| Admin link `/admin/charts/<id>/edit` | **`/admin/charts/<id>.svg` does not exist** (it returns the admin SPA shell). Resolve the chart's `configId` — `SELECT configId FROM charts WHERE id = <id>` on the public Datasette (see the `query-grapher-db` skill), or `GET /admin/api/charts/<id>.config.json` — then use `https://ourworldindata.org/grapher/by-uuid/<configId>.svg`. Works for unpublished drafts too. |
-| Narrative chart (**name**) | name → uuid via the unauthenticated map `https://admin.owid.io/api/narrative-chart-map`, then `https://ourworldindata.org/grapher/by-uuid/<uuid>.svg`. Being unauthenticated, this one route works from a cloud sandbox, while the *authenticated* `admin.owid.io` routes are Access-blocked there — test a specific route rather than assuming the host |
-| Narrative chart (**admin link with a numeric id**, `/admin/narrative-charts/<id>/edit`) | **Try the direct lookup first** — `select id, name, chartConfigId from narrative_charts where id = <id>` on the public Datasette hands you the uuid outright (note the column is `chartConfigId`, not `configId`). Only when the id isn't mirrored yet do you need the guessing route below. |
-| … the same, when the id is **newer than the Datasette mirror** | there is no id→uuid endpoint and the mirror lags production by days. Diff the live name-keyed map against `select name from narrative_charts` for the unmirrored names, then order them by uuid — **uuidv7, so lexical order is creation order** — and count up from the mirror's highest id. That is a *candidate*, not an answer: ids have gaps where charts were deleted, so **always render it and have the user confirm before building**. The **name is the stronger signal** — these are named after the piece they serve (`share-of-women-in-parliament-di`), so an unmirrored name matching the DI's topic and carrying the highest uuid is near-certain. Note a published DI can have `linkedNarrativeCharts: {}` because it ships a hand-made PNG, so the chart may be newer than the post; its embedded JSON still gives `grapher-url`, `authors` and the body text Step 2 needs. |
-| Description only | find candidates via site search (`https://ourworldindata.org/search?q=...`) or a Datasette title match; show the candidates and confirm before proceeding |
-| **Local SVG on disk** (from an `export://static_viz` step) | nothing to resolve — the file *is* the export. Skip the whole texts table below: an ETL step bakes its title, subtitle, `Note:`, `Data source:` and license line into the SVG, building the source string from the indicator's `origins` rather than from `chart.citation`. Read the strings straight out of the file if you need them (`grep -o '<text[^>]*>[^<]*' <file>.svg`), and take the frame's target template from the step, which already sized the figure to it. |
+| Slug, default grapher link, or MDim view | `https://ourworldindata.org/grapher/<slug>.svg?<the view's params, kept verbatim>` |
+| Explorer view | `https://ourworldindata.org/explorers/<slug>.svg?<the view's FULL param set>` — requested bare it returns an axis and nothing else, at HTTP 200 |
+| Admin link `/admin/charts/<id>/edit` | resolve the chart's `configId`, then `grapher/by-uuid/<configId>.svg` — `/admin/charts/<id>.svg` does not exist |
+| Narrative chart | name → uuid via `admin.owid.io/api/narrative-chart-map`, then `grapher/by-uuid/<uuid>.svg`. A numeric id needs a Datasette lookup, and an id newer than the mirror needs the guessing route |
+| Bespoke component | no endpoint — render and serialize it yourself ([BESPOKE-SVG.md](BESPOKE-SVG.md)) |
+| Description only | find candidates by search, and confirm one before proceeding |
+| Local SVG from an `export://static_viz` step | nothing to resolve and no texts to pull — the step baked them into the file |
 
-Then pull the chart's texts, which seed the template texts in Step 6. Read them from **`.metadata.json`**, not `.config.json`, and **keep the view's query params on the request** — `.../energy-mix.metadata.json?metric=per_capita&source=coal` resolves the selected MDim view exactly as the `.svg` request does:
+Then pull the chart's texts, which seed the template texts in Step 6. Read **`.metadata.json`**, not `.config.json`, and **keep the view's query params on the request**: it gives title, subtitle, note and `chart.citation`, with grapher's detail-on-demand markup already unwrapped. The `by-uuid` route is the exception — it has no `.metadata.json`, so a narrative chart's texts come off `.config.json` plus the rendered SVG's footer.
 
-| Template text | Where it comes from |
-|---|---|
-| Title | `chart.title` |
-| Subtitle | `chart.subtitle`; when that's absent the chart is inheriting the indicator's `description_short` — take `columns[<column>].descriptionShort` |
-| Note | `chart.note` (absent when the chart has none) |
-| Data source | `chart.citation` — verbatim what grapher prints after `Data source:` |
-| Topic page | **`.config.json` → `originUrl`** — the one field `.metadata.json` doesn't give (its `chart.originalChartUrl` is the grapher URL, not the topic page). Often null; fall back to asking the user in Step 2. |
+Two things here are not optional, and the reference file works both through:
 
-`.config.json` is not a substitute: it never carries the source attribution, it carries `subtitle`/`note` only when a chart overrides them manually, and **for an MDim slug it 404s** — per-view configs aren't exposed under that path. Pass *every* dimension a view needs; a partial MDim param set returns an empty payload (`title: null`, no columns). If a text is ever in doubt, the rendered SVG is the tie-breaker — it shows exactly what the footer will say.
-
-These texts also arrive **render-ready**: the endpoint unwraps grapher's detail-on-demand links across the whole payload, so a `description_short` written as `[lower secondary](#dod:lower-secondary-education)` reaches you as plain `lower secondary` — paste it as-is, and don't hand-strip anything. `.config.json` hands back the raw markup instead, which is one more reason not to take texts from it.
-
-> **The one exception: `by-uuid` has no `.metadata.json`** — that route serves only `.config.json`, `.png` and `.svg`, so the request 404s. For a **narrative chart**, therefore, take the texts from `by-uuid/<uuid>.config.json`, which is complete for that case: a narrative chart stores its own `title`/`subtitle`/`note`/`originUrl` overrides rather than inheriting them. What it still won't give you is the source attribution — read that off the rendered SVG's footer instead, and re-derive nothing (see the producer-name rule below).
->
-> **In that case read *every* text off the SVG, not just the source.** `.config.json` hands back raw detail-on-demand markup, so a note stored as `expressed in [international-$](#dod:int_dollar_abbreviation)` arrives with the brackets attached and you are one hand-edit away from pasting them into the template. The rendered SVG carries the same strings already unwrapped, in `<g id="header">` (title, subtitle) and `<g id="footer">` (sources, note) — one fetch, render-ready, and it is the file you are importing anyway:
->
-> ```bash
-> .venv/bin/python -c "import html,re,sys; s=open(sys.argv[1]).read(); cut=lambda a,b: html.unescape(re.sub(r'\s+',' ', re.sub(r'<[^>]*>?',' ', s[s.find('>',s.find(a))+1:b]))).strip(); print(cut('id=\"header\"', s.find('id=\"chart-area\"')), '\n\n', cut('id=\"footer\"', None))" chart.svg
-> ```
->
-> Two details the command has to get right: the footer group sits **after** `chart-area` in the document, so a slice that stops at the plot returns the title and subtitle only and quietly loses the source and note; and the SVG carries XML entities (`&#x27;` for an apostrophe), so unescape before pasting.
-
-**Never shorten the producer's name to make it fit.** The footer string is the producer's official name — verify it against `rg "producer: .*<name>" snapshots/` if you're unsure — and "Food and Agriculture Organization of the United Nations" does not become "UN Food and Agriculture Organization" because the line is too long. When it overruns the CC BY text, wrap it (Step 7) rather than editing it.
-
-**Check that every selected entity actually renders.** The failure is not always a missing *latest* year — an entity can be selected and have **no data at all**: `cereal-yield` carries both `North America` and `Northern America` in its selection and the latter has zero rows, so seven selected entities render six lines, and have done for as long as the chart has existed. Two near-identical region names in one selection is the signature; check the count of drawn series against the selection every time, and report a permanent absence as a chart-config bug (not a regression) so someone removes it. Grapher also silently drops an entity whose data doesn't reach the displayed year, with no warning anywhere — a chart pinned to 2023 quietly showed ten of its eleven countries because one stopped at 2022, and the DI text still discussed the missing one. Compare the **effective** selection against the entity labels in the exported SVG, and if they differ, say so before building: the fix is the narrative chart's tolerance setting (or pinning the year), and it belongs to whoever owns the chart.
-
-  "Effective" is the catch. `selectedEntityNames` in `.config.json` is the *saved* chart's selection, so it is the wrong baseline for exactly the inputs this skill takes most often:
-
-  | Input | Baseline to compare the SVG against |
-  |---|---|
-  | Bare slug, or `by-uuid` | `selectedEntityNames` from `.config.json` |
-  | Link carrying `country=` (or `focus=`) | the **URL's** list — it overrides the saved selection entirely |
-  | MDim view | the URL's `country=` if present, otherwise the view's resolved `selectedEntityNames` read from the grapher DB — `multi_dim_x_chart_configs mx JOIN chart_configs cc ON cc.id = mx.chartConfigId` (`/query-grapher-db`) |
-
-  `life-expectancy.config.json` lists `World, Americas, Europe, Africa, Asia, Oceania`, but `life-expectancy.svg?country=USA~CHN` contains only `China` and `United States` — take the config as the baseline there and the check reports six entities missing and two unexpected, on a chart where nothing is wrong. And note the two sides speak different languages: `country=` takes **ISO codes** while the SVG prints **names**, so resolve the codes before comparing rather than diffing the strings.
-
-  **Never use the rendered labels as their own baseline.** For an MDim view with no `country=` it is the tempting shortcut — `.config.json` 404s on MDim slugs (see Gotchas), so the SVG is the only thing in reach. But Step 8c then compares the SVG against the SVG: an entity grapher silently dropped for having no data in this view is missing from **both** sides, so the must-pass completeness check reports success precisely when it should fail. That is the ten-of-eleven defect further down this page, dressed as a green check. Read the resolved selection from the DB, and if you cannot, **report the completeness check as unavailable** for that frame. An honest gap in coverage is worth more than a check that cannot fail.
+- **Never shorten the producer's name to make it fit.** When it overruns the CC BY text, wrap it (Step 7) rather than editing it.
+- **Check that every selected entity actually renders**, comparing the SVG against the *effective* selection rather than the saved one — and never against the rendered labels themselves. Grapher drops an entity with no data in the displayed window silently, so a check that reads the SVG as its own baseline reports success precisely when it should fail.
 
 ## Step 2 — Ask the run options, all at once
 
@@ -288,18 +255,7 @@ One `AskUserQuestion` batch — don't drip-feed or assume an answer while asking
 
 ## Step 3 — Export the SVGs
 
-> **Local SVG on disk: there is nothing to export.** When the input is a file from an
-> `export://static_viz` step, skip this whole step. The step chose its own `figsize` to match a
-> template's proportions, so none of the `imType` / `imFontSize` / `imWidth` aspect solving below
-> applies, and there is no chart-only "embed" to export — the file already *is* the framed chart,
-> carrying its own title, subtitle, `Note:`, `Data source:` and license at that template's own slot
-> positions. So the two assets below come from the step's own output rather than from a `curl`: the
-> **PNG** it emits beside the SVG is the flat reference copy for the page, and the **SVG** is what
-> goes into the template clone. `upload_assets` takes a local path unchanged. Then follow the
-> local-SVG route in Steps 5 and 7 — it replaces the measure-solve-export-fit ordering entirely,
-> because a frame that already matches the template has nothing left to solve.
-
-Two exports per format family: the **original** (placed on the page as the reference copy) and the **embed** (chart area only, placed inside the template).
+Two exports per format family: the **original** (placed on the page as the reference copy) and the **embed** (chart area only, placed inside the template). **[reference/EXPORTING.md](reference/EXPORTING.md) carries the aspect solve, the `imFontSize` rule, the square-render route and the `tab=` trap** — read it before you export the embed.
 
 **Export the original now; export the embed only after the template texts are in (Step 6).** The embed's aspect ratio has to match the band between the header and the footer, and the header's height is not known until the real title and subtitle have reflowed it — a three-line title moves the band by ~30px, which is twice the whole gap budget. The order that avoids re-exports is: original → clone the template → fill the texts → **measure the band** → export the embed → import and fit. Every page in this run that skipped ahead needed a second export.
 
@@ -315,90 +271,9 @@ curl -sL "https://ourworldindata.org/grapher/<slug>.svg?<params>&imType=square&n
 curl -sL "https://ourworldindata.org/grapher/<slug>.svg?<params>&imType=uncaptioned&imWidth=<W>&imHeight=<H>&nocache" -o $DIR/embed.svg
 ```
 
-`imWidth`/`imHeight` set the **aspect ratio only** — the server renormalizes the SVG to ~510k px², so you cannot request a bigger SVG (irrelevant: it's a vector; you scale it in Figma). Sanity-check what came back:
+> **[`scripts/solve_export.py`](scripts/solve_export.py) solves the embed's numbers — don't do the arithmetic by hand.** `--band 508x371 --slug <slug> --params '<the view's query string>'` returns the `imFontSize`, the `imWidth`/`imHeight` to request, the height-first scale into the band and the finished `curl`. **Omit `--params` and that `curl` exports the DEFAULT chart** — a valid, plausible SVG of the wrong entities. It is a two-pass tool, and pass 1 is a probe even when your numbers are measured; EXPORTING.md says why, and what changes between the passes.
 
-> **This is true of the default and `uncaptioned` routes only.** `extractOptions` (`functions/_common/imageOptions.ts`) **returns early** for `imType=thumbnail` and `imType=square`, so neither the `MIN/MAX_ASPECT_RATIO` clamp nor the ~510k normalization runs on them. On the thumbnail route `imWidth`/`imHeight` set the size outright — `staticBounds` becomes `imWidth/4 × imHeight/4` — which is what lets a 302-wide small chart arrive at exactly 302px and skip the Figma rescale entirely (SMALL-CHARTS.md → The export).
-
-```bash
-head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <html
-```
-
-> **[`scripts/solve_export.py`](scripts/solve_export.py) does this arithmetic — don't do it by hand.**
-> Run it from the repo root through the venv — `.venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py …`;
-> it is committed non-executable like the rest of that directory.
-> `--band 508x371 --slug <slug> --params '<the view's query string>'` returns the solved
-> `imFontSize`, the `imWidth`/`imHeight` to
-> request, the predicted content box, the **height-first** scale into the band, the leftover width
-> the x-map has to close, the final label size, and the finished `curl`. **Omit `--params` and that
-> `curl` exports the DEFAULT chart** — a valid, plausible SVG of the wrong entities. Two things more:
-> it reports the leftover width rather than a predicted gap, because the gap is exact by
-> construction once you fit the height (Step 7) — that leftover is the same quantity
-> `measure_fit.js` reports as `xMapShortfall`, and it is the aspect miss expressed in px; and every
-> number comes from the **rounded** `imFontSize`, since that is what the URL carries, so the label
-> size quoted is the one the `curl` will actually produce (it prints the ideal font alongside when
-> rounding moves it). It is a TWO-PASS tool: `--band` alone is pass 1, a probe under the symmetric
-> `1.4 × imFontSize` inset model; pass 2 re-runs with `--declared`/`--ink`/`--im-font-size` measured
-> off the probe's import and is exact, because the real inset is per-axis, not symmetric (see Step 7
-> and reference/FITTING.md). It also carries its own `--self-test` (the worked examples, the band
-> round-trip, and a real run's two measured-inset passes) and the `--thumbnail` route for a 302-wide
-> chart.
->
-> **It solves for `band − 2×--gap`, not for the band** — the gap below is a requirement of the fit,
-> so a solve that ignores it lands the chart edge to edge and you re-export. `--gap` defaults to 14
-> and takes 30 for the Instagram portrait; a 508×371 band makes the target 508×343, 14px at each
-> end. The canvas model is confirmed against the real renderer — a `--gap 0` solve predicted 828×616
-> and grapher returned **829×616**, landing labels at exactly 13.5px — so it is the target fed into
-> it that the gap changes. After you have measured a real import, run the `nextPass` command that
-> `measure_fit.js` prints — with its `CONFIG.declared` and `CONFIG.imFontSize` set from the probe,
-> it is the exact measured-inset second pass rather than another guess — see Step 7.
-
-**The aspect you request is the *canvas*, not the chart — so solve for the padding, or you re-export every page.** Grapher insets the drawing inside the SVG it returns, and it is the imported *group* that has to fill the band, so requesting the aspect you want yields a chart that misses it (measured: a 336.9px chart where 343 was needed — a 17px gap against a 14px target). `solve_export.py` does this arithmetic; its `--help` carries the closed-form solve, the canvas model and the measured per-axis insets, so read it there rather than re-deriving it here.
-
-**The inset is per-axis, and it grows once the furniture you are replacing is out of the measurement — so pass 1 is a probe even with measured numbers.** Dropping the end label from the measurement on a single-series chart took this chart's `insetX` from the 64.1 its own docstring records to **122.08**, because the reserved right margin left the ink: the requested aspect came back as a 1.31 group where 1.4033 was solved for, and the x-map correctly REFUSED to close a 7.2% miss by squeezing. Exclude everything you are replacing from the measurement — `measure_fit.js`'s `hideNames`/`hideIds` compute the aspect *as if* those nodes were hidden **without** hiding them, so the probe needs no mutation at all — then run the pass-2 command.
-
-**Then be ready for the target itself to move: taking the replaced furniture out changes the group's aspect.** `connectors` extend to the right of the plot, so dropping them (Step 8) narrows the group and makes it relatively *taller* — the same export that was solved for a 1.6026 content aspect measured 1.5558 once the elbows were gone, turning a 14px gap into 9.5px. Account for the connectors and the year markers **before** you measure and scale, not after, and re-read the aspect from the group you are actually going to fit.
-
-**And the two cases take different actions — this is where hiding bites.** For the probe, *exclude* the furniture from the measurement as above; nothing is mutated. Before the **final** measurement and fit, *remove* the replaced nodes from the working clone. A node switched off with `visible = false` still contributes to its group's `absoluteBoundingBox`, which is exactly what `box-alignment` reads — the 2.28px failure worked through in reference/FITTING.md, on a chart whose visible ink measured 508.001 exactly.
-
-> **Square charts, second route:** grapher's `imType=square` render re-lays out the chart for a square
-> canvas (legend placement, font sizing tuned by the web team). Import the full square SVG and delete its
-> `header` and `footer` groups after import. Its attraction is that it can land ladder-exact with no
-> rescale at all — measured once at a ≈505×328 chart area with every label at exactly **15px**, where
-> reaching 15px through `imType=uncaptioned` took `imFontSize≈36` — which also spent more of the frame
-> on furniture, coming back with a **279px** plot against the square route's **294.6px**.
->
-> **But it is laid out under grapher's OWN header and footer, not the template's, so its chart area is
-> sized for a band you are not filling — and that usually loses.** Across five DI pages it came back
-> **314.9px** tall for a **371px** band: a 28px gap at each end, twice the target, closable only by a
-> rescale that then breaks the width. So **measure the band first (Step 7), then pick**, comparing the two
-> exports on three numbers — final font size at the template width, plot height, plot width. The square
-> route wins only when its chart area happens to fill your band (a short template header, or a map or
-> big-legend chart whose square re-layout is genuinely better). The band is knowable only once the
-> template texts are in, which is why Step 6 comes before the embed export.
-
-**Size the text at export time with `imFontSize` — scaling in Figma cannot fix it.** Grapher picks a base font for the canvas it renders (`max(10, height/25)`, so ~24 for the default uncaptioned export), and every label is derived from it — the segment values and country names land at about **0.75 × the base**. Placing that export at 508px wide shrinks all of it by the same factor, so a default export ends up with ~12px labels: legal, but on the floor of the 12px minimum. Ask for a bigger base instead — `imFontSize=28` gives ~13.5px labels and ~14px legend text in a 540 frame, which matches the template's own 14px source line. Check the export before importing:
-
-```bash
-grep -oE 'font-size="[0-9.]+"' chart.svg | sort | uniq -c | sort -rn | head -3
-# multiply the most common value by (508 / the export's content width) to get the final size
-```
-
-Bigger text needs more room, so this trades against how much fits — see the axis rule in Step 8 and, failing that, the entity count.
-
-**`tab=` FALLS BACK SILENTLY when the chart does not declare that type — check the mark group, not the HTTP status.** `co-emissions-per-capita?tab=marimekko` returns 200 and a plausible 9 KB SVG containing `lines`: a line chart. `tab=stacked-discrete-bar` on the same slug returns `stacked-areas`. Nothing errors and the file looks right, so a whole "chart-type sweep" can be built on two charts that are not the types you asked for — which is what happened here. Two defences: find charts that actually declare the type (`json_extract_string(cc.config, '$.chartTypes')` on the public Datasette — `/query-grapher-db`), and assert the mark group in the returned SVG:
-
-| type | mark group `id` |
-|---|---|
-| line | `lines` |
-| discrete bar | `bars` + `entity-labels` + `value-labels` |
-| stacked discrete bar | `bars` |
-| stacked area | `stacked-areas` |
-| slope | `slopes` |
-| scatter | `points` |
-| marimekko | `marimekko-chart` |
-| map | `map` |
-
-Caveats: `?tab=table` is silently ignored (renders the default tab); `imSquareSize` affects PNG only; add `nocache` when re-exporting after a config change.
+**Local SVG on disk: skip this step entirely.** A file from an `export://static_viz` step already *is* the framed chart at a template's proportions, so none of the aspect solving applies — take the SVG and the PNG the step emitted, and follow the local-SVG route in Steps 5 and 7.
 
 ## Step 4 — Propose, then get the go-ahead
 

--- a/.claude/skills/create-figma-chart/reference/EXPORTING.md
+++ b/.claude/skills/create-figma-chart/reference/EXPORTING.md
@@ -1,0 +1,100 @@
+# Step 3 — Export the SVGs
+
+> Read at Step 3.  Part of [`/create-figma-chart`](../SKILL.md); the spine has the step order.
+
+
+> **Local SVG on disk: there is nothing to export.** When the input is a file from an
+> `export://static_viz` step, skip this whole step. The step chose its own `figsize` to match a
+> template's proportions, so none of the `imType` / `imFontSize` / `imWidth` aspect solving below
+> applies, and there is no chart-only "embed" to export — the file already *is* the framed chart,
+> carrying its own title, subtitle, `Note:`, `Data source:` and license at that template's own slot
+> positions. So the two assets below come from the step's own output rather than from a `curl`: the
+> **PNG** it emits beside the SVG is the flat reference copy for the page, and the **SVG** is what
+> goes into the template clone. `upload_assets` takes a local path unchanged. Then follow the
+> local-SVG route in Steps 5 and 7 — it replaces the measure-solve-export-fit ordering entirely,
+> because a frame that already matches the template has nothing left to solve.
+
+`imWidth`/`imHeight` set the **aspect ratio only** — the server renormalizes the SVG to ~510k px², so you cannot request a bigger SVG (irrelevant: it's a vector; you scale it in Figma). Sanity-check what came back:
+
+> **This is true of the default and `uncaptioned` routes only.** `extractOptions` (`functions/_common/imageOptions.ts`) **returns early** for `imType=thumbnail` and `imType=square`, so neither the `MIN/MAX_ASPECT_RATIO` clamp nor the ~510k normalization runs on them. On the thumbnail route `imWidth`/`imHeight` set the size outright — `staticBounds` becomes `imWidth/4 × imHeight/4` — which is what lets a 302-wide small chart arrive at exactly 302px and skip the Figma rescale entirely (SMALL-CHARTS.md → The export).
+
+```bash
+head -c 300 $DIR/embed.svg   # expect <svg ... width="..." height="...">, no <html
+```
+
+> **[`scripts/solve_export.py`](../scripts/solve_export.py) does this arithmetic — don't do it by hand.**
+> Run it from the repo root through the venv — `.venv/bin/python .claude/skills/create-figma-chart/scripts/solve_export.py …`;
+> it is committed non-executable like the rest of that directory.
+> `--band 508x371 --slug <slug> --params '<the view's query string>'` returns the solved
+> `imFontSize`, the `imWidth`/`imHeight` to
+> request, the predicted content box, the **height-first** scale into the band, the leftover width
+> the x-map has to close, the final label size, and the finished `curl`. **Omit `--params` and that
+> `curl` exports the DEFAULT chart** — a valid, plausible SVG of the wrong entities. Two things more:
+> it reports the leftover width rather than a predicted gap, because the gap is exact by
+> construction once you fit the height (Step 7) — that leftover is the same quantity
+> `measure_fit.js` reports as `xMapShortfall`, and it is the aspect miss expressed in px; and every
+> number comes from the **rounded** `imFontSize`, since that is what the URL carries, so the label
+> size quoted is the one the `curl` will actually produce (it prints the ideal font alongside when
+> rounding moves it). It is a TWO-PASS tool: `--band` alone is pass 1, a probe under the symmetric
+> `1.4 × imFontSize` inset model; pass 2 re-runs with `--declared`/`--ink`/`--im-font-size` measured
+> off the probe's import and is exact, because the real inset is per-axis, not symmetric (see Step 7
+> and reference/FITTING.md). It also carries its own `--self-test` (the worked examples, the band
+> round-trip, and a real run's two measured-inset passes) and the `--thumbnail` route for a 302-wide
+> chart.
+>
+> **It solves for `band − 2×--gap`, not for the band** — the gap below is a requirement of the fit,
+> so a solve that ignores it lands the chart edge to edge and you re-export. `--gap` defaults to 14
+> and takes 30 for the Instagram portrait; a 508×371 band makes the target 508×343, 14px at each
+> end. The canvas model is confirmed against the real renderer — a `--gap 0` solve predicted 828×616
+> and grapher returned **829×616**, landing labels at exactly 13.5px — so it is the target fed into
+> it that the gap changes. After you have measured a real import, run the `nextPass` command that
+> `measure_fit.js` prints — with its `CONFIG.declared` and `CONFIG.imFontSize` set from the probe,
+> it is the exact measured-inset second pass rather than another guess — see Step 7.
+
+**The aspect you request is the *canvas*, not the chart — so solve for the padding, or you re-export every page.** Grapher insets the drawing inside the SVG it returns, and it is the imported *group* that has to fill the band, so requesting the aspect you want yields a chart that misses it (measured: a 336.9px chart where 343 was needed — a 17px gap against a 14px target). `solve_export.py` does this arithmetic; its `--help` carries the closed-form solve, the canvas model and the measured per-axis insets, so read it there rather than re-deriving it here.
+
+**The inset is per-axis, and it grows once the furniture you are replacing is out of the measurement — so pass 1 is a probe even with measured numbers.** Dropping the end label from the measurement on a single-series chart took this chart's `insetX` from the 64.1 its own docstring records to **122.08**, because the reserved right margin left the ink: the requested aspect came back as a 1.31 group where 1.4033 was solved for, and the x-map correctly REFUSED to close a 7.2% miss by squeezing. Exclude everything you are replacing from the measurement — `measure_fit.js`'s `hideNames`/`hideIds` compute the aspect *as if* those nodes were hidden **without** hiding them, so the probe needs no mutation at all — then run the pass-2 command.
+
+**Then be ready for the target itself to move: taking the replaced furniture out changes the group's aspect.** `connectors` extend to the right of the plot, so dropping them (Step 8) narrows the group and makes it relatively *taller* — the same export that was solved for a 1.6026 content aspect measured 1.5558 once the elbows were gone, turning a 14px gap into 9.5px. Account for the connectors and the year markers **before** you measure and scale, not after, and re-read the aspect from the group you are actually going to fit.
+
+**And the two cases take different actions — this is where hiding bites.** For the probe, *exclude* the furniture from the measurement as above; nothing is mutated. Before the **final** measurement and fit, *remove* the replaced nodes from the working clone. A node switched off with `visible = false` still contributes to its group's `absoluteBoundingBox`, which is exactly what `box-alignment` reads — the 2.28px failure worked through in reference/FITTING.md, on a chart whose visible ink measured 508.001 exactly.
+
+> **Square charts, second route:** grapher's `imType=square` render re-lays out the chart for a square
+> canvas (legend placement, font sizing tuned by the web team). Import the full square SVG and delete its
+> `header` and `footer` groups after import. Its attraction is that it can land ladder-exact with no
+> rescale at all — measured once at a ≈505×328 chart area with every label at exactly **15px**, where
+> reaching 15px through `imType=uncaptioned` took `imFontSize≈36` — which also spent more of the frame
+> on furniture, coming back with a **279px** plot against the square route's **294.6px**.
+>
+> **But it is laid out under grapher's OWN header and footer, not the template's, so its chart area is
+> sized for a band you are not filling — and that usually loses.** Across five DI pages it came back
+> **314.9px** tall for a **371px** band: a 28px gap at each end, twice the target, closable only by a
+> rescale that then breaks the width. So **measure the band first (Step 7), then pick**, comparing the two
+> exports on three numbers — final font size at the template width, plot height, plot width. The square
+> route wins only when its chart area happens to fill your band (a short template header, or a map or
+> big-legend chart whose square re-layout is genuinely better). The band is knowable only once the
+> template texts are in, which is why Step 6 comes before the embed export.
+
+**Size the text at export time with `imFontSize` — scaling in Figma cannot fix it.** Grapher picks a base font for the canvas it renders (`max(10, height/25)`, so ~24 for the default uncaptioned export), and every label is derived from it — the segment values and country names land at about **0.75 × the base**. Placing that export at 508px wide shrinks all of it by the same factor, so a default export ends up with ~12px labels: legal, but on the floor of the 12px minimum. Ask for a bigger base instead — `imFontSize=28` gives ~13.5px labels and ~14px legend text in a 540 frame, which matches the template's own 14px source line. Check the export before importing:
+
+```bash
+grep -oE 'font-size="[0-9.]+"' chart.svg | sort | uniq -c | sort -rn | head -3
+# multiply the most common value by (508 / the export's content width) to get the final size
+```
+
+Bigger text needs more room, so this trades against how much fits — see the axis rule in Step 8 and, failing that, the entity count.
+
+**`tab=` FALLS BACK SILENTLY when the chart does not declare that type — check the mark group, not the HTTP status.** `co-emissions-per-capita?tab=marimekko` returns 200 and a plausible 9 KB SVG containing `lines`: a line chart. `tab=stacked-discrete-bar` on the same slug returns `stacked-areas`. Nothing errors and the file looks right, so a whole "chart-type sweep" can be built on two charts that are not the types you asked for — which is what happened here. Two defences: find charts that actually declare the type (`json_extract_string(cc.config, '$.chartTypes')` on the public Datasette — `/query-grapher-db`), and assert the mark group in the returned SVG:
+
+| type | mark group `id` |
+|---|---|
+| line | `lines` |
+| discrete bar | `bars` + `entity-labels` + `value-labels` |
+| stacked discrete bar | `bars` |
+| stacked area | `stacked-areas` |
+| slope | `slopes` |
+| scatter | `points` |
+| marimekko | `marimekko-chart` |
+| map | `map` |
+
+Caveats: `?tab=table` is silently ignored (renders the default tab); `imSquareSize` affects PNG only; add `nocache` when re-exporting after a config change.

--- a/.claude/skills/create-figma-chart/reference/RESOLVING-THE-CHART.md
+++ b/.claude/skills/create-figma-chart/reference/RESOLVING-THE-CHART.md
@@ -1,0 +1,60 @@
+# Step 1 — Resolve the chart and gather its text
+
+> Read at Step 1.  Part of [`/create-figma-chart`](../SKILL.md); the spine has the step order.
+
+
+Get an SVG URL for the chart, whatever form the reference takes:
+
+| Input | SVG URL |
+|---|---|
+| Slug or default grapher link | `https://ourworldindata.org/grapher/<slug>.svg` |
+| Customized grapher link (query params) | insert `.svg` before the `?`, keep the query verbatim: `https://ourworldindata.org/grapher/<slug>.svg?country=USA~CHN&time=1990..latest` — `country`, `time`, `tab`, `stackMode`, `region`, `focus`, … are all honored, and slug redirects work |
+| MDim view | same — the dimension params select the view: `.../energy-mix.svg?metric=per_capita&source=coal` |
+| **Explorer view** | `https://ourworldindata.org/explorers/<slug>.svg?<view params>` — `EXPLORER_DYNAMIC_THUMBNAIL_URL` in `settings/clientSettings.ts`. **Carry the view's full param set:** requested bare it returns an axis and nothing else, at HTTP 200 (2 texts, no series). Verified on the `imType=thumbnail` route; untested for the other `imType`s. |
+| **Bespoke component** (no slug, no `.svg`) | there is no endpoint — render and serialize the component yourself. See [BESPOKE-SVG.md](../BESPOKE-SVG.md). |
+| Admin link `/admin/charts/<id>/edit` | **`/admin/charts/<id>.svg` does not exist** (it returns the admin SPA shell). Resolve the chart's `configId` — `SELECT configId FROM charts WHERE id = <id>` on the public Datasette (see the `query-grapher-db` skill), or `GET /admin/api/charts/<id>.config.json` — then use `https://ourworldindata.org/grapher/by-uuid/<configId>.svg`. Works for unpublished drafts too. |
+| Narrative chart (**name**) | name → uuid via the unauthenticated map `https://admin.owid.io/api/narrative-chart-map`, then `https://ourworldindata.org/grapher/by-uuid/<uuid>.svg`. Being unauthenticated, this one route works from a cloud sandbox, while the *authenticated* `admin.owid.io` routes are Access-blocked there — test a specific route rather than assuming the host |
+| Narrative chart (**admin link with a numeric id**, `/admin/narrative-charts/<id>/edit`) | **Try the direct lookup first** — `select id, name, chartConfigId from narrative_charts where id = <id>` on the public Datasette hands you the uuid outright (note the column is `chartConfigId`, not `configId`). Only when the id isn't mirrored yet do you need the guessing route below. |
+| … the same, when the id is **newer than the Datasette mirror** | there is no id→uuid endpoint and the mirror lags production by days. Diff the live name-keyed map against `select name from narrative_charts` for the unmirrored names, then order them by uuid — **uuidv7, so lexical order is creation order** — and count up from the mirror's highest id. That is a *candidate*, not an answer: ids have gaps where charts were deleted, so **always render it and have the user confirm before building**. The **name is the stronger signal** — these are named after the piece they serve (`share-of-women-in-parliament-di`), so an unmirrored name matching the DI's topic and carrying the highest uuid is near-certain. Note a published DI can have `linkedNarrativeCharts: {}` because it ships a hand-made PNG, so the chart may be newer than the post; its embedded JSON still gives `grapher-url`, `authors` and the body text Step 2 needs. |
+| Description only | find candidates via site search (`https://ourworldindata.org/search?q=...`) or a Datasette title match; show the candidates and confirm before proceeding |
+| **Local SVG on disk** (from an `export://static_viz` step) | nothing to resolve — the file *is* the export. Skip the whole texts table below: an ETL step bakes its title, subtitle, `Note:`, `Data source:` and license line into the SVG, building the source string from the indicator's `origins` rather than from `chart.citation`. Read the strings straight out of the file if you need them (`grep -o '<text[^>]*>[^<]*' <file>.svg`), and take the frame's target template from the step, which already sized the figure to it. |
+
+Then pull the chart's texts, which seed the template texts in Step 6. Read them from **`.metadata.json`**, not `.config.json`, and **keep the view's query params on the request** — `.../energy-mix.metadata.json?metric=per_capita&source=coal` resolves the selected MDim view exactly as the `.svg` request does:
+
+| Template text | Where it comes from |
+|---|---|
+| Title | `chart.title` |
+| Subtitle | `chart.subtitle`; when that's absent the chart is inheriting the indicator's `description_short` — take `columns[<column>].descriptionShort` |
+| Note | `chart.note` (absent when the chart has none) |
+| Data source | `chart.citation` — verbatim what grapher prints after `Data source:` |
+| Topic page | **`.config.json` → `originUrl`** — the one field `.metadata.json` doesn't give (its `chart.originalChartUrl` is the grapher URL, not the topic page). Often null; fall back to asking the user in Step 2. |
+
+`.config.json` is not a substitute: it never carries the source attribution, it carries `subtitle`/`note` only when a chart overrides them manually, and **for an MDim slug it 404s** — per-view configs aren't exposed under that path. Pass *every* dimension a view needs; a partial MDim param set returns an empty payload (`title: null`, no columns). If a text is ever in doubt, the rendered SVG is the tie-breaker — it shows exactly what the footer will say.
+
+These texts also arrive **render-ready**: the endpoint unwraps grapher's detail-on-demand links across the whole payload, so a `description_short` written as `[lower secondary](#dod:lower-secondary-education)` reaches you as plain `lower secondary` — paste it as-is, and don't hand-strip anything. `.config.json` hands back the raw markup instead, which is one more reason not to take texts from it.
+
+> **The one exception: `by-uuid` has no `.metadata.json`** — that route serves only `.config.json`, `.png` and `.svg`, so the request 404s. For a **narrative chart**, therefore, take the texts from `by-uuid/<uuid>.config.json`, which is complete for that case: a narrative chart stores its own `title`/`subtitle`/`note`/`originUrl` overrides rather than inheriting them. What it still won't give you is the source attribution — read that off the rendered SVG's footer instead, and re-derive nothing (see the producer-name rule below).
+>
+> **In that case read *every* text off the SVG, not just the source.** `.config.json` hands back raw detail-on-demand markup, so a note stored as `expressed in [international-$](#dod:int_dollar_abbreviation)` arrives with the brackets attached and you are one hand-edit away from pasting them into the template. The rendered SVG carries the same strings already unwrapped, in `<g id="header">` (title, subtitle) and `<g id="footer">` (sources, note) — one fetch, render-ready, and it is the file you are importing anyway:
+>
+> ```bash
+> .venv/bin/python -c "import html,re,sys; s=open(sys.argv[1]).read(); cut=lambda a,b: html.unescape(re.sub(r'\s+',' ', re.sub(r'<[^>]*>?',' ', s[s.find('>',s.find(a))+1:b]))).strip(); print(cut('id=\"header\"', s.find('id=\"chart-area\"')), '\n\n', cut('id=\"footer\"', None))" chart.svg
+> ```
+>
+> Two details the command has to get right: the footer group sits **after** `chart-area` in the document, so a slice that stops at the plot returns the title and subtitle only and quietly loses the source and note; and the SVG carries XML entities (`&#x27;` for an apostrophe), so unescape before pasting.
+
+**Never shorten the producer's name to make it fit.** The footer string is the producer's official name — verify it against `rg "producer: .*<name>" snapshots/` if you're unsure — and "Food and Agriculture Organization of the United Nations" does not become "UN Food and Agriculture Organization" because the line is too long. When it overruns the CC BY text, wrap it (Step 7) rather than editing it.
+
+**Check that every selected entity actually renders.** The failure is not always a missing *latest* year — an entity can be selected and have **no data at all**: `cereal-yield` carries both `North America` and `Northern America` in its selection and the latter has zero rows, so seven selected entities render six lines, and have done for as long as the chart has existed. Two near-identical region names in one selection is the signature; check the count of drawn series against the selection every time, and report a permanent absence as a chart-config bug (not a regression) so someone removes it. Grapher also silently drops an entity whose data doesn't reach the displayed year, with no warning anywhere — a chart pinned to 2023 quietly showed ten of its eleven countries because one stopped at 2022, and the DI text still discussed the missing one. Compare the **effective** selection against the entity labels in the exported SVG, and if they differ, say so before building: the fix is the narrative chart's tolerance setting (or pinning the year), and it belongs to whoever owns the chart.
+
+  "Effective" is the catch. `selectedEntityNames` in `.config.json` is the *saved* chart's selection, so it is the wrong baseline for exactly the inputs this skill takes most often:
+
+  | Input | Baseline to compare the SVG against |
+  |---|---|
+  | Bare slug, or `by-uuid` | `selectedEntityNames` from `.config.json` |
+  | Link carrying `country=` (or `focus=`) | the **URL's** list — it overrides the saved selection entirely |
+  | MDim view | the URL's `country=` if present, otherwise the view's resolved `selectedEntityNames` read from the grapher DB — `multi_dim_x_chart_configs mx JOIN chart_configs cc ON cc.id = mx.chartConfigId` (`/query-grapher-db`) |
+
+  `life-expectancy.config.json` lists `World, Americas, Europe, Africa, Asia, Oceania`, but `life-expectancy.svg?country=USA~CHN` contains only `China` and `United States` — take the config as the baseline there and the check reports six entities missing and two unexpected, on a chart where nothing is wrong. And note the two sides speak different languages: `country=` takes **ISO codes** while the SVG prints **names**, so resolve the codes before comparing rather than diffing the strings.
+
+  **Never use the rendered labels as their own baseline.** For an MDim view with no `country=` it is the tempting shortcut — `.config.json` 404s on MDim slugs (see Gotchas), so the SVG is the only thing in reach. But Step 8c then compares the SVG against the SVG: an entity grapher silently dropped for having no data in this view is missing from **both** sides, so the must-pass completeness check reports success precisely when it should fail. That is the ten-of-eleven defect further down this page, dressed as a green check. Read the resolved selection from the DB, and if you cannot, **report the completeness check as unavailable** for that frame. An honest gap in coverage is worth more than a check that cannot fail.


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

## Why

`SKILL.md` had **19 bytes** of headroom against the 64,000-byte cap `verify_docs.py --structure` enforces. That is not a comfortable margin, it is an exhausted budget: the file has grown about **600 bytes a day** since the big split on 2026-08-20, so the next lesson write-back breaks the build.

It is already costing quality rather than just blocking commits. #6787 had 62 bytes to spend on its Step 2 tripwire, spent 46 of them, and the compression produced a pointer to a `GOTCHAS.md` entry that did not exist. That was caught in review, but the pressure that caused it is still there.

**The cap is not the thing to change, and the file says so itself.** It was set on 2026-08-28 at that day's size plus 450 bytes, in the commit that raised it from 62 KB. The paragraph that did the raising is explicit:

> A cap that moves whenever it is hit is not a cap: the discipline below is unchanged, and the next addition pays for itself by deduplicating rather than by another raise.

So this PR frees space instead. There is room under the combined 145,000-byte cap to raise the per-file one, and taking it would re-arm the same ratchet inside a fortnight.

## What

Steps 6, 7, 8 and 8c are already pure routing — **426 bytes each on average**, a pointer into the reference file that carries the detail. Steps 1 and 3 never got that treatment and held **35% of the spine** between them. This finishes the refactor rather than inventing a structure.

| Step | Before | After | New home |
|---|---|---|---|
| Step 1, resolve the chart | 10,837 | ~1,900 | `reference/RESOLVING-THE-CHART.md` |
| Step 3, export the SVGs | 11,639 | ~2,200 | `reference/EXPORTING.md` |

The spine keeps the **decision** and hands off the per-case detail:

- **Step 1** keeps a seven-row input-to-URL table, one line per route, plus the two rules that must not be skipped whatever the input: never shorten the producer's name, and check every selected entity actually renders. A run reads the one row for the input it was handed instead of carrying twelve prose cells about narrative-chart uuid recovery and Datasette mirror lag.
- **Step 3** keeps the two-exports framing, the ordering rule that avoids a re-export, the `curl` block and a short `solve_export.py` pointer. The aspect solve and its per-axis insets, `imFontSize`, the `imType=square` alternative and the silent `tab=` fallback move out.

Both new files carry the original prose **verbatim**. Nothing was rewritten in transit, and nothing is duplicated between spine and reference.

## Result

| | Before | After |
|---|---|---|
| `SKILL.md` | 63,981 / 64,000 | **47,013 / 64,000** |
| Headroom | 19 bytes | **16,987 bytes** |
| Eagerly-read pair | 115,927 / 145,000 | **98,959 / 145,000** |

No cap changed. At the current write-back rate that is about a month of runway, and the pattern for the next one is now uniform across all nine steps.

## Verification

- `verify_docs.py --against origin/master` — **zero `LOST` lines**, which is the whole safety argument for a move this size. Two `REWORDED` findings, both deliberate: the budget paragraph now records that the cap held and how, and a stale `~180 KB` figure for `reference/` is corrected to `~510 KB`.
- `verify_docs.py --structure` — clean. Both new files are reachable from the spine's file map, and the two markdown links that moved a directory down were re-depthed.
- `test_inline_script.py` — 76/76.
- codespell on the three files — clean.
- `make check` — clean.

Script sizes are untouched, since no script changed. The largest documented `use_figma` call is still `verify_page.js --rows type,geometry` at 40,664 chars, 81% of the 50,000 cap.

## Open items

- The other two fat sections are the **preamble at 11,188 bytes** and **Round-trip budget at 8,317**. Neither is a step, so neither has an obvious reference file to move to, and both are arguably spine material. Left alone deliberately; worth a look if the file tightens again.
- This does nothing about the growth *rate*, only the runway. If write-backs keep landing at 600 bytes a day, the same conversation is due in about a month, and the answer then is likely to be that some of what accumulated is no longer worth its bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
