### PR TITLE
🐛🤖 Fix six chart-text and unit errors found by LLM chart review

### DIFF
--- a/etl/steps/data/garden/covid/latest/deaths_vax_status.meta.yml
+++ b/etl/steps/data/garden/covid/latest/deaths_vax_status.meta.yml
@@ -3,7 +3,9 @@ definitions:
   common:
     description_short: |-
       Death rates are calculated as the number of deaths in each group, divided by the total number of people in this group. This is given per 100,000 people.
-    unit: doses
+    # Every indicator in this dataset is a death rate, not a dose count -- `doses` was left over from
+    # the vaccination-doses datasets these were built alongside.
+    unit: deaths per 100,000 people
     presentation:
       topic_tags:
         - COVID-19
@@ -82,6 +84,14 @@ tables:
           timeInterval: week
   england:
     common:
+      # ONS reports these as age-standardized rates per 100,000 *person-years*, not per 100,000
+      # people: person-years count the time each individual spends in a given vaccination status, so
+      # the denominator is exposure time rather than a headcount. The other three sources (CDC,
+      # Chile, Switzerland) do report per-population rates, so this overrides the shared unit rather
+      # than changing it.
+      unit: deaths per 100,000 person-years
+      description_short: |-
+        Death rates are age-standardized and given per 100,000 person-years, which accounts for both the number of people in each vaccination status and the time they spent in it.
       description_key:
         - Unvaccinated people have not received any dose.
         - Partially-vaccinated people are excluded.

--- a/etl/steps/data/garden/energy_institute/2026-06-30/statistical_review_of_world_energy.meta.yml
+++ b/etl/steps/data/garden/energy_institute/2026-06-30/statistical_review_of_world_energy.meta.yml
@@ -4,6 +4,12 @@ definitions:
     presentation:
       topic_tags:
         - Energy
+  # The constant-dollar oil price's reference year is derived from the release's publication date
+  # (see the step), so this sentence must be templated rather than typed into a chart -- the chart
+  # subtitle used to hard-code "2023" while the indicator's unit already said 2025.
+  description_oil_price_constant: &description-oil-price-constant >-
+    Prices are measured in constant {price_reference_year} US$ per cubic meter, which means they are
+    adjusted for inflation.
   description_processing_oil_production_twh: &description-processing-oil-production-twh |-
     * Oil production is approximately converted from million tonnes to energy using a standard average oil-equivalent conversion factor of 41.868 petajoules per million tonnes. We then convert 1 petajoule to 0.278 terawatt-hours.
 
@@ -886,8 +892,13 @@ tables:
         title: 'Oil price - Crude prices since 1861 (constant {price_reference_year} US$)'
         unit: 'constant {price_reference_year} US$ per cubic meter'
         short_unit: '$'
+        description_short: *description-oil-price-constant
         presentation:
           title_public: 'Oil price - Crude prices since 1861'
+          # `description_short` is not used as a chart-subtitle fallback at render time, so the
+          # subtitle has to be set here for a chart to inherit it.
+          grapher_config:
+            subtitle: *description-oil-price-constant
       # oil_spot_crude_price_brent_current_dollars_per_barrel:
       #   title: Oil spot crude price - Brent
       #   unit: 'current US$ per barrel'

--- a/etl/steps/data/garden/un/2025-05-07/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2025-05-07/undp_hdr.meta.yml
@@ -494,6 +494,11 @@ tables:
           Official PPP conversion rates are produced by the International Comparison Program, whose surveys periodically collect thousands of prices of matched goods and services in many countries. The last round of this exercise refers to 2021 and covered 176 economies.
         presentation:
           title_variant: In constant international-$
+          # Authored here rather than typed into the chart: the PPP base year moves with each HDR
+          # release, so a hard-coded year in a chart note silently goes stale (it read "2017" while
+          # the unit already said 2021).
+          grapher_config:
+            note: "{definitions.ppp_prices}"
 
       # Labour force
       lfpr:

--- a/etl/steps/data/garden/who/2026-05-22/gho.meta.yml
+++ b/etl/steps/data/garden/who/2026-05-22/gho.meta.yml
@@ -203,7 +203,3 @@ tables:
           - "Interval lengths differ by age group: one year for the under-1 group, four years for ages 1–4, and five years for every group from 5–9 upwards. A value cannot be compared across age groups without accounting for that."
           - For the under-1 group the interval is a single year, so the value coincides with the infant mortality rate.
           - "As an example: a value of 0.043 for ages 1–4 means about 43 of every 1,000 children who reach their first birthday die before their fifth — an average annual risk of roughly 1.1%, not 4.3%."
-        short_unit: ""
-        unit: ""
-        display:
-          numDecimalPlaces: 4

