### PR TITLE
🐛 Pin grapher_schema in US decade chart config

### DIFF
--- a/etl/steps/export/multidim/migration/latest/us_foreign_born_annual_change_by_decade.config.yml
+++ b/etl/steps/export/multidim/migration/latest/us_foreign_born_annual_change_by_decade.config.yml
@@ -1,3 +1,4 @@
+grapher_schema: "011"
 chart_config_id: 01a061a0-e423-79ce-840c-50bcb9c31c26
 topic_tags:
   - "Migration"


### PR DESCRIPTION
> _Written by Claude Fable 5 — @edomt at the wheel._

One-line fix: add the required `grapher_schema: "011"` pin to the chart config added in #6498. Its absence broke `test_multidim_configs_pin_grapher_schema` in the unit tests on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)