### PR TITLE
🐛 chart-critic: one definition of "the same finding, reworded"

### DIFF
--- a/apps/chart_critic/cli.py
+++ b/apps/chart_critic/cli.py
@@ -41,9 +41,11 @@ from apps.chart_critic.critic import (
     DEFAULT_MODEL,
     FALLBACK_PRICES,
     build_agent,
+    claim_tokens,
     format_views,
     issue_params,
     prompt_parts,
+    same_finding,
 )
 from apps.utils.llms.costs import estimate_llm_cost
 from etl.db import read_sql
@@ -211,13 +213,6 @@ def _link_keys(slug: str, params: str) -> set[str]:
         return keys
 
 
-def _claim_tokens(claim: str) -> set[str]:
-    # Crude singular/plural folding. Without it "the unit for all three indicators is incorrectly
-    # set to 'doses'" and "the indicator unit is incorrectly set to 'doses'" scored below the
-    # merge threshold and were reported as two findings.
-    return {w.rstrip("s") for w in re.findall(r"[a-z0-9]{4,}", claim.lower())}
-
-
 def _merge(issues: list[dict[str, Any]], new: dict[str, Any]) -> None:
     """Fold a finding into the list, merging it with the same finding from an earlier pass.
 
@@ -225,11 +220,9 @@ def _merge(issues: list[dict[str, Any]], new: dict[str, Any]) -> None:
     "under 20 years" are one finding — so matching on a prefix counts them separately. Overlap
     of the significant words is crude but survives the rewording.
     """
-    tokens = _claim_tokens(new["claim"])
+    tokens = claim_tokens(new["claim"])
     for existing in issues:
-        other = _claim_tokens(existing["claim"])
-        overlap = len(tokens & other) / max(len(tokens | other), 1)
-        if existing["kind"] == new["kind"] and overlap >= 0.4:
+        if existing["kind"] == new["kind"] and same_finding(tokens, claim_tokens(existing["claim"])):
             existing["passes"] += 1
             return
     issues.append(new | {"passes": 1})

--- a/apps/chart_critic/critic.py
+++ b/apps/chart_critic/critic.py
@@ -26,6 +26,7 @@ tests are ``apps/anomalist``'s job and are deliberately not duplicated here.
 from __future__ import annotations
 
 import datetime as dt
+import re
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -145,6 +146,30 @@ that the International Poverty Line is not $3 per day, when it was revised to ex
 
 Do not invent problems. An ordinary chart has no issues, and returning an empty list is the
 expected outcome for most charts."""
+
+
+# Two claims are the same finding when this much of their significant vocabulary is shared.
+# One constant, used in both places it is needed: folding a chart's repeated passes into one
+# finding, and recognising a finding the digest already posted on an earlier day. They have to
+# agree — a run that merges two wordings into one while the state files them separately posts
+# the same thing twice.
+SAME_FINDING_OVERLAP = 0.4
+
+
+def claim_tokens(claim: str) -> set[str]:
+    """The significant words of a claim, crudely singular-folded.
+
+    Without the folding, "the unit for all three indicators is incorrectly set to 'doses'" and
+    "the indicator unit is incorrectly set to 'doses'" scored below the threshold and were
+    reported as two findings.
+    """
+    return {word.rstrip("s") for word in re.findall(r"[a-z0-9]{4,}", claim.lower())}
+
+
+def same_finding(tokens: set[str], other: set[str]) -> bool:
+    """Whether two token sets describe one finding. The model rewords freely between passes and
+    between days — "life expectancy of around 18-20 years" and "under 20 years" are one thing."""
+    return len(tokens & other) / max(len(tokens | other), 1) >= SAME_FINDING_OVERLAP
 
 
 def issue_params(target_params: str, issue: dict) -> str:

--- a/apps/chart_critic/digest.py
+++ b/apps/chart_critic/digest.py
@@ -20,12 +20,13 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any
 
 from structlog import get_logger
 
-from apps.chart_critic.critic import format_views
+from apps.chart_critic.critic import claim_tokens, format_views, same_finding
 from etl.paths import CACHE_DIR
 
 log = get_logger()
@@ -156,10 +157,32 @@ def _fingerprint_keys(slug: str, issue: dict[str, Any], facts: dict[str, dict[st
     Chart-level findings stay keyed by slug: a wrong subtitle really is specific to that chart
     even when the data behind it is shared.
     """