--- a/etl/steps/data/garden/who/2026-05-22/gho.meta.yml
+++ b/etl/steps/data/garden/who/2026-05-22/gho.meta.yml
@@ -189,3 +189,21 @@ tables:
         unit: vehicles per 1,000 people
         display:
           numDecimalPlaces: 0
+
+  # WHO life-table nqx. The values are whole-interval probabilities (the source's own column name
+  # says "between ages x and x+n"), so they are only an annual risk for the <1 year group, where
+  # n = 1. Spelled out here because the GHO API ships no unit or short description for this
+  # indicator, which left the chart subtitle as a reader's only description -- and it said "annual".
+  nqx__probability_of_dying_between_ages_x_and_xplusn:
+    variables:
+      nqx__probability_of_dying_between_ages_x_and_xplusn:
+        description_short: "Probability of dying within the age interval shown, expressed as a fraction. Intervals span several years for every group except infants, so this is not an annual risk."
+        description_key:
+          - This is the life-table quantity nqx — the probability that someone who reaches the start of an age interval dies before reaching the end of it.
+          - "Interval lengths differ by age group: one year for the under-1 group, four years for ages 1–4, and five years for every group from 5–9 upwards. A value cannot be compared across age groups without accounting for that."
+          - For the under-1 group the interval is a single year, so the value coincides with the infant mortality rate.
+          - "As an example: a value of 0.043 for ages 1–4 means about 43 of every 1,000 children who reach their first birthday die before their fifth — an average annual risk of roughly 1.1%, not 4.3%."
+        short_unit: ""
+        unit: ""
+        display:
+          numDecimalPlaces: 4

--- a/etl/steps/export/multidim/education/latest/enrolment_rates.py
+++ b/etl/steps/export/multidim/education/latest/enrolment_rates.py
@@ -361,12 +361,17 @@ LEVEL_MAPPINGS = {
         "level_side_by_side_net": "[pre-primary](#dod:pre-primary-education), [primary](#dod:primary-education), [lower secondary](#dod:lower-secondary-education), and [upper secondary](#dod:upper-secondary-education)",
         "enrolment_type_side_by_side": "{level_dod}",
     },