-    words = sorted({w.rstrip("s") for w in re.findall(r"[a-z0-9]{5,}", issue.get("claim", "").lower())})
-    tail = f"{issue.get('kind', '')}:{'-'.join(words[:8])}"
+    words = sorted(claim_tokens(issue.get("claim", "")))
+    tail = f"{issue.get('kind', '')}:{'-'.join(words)}"
     indicators = _indicators(facts, slug) if issue.get("kind") == "data" else []
     return [f"{i}:{tail}" for i in indicators] or [f"{slug}:{tail}"]
+
+
+def _already_posted(keys: list[str], known: Iterable[str]) -> bool:
+    """Whether any of these keys names a finding we have already sent.
+
+    Not an exact key match, which is what this used to be. The overlapping review window means
+    a chart is looked at on several consecutive days, and the model does not repeat itself
+    verbatim — so an exact match would file "the unit is set to doses" and "all three indicators
+    are labelled in doses" as two separate findings and post the same thing twice. Subject and
+    kind must agree exactly, and the claim's vocabulary has to overlap by the same margin that
+    folds repeated passes into one finding within a run.
+    """
+    for key in keys:
+        subject, kind, words = key.split(":", 2)
+        tokens = set(words.split("-")) - {""}
+        for other in known:
+            other_subject, other_kind, other_words = other.split(":", 2)
+            if (other_subject, other_kind) != (subject, kind):
+                continue
+            if same_finding(tokens, set(other_words.split("-")) - {""}):
+                return True
+    return False
 
 
 def load_state() -> dict[str, str]:
@@ -194,9 +217,10 @@ def new_findings(
     )
     for result, issue in ranked:
         keys = _fingerprint_keys(result["slug"], issue, facts)
-        # Any overlap counts as already-known: the same defect on a second chart sharing one
-        # indicator is not news, even though the two charts are not the same chart.
-        if any(k in state or k in seen for k in keys):
+        # Already-known on either axis: an earlier day (state) or an earlier chart in this run
+        # sharing one indicator (seen) — the same defect on a second chart is not news, even
+        # though the two charts are not the same chart.
+        if _already_posted(keys, state) or _already_posted(keys, seen):
             continue
         seen.update(keys)
         out.append((result, issue))


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

A follow-up to #6778, which merged while this was in flight. One idea, in three files: **"the same finding, reworded" should mean one thing.**

Two places need that judgement and they disagreed:

| | how it matched | consequence |
|---|---|---|
| Folding a chart's repeated passes into one finding | Jaccard ≥ 0.4 over the claim's significant words | correct |
| Recognising a finding the digest posted on an earlier day | **exact key equality** | the same defect, reworded, posts twice |

So a run could merge two wordings into one finding while the state filed them separately. `claim_tokens()`, `same_finding()` and `SAME_FINDING_OVERLAP` now live in `critic.py` and both callers use them.

This matters because the model does not repeat itself. A chart edited on two consecutive days appears in two consecutive daily runs, and:

```
"The coal share of electricity exceeds 100% for the United Kingdom in the 1950s"
"United Kingdom coal generation is shown as more than 100 percent of electricity in 1951-1958"
```

are one finding that exact matching files as two.

## Where the threshold does *not* reach, and what follows

Those two phrasings measure **0.29 overlap against the 0.40 threshold** — so this closes the common case (the model rewording slightly) and not the general one (two genuinely different phrasings of the same defect).

That is why the scheduled digest stays at `--changed-since 1`, matching its daily cadence, rather than using an overlapping window to insure against a failed build. The overlap is nearly free in money and time — 3 days is 21 charts against 17, about $0.05 with a warm cache — but it puts the same chart in front of the model on consecutive days and buys a daily duplicate-post risk to cover a rare failure. A failed build is red and visible; re-running it by hand with a wider window covers the gap once. See owid/ops#647.

## Testing

`etl chart-critic --eval` → **9/9, exit 0, $0.21** (including the case marked `flaky`, which lands about 1 pass in 15 and happened to land here).

Behaviour, verified directly: a reworded claim on the same chart the next day is suppressed; so is one on a *different* chart sharing the defective indicator; a genuinely different defect on that same indicator still gets through; and chart-level findings on shared data stay separate.