+    # These parentheticals are the age *span* a level covers, matching the ISCED reference ages used
+    # in children_out_of_school.py. They previously gave the range of official *entrance* ages across
+    # countries (primary "between 5 and 7 years old"), which is a different quantity: primary lasts
+    # about six years, and the denominator of an enrolment ratio is the official school-age
+    # population, i.e. a span rather than the entrance window.
     "plain": {
-        "primary": "primary school age (between 5 and 7 years old)",
-        "preprimary": "pre-primary school age (between 3 and 5 years old)",
-        "lower_secondary": "lower secondary school age (between 11 and 14 years old)",
-        "upper_secondary": "upper secondary school age (between 15 and 18 years old)",
-        "tertiary": "tertiary education age (typically between 18 and 22 years old)",
+        "primary": "primary school age (typically 6–11 years)",
+        "preprimary": "pre-primary school age (typically 3–5 years)",
+        "lower_secondary": "lower secondary school age (typically 12–14 years)",
+        "upper_secondary": "upper secondary school age (typically 15–17 years)",
+        "tertiary": "tertiary education age (typically 18–22 years)",
         "level_side_by_side_gross": "pre-primary, primary, lower secondary, upper secondary, and tertiary",
         "level_side_by_side_net": "pre-primary, primary, lower secondary, and upper secondary",
         "enrolment_type_side_by_side": "{level_plain}",


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Six chart-text and unit errors from #6779 — wrong labels on correct data, plus one typo. No values change anywhere in this PR. The two findings that *did* move data grew their own PRs: **#6813** (the Central African Republic mortality correction) and **#6810** (the COVID vaccination aggregation bug).

_Skim. Five metadata files and one mdim template; the only thing needing a judgement call is the enrolment wording, flagged at the bottom._

## The fixes

| # | What was wrong | Where it is fixed |
|---|---|---|
| 3 | `Estimated **aumber** of suicides` on [`suicide-rate-in-1980-vs-2023`](https://ourworldindata.org/grapher/suicide-rate-in-1980-vs-2023) | chart 3794 config (staging) — the only chart in the DB containing the string |
| 5 | "primary school age (between 5 and 7 years old)" gave the range of official *entrance* ages, not the age span the enrolment ratio's denominator covers | `enrolment_rates.py` |
| 6 | WHO life-table `nqx` labelled "annual" when the values are whole-interval probabilities | `gho.meta.yml` + chart 6294 subtitle (staging) |
| 7 | Chart note said 2017 prices, indicator unit said 2021 | `undp_hdr.meta.yml` + chart 7191 (staging) |
| 8 | COVID death rates carried `unit: doses` | `deaths_vax_status.meta.yml` |
| 9 | Subtitle said 2023 US$, indicator unit said 2025 | `statistical_review_of_world_energy.meta.yml` + chart 8240 (staging) |

**Finding 4 (UK coal share >100%) needs nothing.** Re-checked against production: 1951 reads 95.50% and every year 1951–1958 is now under 100%, matching the resolution noted on the issue.

## The two that are the same bug

Findings 7 and 9 are both a currency base written in two places, only one of which gets updated. Both are fixed by moving the text into the indicator's `grapher_config`, where the year is already templated from the source, and deleting the chart-level copy so it cannot drift again:

- **Oil price** — the step derives `price_reference_year` from the release's publication date, so `subtitle: 'Prices are measured in constant {price_reference_year} US$ per cubic meter…'` tracks the data. Chart 8240 already had inheritance enabled, so dropping its subtitle was enough.
- **GNI** — `note: "{definitions.ppp_prices}"`, which already renders the PPP base year the HDR release uses. Chart 7191 had inheritance *disabled*, so this PR also turns it on; its own `tab`, `selectedEntityNames` etc. still win over the inherited config.

One wrinkle worth knowing: `description_short` is **not** used as a chart-subtitle fallback at render time. My first attempt at the oil-price fix set only `description_short`, and the chart then rendered with no subtitle at all on staging. The subtitle has to be in `grapher_config` for a chart to inherit it; both texts now come from a YAML anchor so there is no restated literal.

## Finding 6, in more detail

The relabel, not the conversion — converting to annualised rates would have departed from WHO's published values for every series except `<1 year`. Confirmed the interval reading arithmetically: Nigeria 2021's `q(0-1)=0.0699` and `q(1-4)=0.0429` combine to 10.98% under-five mortality against `child-mortality-igme`'s 11.76%, versus 21.95% under the annual reading.

The indicator also had no `unit` and no `description_short` at all, so the chart subtitle was a reader's only description — hence the new `description_short` and `description_key` rather than only a chart edit. `display.numDecimalPlaces: 4` goes with it: at the previous 2 decimals, **8 of the 18 age groups rendered as "<0.01"**, which is exactly the childhood range where "annual" versus "interval" differs by a factor of four. The values themselves are unchanged — owidbot's chart-diff confirms *Data changes: 0*.

## Verified

- Confirmed on staging: `school-enrolment` serves "(typically 6–11 years)" / "(typically 12–14 years)"; the COVID death-rate indicators carry the new unit; the nqx `description_short` and 4-item `description_key` are live.
- The four chart-config edits are in the staging DB — `chart_configs` for 3794 / 6294 / 7191 / 8240, versions bumped, read back through the admin API. **Staging's baked `config.json` lags one version** and still serves the old text, so check these through the admin rather than the baked JSON. Production is unaffected either way: chart-sync reads the DB, not the bake.
- The enrolment subtitles were rendered directly from the template constants for all five levels.
- **Not verified:** nothing was checked against production, by design.

## Decisions worth a second look

**Finding 5's wording is an editor's call** — the issue said as much and declined to propose text. I replaced the entrance-age ranges with the ISCED spans the sibling `children_out_of_school.py` already uses (6–11, 3–5, 12–14, 15–17), which is at least internally consistent, but the exact phrasing is open.

**England's death rates are per person-years, not per people** (raised in review). ONS reports "age-standardized mortality rates per 100,000 **person-years**", while Chile ("per 100,000 inhabitants"), Switzerland ("per 100,000 population") and the CDC do not. So England gets a table-level override of both `unit` and `description_short` rather than the shared default changing. The shared `description_short` had the same problem before this PR.

<details>
<summary>Reproducing</summary>

The typo existed in exactly one chart config site-wide:

```sql
-- datasette-public.owid.io
select c.id, cc.slug from chart_configs cc join charts c on c.configId = cc.id where cc.config like '%aumber%'
```

The two price bases, each against its indicator's unit:

```bash
curl -sL "https://ourworldindata.org/grapher/gross-national-income-per-capita-undp.metadata.json?useColumnShortNames=true" \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print('note:', d['chart']['note']); print('unit:', list(d['columns'].values())[0]['unit'])"
curl -sL "https://ourworldindata.org/grapher/oil-prices-inflation-adjusted.metadata.json?useColumnShortNames=true" \
  | python3 -c "import json,sys; d=json.load(sys.stdin); print('subtitle:', d['chart']['subtitle']); print('unit:', list(d['columns'].values())[0]['unit'])"
```

</details>
