### PR TITLE
📊 Maintain GCO cancers attributable to infections dataset

### DIFF
--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -4,69 +4,78 @@ definitions:
     presentation:
       topic_tags:
         - Cancer
-
+      attribution_short: IARC
     processing_level: minor
     display:
       numDecimalPlaces: 1
-  sex: |-
-    <% if sex == "both" %>all individuals<% elif sex == "males" %>males<% elif sex == "females" %>females<% endif %>
-  footnote: |-
-    To allow for comparisons between countries and over time, this metric is [age-standardized](#dod:age_standardized).
+    description_key:
+      - Estimates come from the International Agency for Research on Cancer (IARC). They apply the population attributable fractions from the study "Global burden of cancer attributable to infections in 2018" (de Martel et al., 2020) to the GLOBOCAN 2020 cancer incidence estimates.
+      - |-
+        Ten infectious agents classified as carcinogenic by IARC are covered: Helicobacter pylori, human papillomavirus (HPV), hepatitis B and C viruses, Epstein-Barr virus (EBV), human herpesvirus type 8, human T-cell lymphotropic virus, the liver flukes Opisthorchis viverrini and Clonorchis sinensis, and Schistosoma haematobium.
+      - Non-melanoma skin cancers are excluded because their registration is often incomplete and inconsistent across countries.
+      - Estimates carry uncertainty, especially for countries without population-based cancer registries or with limited data on how common these infections are.
+  sex: <% if sex == "both" %>both sexes<% elif sex == "males" %>men<% elif sex == "females" %>women<% endif %>
+  people: <% if sex == "both" %>people<% elif sex == "males" %>men<% elif sex == "females" %>women<% endif %>
+  agent: |-
+    <% if agent == "All infectious agents" %>all infectious agents<% elif agent == "HPV" %>human papillomavirus (HPV)<% elif agent == "EBV" %>Epstein-Barr virus (EBV)<% elif agent == "Hepatitis B virus" %>hepatitis B virus<% elif agent == "Hepatitis C virus" %>hepatitis C virus<% elif agent == "Human T-cell lymphotropic virus" %>human T-cell lymphotropic virus<% elif agent == "Human herpesvirus type 8" %>human herpesvirus type 8<% else %><< agent >><% endif %>
+  cancer: |-
+    <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %>all cancers (excluding non-melanoma skin cancer)<% else %><< cancer.lower().replace("hodkin", "hodgkin").replace("hodgkin", "Hodgkin").replace("burkitt", "Burkitt").replace("kaposi", "Kaposi").replace("t-cell", "T-cell") >><% endif %>
+  footnote: To allow for comparisons between countries and over time, this metric is [age-standardized](#dod:age_standardized).
+  processing_regions: |-
+    For world regions, Our World in Data sums the values of the countries in the region with data. For cancer sites, the source only reports men and women separately; the both-sexes values are the sum of the two.
 
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
   update_period_days: 365
-
-
   owners:
     - Tuna Acisu
+    - Lucas Rodés-Guirao
+
 tables:
   gco_infections:
     variables:
-      attr_cases:
-        title: |-
-          Number of new << cancer.lower() >> cases attributable to << agent.lower() >> among {definitions.sex}
-        description_short: |-
-          Estimated number of new << cancer.lower() >> cases attributable to << agent.lower() >> among {definitions.sex}.
+      cases:
+        title: Number of new cases of {definitions.cancer} among {definitions.sex}
+        description_short: Estimated number of new cases of {definitions.cancer} among {definitions.sex}.
         unit: cases
+        description_processing: "{definitions.processing_regions}"
+        processing_level: major
 
-      asir_att:
-        title: |-
-          Age-standardized incidence rate of << cancer.lower() >> attributable to << agent.lower() >> among {definitions.sex}
-        description_short: |-
-          Estimated age-standardized incidence rate of << cancer.lower() >> attributable to << agent.lower() >> among {definitions.sex}.
-        unit: per 100,000 people
-        presentation:
-          grapher_config:
-            note: |-
-              {definitions.footnote}
+      attr_cases:
+        title: Number of new cases of {definitions.cancer} attributable to {definitions.agent} among {definitions.sex}
+        description_short: Estimated number of new cases of {definitions.cancer} among {definitions.sex} that are attributable to {definitions.agent}.
+        unit: cases
+        description_processing: "{definitions.processing_regions}"
+        processing_level: major
+
+      attr_cases_share:
+        title: Share of new cases of {definitions.cancer} among {definitions.sex} attributable to {definitions.agent}
+        description_short: Estimated share of new cases of {definitions.cancer} among {definitions.sex} that are attributable to {definitions.agent}.
+        unit: "%"
+        short_unit: "%"
+        description_processing: |-
+          Computed by Our World in Data as the number of attributable cases divided by the total number of new cases. {definitions.processing_regions}
+        processing_level: major
+
       paf:
-        title: |-
-          Proportion of << cancer.lower() >> cases among {definitions.sex} attributable to << agent.lower() >>
-        description_short: |-
-          Proportion of << cancer.lower() >> cases among {definitions.sex} attributable to << agent.lower() >>.
-        unit: '%'
-        short_unit: '%'
+        title: Population attributable fraction of {definitions.cancer} among {definitions.sex} due to {definitions.agent}
+        description_short: Estimated share of new cases of {definitions.cancer} among {definitions.sex} that are attributable to {definitions.agent}, as published by the source.
+        unit: "%"
+        short_unit: "%"
 
       asir:
-        title: |-
-          Age-standardized incidence rate of << cancer.lower() >> among {definitions.sex}
-        description_short: |-
-          Estimated age-standardized incidence rate of << cancer.lower() >> among {definitions.sex}.
-        unit: per 100,000 people
+        title: Age-standardized incidence rate of {definitions.cancer} among {definitions.sex}
+        description_short: Estimated number of new cases of {definitions.cancer} per 100,000 {definitions.people} in a year, age-standardized.
+        unit: cases per 100,000 people
         presentation:
           grapher_config:
-            note: |-
-              {definitions.footnote}
-      attr_cases_share:
-        title: |-
-          Share of new << cancer.lower() >> cases among {definitions.sex} attributable to << agent.lower() >>
-        description_short: |-
-          Share of new << cancer.lower() >> cases among {definitions.sex} attributable to << agent.lower() >>.
-        unit: '%'
-        short_unit: '%'
-      cases:
-        title: |-
-          Number of new << cancer.lower() >> cases among {definitions.sex}
-        description_short: |-
-          Estimated number of new << cancer.lower() >> cases among {definitions.sex}.
-        unit: cases
+            note: "{definitions.footnote}"
+
+      asir_att:
+        title: Age-standardized incidence rate of {definitions.cancer} attributable to {definitions.agent} among {definitions.sex}
+        description_short: Estimated number of new cases of {definitions.cancer} attributable to {definitions.agent} per 100,000 {definitions.people} in a year, age-standardized.
+        unit: cases per 100,000 people
+        presentation:
+          grapher_config:
+            note: "{definitions.footnote}"

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -20,13 +20,12 @@ definitions:
   # Readable labels for the three dimensions. The source labels are kept as dimension values (so indicator short names
   # do not change); only the displayed text is rewritten. "Other Non-Hodkin lymphoma" is a typo in the source.
   cases_of: |-
-    <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %>cancer cases<% else %>cases of << cancer.lower().replace("hodkin", "hodgkin").replace("hodgkin", "Hodgkin").replace("burkitt", "Burkitt").replace("kaposi", "Kaposi").replace("t-cell", "T-cell") >><% endif %>
+    <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %>cancer cases (excluding non-melanoma skin cancer)<% else %>cases of << cancer.lower().replace("hodkin", "hodgkin").replace("hodgkin", "Hodgkin").replace("burkitt", "Burkitt").replace("kaposi", "Kaposi").replace("t-cell", "T-cell") >><% endif %>
   agent_phrase: |-
     <% if agent == "All infectious agents" %>infections<% elif agent == "HPV" %>human papillomavirus (HPV)<% elif agent == "EBV" %>Epstein-Barr virus (EBV)<% elif agent == "Hepatitis B virus" %>hepatitis B virus<% elif agent == "Hepatitis C virus" %>hepatitis C virus<% elif agent == "Human T-cell lymphotropic virus" %>human T-cell lymphotropic virus<% elif agent == "Human herpesvirus type 8" %>human herpesvirus type 8<% else %><< agent >><% endif %>
   # Sex is only spelled out for men and women; "both sexes" is the default and is left implicit.
   among_sex: <% if sex == "males" %> among men<% elif sex == "females" %> among women<% endif %>
   people: <% if sex == "males" %>men<% elif sex == "females" %>women<% else %>people<% endif %>
-  nmsc: <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %> Non-melanoma skin cancers are excluded.<% endif %>
   footnote: To allow for comparisons between countries and over time, this metric is [age-standardized](#dod:age_standardized).
   processing_regions: |-
     For world regions, Our World in Data sums the values of the countries in the region with data. For cancer sites, the source only reports men and women separately; the both-sexes values are the sum of the two.
@@ -43,21 +42,21 @@ tables:
     variables:
       cases:
         title: Number of new {definitions.cases_of}{definitions.among_sex}
-        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex}.{definitions.nmsc}
+        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex}.
         unit: cases
         description_processing: "{definitions.processing_regions}"
         processing_level: major
 
       attr_cases:
         title: Number of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
-        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.{definitions.nmsc}
+        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
         unit: cases
         description_processing: "{definitions.processing_regions}"
         processing_level: major
 
       attr_cases_share:
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
-        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.{definitions.nmsc}
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
         unit: "%"
         short_unit: "%"
         description_processing: |-
@@ -68,7 +67,7 @@ tables:
         # The source's own attributable fraction. It only covers the all-cancers total by agent, for countries; the
         # "attr_cases_share" indicator above covers cancer sites, regions and both sexes.
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex} (population attributable fraction)
-        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}, as published by IARC.{definitions.nmsc}
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}, as published by IARC.
         unit: "%"
         short_unit: "%"
         presentation:
@@ -76,7 +75,7 @@ tables:
 
       asir:
         title: New {definitions.cases_of} per 100,000 {definitions.people} (age-standardized)
-        description_short: Estimated number of new {definitions.cases_of} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.{definitions.nmsc}
+        description_short: Estimated number of new {definitions.cases_of} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
         unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:
@@ -84,7 +83,7 @@ tables:
 
       asir_att:
         title: New {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people} (age-standardized)
-        description_short: Estimated number of new {definitions.cases_of} attributed to {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.{definitions.nmsc}
+        description_short: Estimated number of new {definitions.cases_of} attributed to {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
         unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -8,12 +8,15 @@ definitions:
     processing_level: minor
     display:
       numDecimalPlaces: 1
-    description_key:
-      - Estimates come from the International Agency for Research on Cancer (IARC). They apply the population attributable fractions from the study "Global burden of cancer attributable to infections in 2018" (de Martel et al., 2020) to the GLOBOCAN 2020 cancer incidence estimates.
-      - |-
-        Ten infectious agents classified as carcinogenic by IARC are covered: Helicobacter pylori, human papillomavirus (HPV), hepatitis B and C viruses, Epstein-Barr virus (EBV), human herpesvirus type 8, human T-cell lymphotropic virus, the liver flukes Opisthorchis viverrini and Clonorchis sinensis, and Schistosoma haematobium.
-      - Non-melanoma skin cancers are excluded because their registration is often incomplete and inconsistent across countries.
-      - Estimates carry uncertainty, especially for countries without population-based cancer registries or with limited data on how common these infections are.
+    # NOTE: Draft "What you should know" bullets, not enabled. Each paraphrases text OWID or IARC already publishes
+    # (the tool's methodology statement, the agent list in the data, the footnote and subtitle on charts 8059-8061),
+    # but they have not been reviewed by the dataset owner. Uncomment after review to enable them.
+    # description_key:
+    #   - Estimates come from the International Agency for Research on Cancer (IARC). They apply the population attributable fractions from the study "Global burden of cancer attributable to infections in 2018" (de Martel et al., 2020) to the GLOBOCAN 2020 cancer incidence estimates.
+    #   - |-
+    #     Ten infectious agents classified as carcinogenic by IARC are covered: Helicobacter pylori, human papillomavirus (HPV), hepatitis B and C viruses, Epstein-Barr virus (EBV), human herpesvirus type 8, human T-cell lymphotropic virus, the liver flukes Opisthorchis viverrini and Clonorchis sinensis, and Schistosoma haematobium.
+    #   - Non-melanoma skin cancers are excluded because their registration is often incomplete and inconsistent across countries.
+    #   - Estimates carry uncertainty, especially for countries without population-based cancer registries or with limited data on how common these infections are.
   sex: <% if sex == "both" %>both sexes<% elif sex == "males" %>men<% elif sex == "females" %>women<% endif %>
   people: <% if sex == "both" %>people<% elif sex == "males" %>men<% elif sex == "females" %>women<% endif %>
   agent: |-

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -7,6 +7,7 @@ definitions:
       attribution_short: IARC
     processing_level: minor
     display:
+      # Shares and rates (the majority of indicators) show one decimal; the two count indicators override this to 0.
       numDecimalPlaces: 1
     # NOTE: Draft "What you should know" bullets, not enabled. Each paraphrases text OWID or IARC already publishes
     # (the tool's methodology statement, the agent list in the data, the footnote and subtitle on charts 8059-8061),
@@ -44,6 +45,8 @@ tables:
   gco_infections:
     variables:
       cases:
+        display:
+          numDecimalPlaces: 0
         title: Number of new {definitions.cases_of}{definitions.among_sex}
         description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex}.
         unit: cases
@@ -51,6 +54,8 @@ tables:
         processing_level: major
 
       attr_cases:
+        display:
+          numDecimalPlaces: 0
         title: Number of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
         description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
         unit: cases

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -28,7 +28,10 @@ definitions:
   people: <% if sex == "males" %>men<% elif sex == "females" %>women<% else %>people<% endif %>
   footnote: To allow for comparisons between countries and over time, this metric is [age-standardized](#dod:age_standardized).
   processing_regions: |-
-    For world regions, Our World in Data sums the values of the countries in the region with data. For cancer sites, the source only reports men and women separately; the both-sexes values are the sum of the two.
+    For world regions, Our World in Data sums the values of the countries in the region with data.
+  # The source reports cancer sites for men and women only; we add the both-sexes rows. The all-cancers total for
+  # both sexes is published by the source itself, so this sentence must not appear there.
+  processing_both_sexes: <% if sex == "both" and cancer != "All cancers but non-melanoma skin cancer (C00-97, but C44)" %> For this cancer site, the source only reports men and women separately; the both-sexes value is the sum of the values reported for men and women.<% endif %>
 
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
@@ -44,14 +47,14 @@ tables:
         title: Number of new {definitions.cases_of}{definitions.among_sex}
         description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex}.
         unit: cases
-        description_processing: "{definitions.processing_regions}"
+        description_processing: "{definitions.processing_regions}{definitions.processing_both_sexes}"
         processing_level: major
 
       attr_cases:
         title: Number of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
         description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
         unit: cases
-        description_processing: "{definitions.processing_regions}"
+        description_processing: "{definitions.processing_regions}{definitions.processing_both_sexes}"
         processing_level: major
 
       attr_cases_share:
@@ -60,7 +63,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_processing: |-
-          Computed by Our World in Data as the number of attributable cases divided by the total number of new cases. {definitions.processing_regions}
+          Computed by Our World in Data as the number of attributable cases divided by the total number of new cases. {definitions.processing_regions}{definitions.processing_both_sexes}
         processing_level: major
 
       paf:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -9,15 +9,14 @@ definitions:
     display:
       # Shares and rates (the majority of indicators) show one decimal; the two count indicators override this to 0.
       numDecimalPlaces: 1
-    # NOTE: Draft "What you should know" bullets, not enabled. Each paraphrases text OWID or IARC already publishes
-    # (the tool's methodology statement, the agent list in the data, the footnote and subtitle on charts 8059-8061),
-    # but they have not been reviewed by the dataset owner. Uncomment after review to enable them.
-    # description_key:
-    #   - Estimates come from the International Agency for Research on Cancer (IARC). They apply the population attributable fractions from the study "Global burden of cancer attributable to infections in 2018" (de Martel et al., 2020) to the GLOBOCAN 2020 cancer incidence estimates.
-    #   - |-
-    #     Ten infectious agents classified as carcinogenic by IARC are covered: Helicobacter pylori, human papillomavirus (HPV), hepatitis B and C viruses, Epstein-Barr virus (EBV), human herpesvirus type 8, human T-cell lymphotropic virus, the liver flukes Opisthorchis viverrini and Clonorchis sinensis, and Schistosoma haematobium.
-    #   - Non-melanoma skin cancers are excluded because their registration is often incomplete and inconsistent across countries.
-    #   - Estimates carry uncertainty, especially for countries without population-based cancer registries or with limited data on how common these infections are.
+    description_key:
+      - Estimates come from the International Agency for Research on Cancer (IARC). They apply the population attributable fractions from the study "Global burden of cancer attributable to infections in 2018" (de Martel et al., 2020) to the GLOBOCAN 2020 cancer incidence estimates.
+      - |-
+        Ten infectious agents classified as carcinogenic by IARC are covered: Helicobacter pylori, human papillomavirus (HPV), hepatitis B and C viruses, Epstein-Barr virus (EBV), human herpesvirus type 8, human T-cell lymphotropic virus, the liver flukes Opisthorchis viverrini and Clonorchis sinensis, and Schistosoma haematobium.
+      - Non-melanoma skin cancers are excluded because their registration is often incomplete and inconsistent across countries.
+      - Estimates carry uncertainty, especially for countries without population-based cancer registries or with limited data on how common these infections are.
+      - |-
+        For four cancer types (cervical cancer, Kaposi sarcoma, anal squamous cell carcinoma, and adult T-cell leukemia and lymphoma), IARC attributes every case to an infection, so their attributable share is 100% by construction rather than an observed value.
   # Readable labels for the three dimensions. The source labels are kept as dimension values (so indicator short names
   # do not change); only the displayed text is rewritten. "Other Non-Hodkin lymphoma" is a typo in the source.
   cases_of: |-

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -49,14 +49,14 @@ tables:
 
       attr_cases:
         title: Number of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
-        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} caused by {definitions.agent_phrase}.
+        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
         unit: cases
         description_processing: "{definitions.processing_regions}"
         processing_level: major
 
       attr_cases_share:
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
-        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} caused by {definitions.agent_phrase}.
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
         unit: "%"
         short_unit: "%"
         description_processing: |-
@@ -67,7 +67,7 @@ tables:
         # The source's own attributable fraction. It only covers the all-cancers total by agent, for countries; the
         # "attr_cases_share" indicator above covers cancer sites, regions and both sexes.
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex} (population attributable fraction)
-        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} caused by {definitions.agent_phrase}, as published by IARC.
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}, as published by IARC.
         unit: "%"
         short_unit: "%"
         presentation:
@@ -83,7 +83,7 @@ tables:
 
       asir_att:
         title: New {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people} (age-standardized)
-        description_short: Estimated number of new {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
+        description_short: Estimated number of new {definitions.cases_of} attributed to {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
         unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -17,12 +17,16 @@ definitions:
     #     Ten infectious agents classified as carcinogenic by IARC are covered: Helicobacter pylori, human papillomavirus (HPV), hepatitis B and C viruses, Epstein-Barr virus (EBV), human herpesvirus type 8, human T-cell lymphotropic virus, the liver flukes Opisthorchis viverrini and Clonorchis sinensis, and Schistosoma haematobium.
     #   - Non-melanoma skin cancers are excluded because their registration is often incomplete and inconsistent across countries.
     #   - Estimates carry uncertainty, especially for countries without population-based cancer registries or with limited data on how common these infections are.
-  sex: <% if sex == "both" %>both sexes<% elif sex == "males" %>men<% elif sex == "females" %>women<% endif %>
-  people: <% if sex == "both" %>people<% elif sex == "males" %>men<% elif sex == "females" %>women<% endif %>
-  agent: |-
-    <% if agent == "All infectious agents" %>all infectious agents<% elif agent == "HPV" %>human papillomavirus (HPV)<% elif agent == "EBV" %>Epstein-Barr virus (EBV)<% elif agent == "Hepatitis B virus" %>hepatitis B virus<% elif agent == "Hepatitis C virus" %>hepatitis C virus<% elif agent == "Human T-cell lymphotropic virus" %>human T-cell lymphotropic virus<% elif agent == "Human herpesvirus type 8" %>human herpesvirus type 8<% else %><< agent >><% endif %>
-  cancer: |-
-    <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %>all cancers (excluding non-melanoma skin cancer)<% else %><< cancer.lower().replace("hodkin", "hodgkin").replace("hodgkin", "Hodgkin").replace("burkitt", "Burkitt").replace("kaposi", "Kaposi").replace("t-cell", "T-cell") >><% endif %>
+  # Readable labels for the three dimensions. The source labels are kept as dimension values (so indicator short names
+  # do not change); only the displayed text is rewritten. "Other Non-Hodkin lymphoma" is a typo in the source.
+  cases_of: |-
+    <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %>cancer cases<% else %>cases of << cancer.lower().replace("hodkin", "hodgkin").replace("hodgkin", "Hodgkin").replace("burkitt", "Burkitt").replace("kaposi", "Kaposi").replace("t-cell", "T-cell") >><% endif %>
+  agent_phrase: |-
+    <% if agent == "All infectious agents" %>infections<% elif agent == "HPV" %>human papillomavirus (HPV)<% elif agent == "EBV" %>Epstein-Barr virus (EBV)<% elif agent == "Hepatitis B virus" %>hepatitis B virus<% elif agent == "Hepatitis C virus" %>hepatitis C virus<% elif agent == "Human T-cell lymphotropic virus" %>human T-cell lymphotropic virus<% elif agent == "Human herpesvirus type 8" %>human herpesvirus type 8<% else %><< agent >><% endif %>
+  # Sex is only spelled out for men and women; "both sexes" is the default and is left implicit.
+  among_sex: <% if sex == "males" %> among men<% elif sex == "females" %> among women<% endif %>
+  people: <% if sex == "males" %>men<% elif sex == "females" %>women<% else %>people<% endif %>
+  nmsc: <% if cancer == "All cancers but non-melanoma skin cancer (C00-97, but C44)" %> Non-melanoma skin cancers are excluded.<% endif %>
   footnote: To allow for comparisons between countries and over time, this metric is [age-standardized](#dod:age_standardized).
   processing_regions: |-
     For world regions, Our World in Data sums the values of the countries in the region with data. For cancer sites, the source only reports men and women separately; the both-sexes values are the sum of the two.
@@ -38,22 +42,22 @@ tables:
   gco_infections:
     variables:
       cases:
-        title: Number of new cases of {definitions.cancer} among {definitions.sex}
-        description_short: Estimated number of new cases of {definitions.cancer} among {definitions.sex}.
+        title: Number of new {definitions.cases_of}{definitions.among_sex}
+        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex}.{definitions.nmsc}
         unit: cases
         description_processing: "{definitions.processing_regions}"
         processing_level: major
 
       attr_cases:
-        title: Number of new cases of {definitions.cancer} attributable to {definitions.agent} among {definitions.sex}
-        description_short: Estimated number of new cases of {definitions.cancer} among {definitions.sex} that are attributable to {definitions.agent}.
+        title: Number of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
+        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.{definitions.nmsc}
         unit: cases
         description_processing: "{definitions.processing_regions}"
         processing_level: major
 
       attr_cases_share:
-        title: Share of new cases of {definitions.cancer} among {definitions.sex} attributable to {definitions.agent}
-        description_short: Estimated share of new cases of {definitions.cancer} among {definitions.sex} that are attributable to {definitions.agent}.
+        title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.{definitions.nmsc}
         unit: "%"
         short_unit: "%"
         description_processing: |-
@@ -61,22 +65,26 @@ tables:
         processing_level: major
 
       paf:
-        title: Population attributable fraction of {definitions.cancer} among {definitions.sex} due to {definitions.agent}
-        description_short: Estimated share of new cases of {definitions.cancer} among {definitions.sex} that are attributable to {definitions.agent}, as published by the source.
+        # The source's own attributable fraction. It only covers the all-cancers total by agent, for countries; the
+        # "attr_cases_share" indicator above covers cancer sites, regions and both sexes.
+        title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex} (population attributable fraction)
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}, as published by IARC.{definitions.nmsc}
         unit: "%"
         short_unit: "%"
+        presentation:
+          title_public: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
 
       asir:
-        title: Age-standardized incidence rate of {definitions.cancer} among {definitions.sex}
-        description_short: Estimated number of new cases of {definitions.cancer} per 100,000 {definitions.people} in a year, age-standardized.
+        title: New {definitions.cases_of} per 100,000 {definitions.people} (age-standardized)
+        description_short: Estimated number of new {definitions.cases_of} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.{definitions.nmsc}
         unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:
             note: "{definitions.footnote}"
 
       asir_att:
-        title: Age-standardized incidence rate of {definitions.cancer} attributable to {definitions.agent} among {definitions.sex}
-        description_short: Estimated number of new cases of {definitions.cancer} attributable to {definitions.agent} per 100,000 {definitions.people} in a year, age-standardized.
+        title: New {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people} (age-standardized)
+        description_short: Estimated number of new {definitions.cases_of} attributed to {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.{definitions.nmsc}
         unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -49,14 +49,14 @@ tables:
 
       attr_cases:
         title: Number of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
-        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
+        description_short: Estimated number of new {definitions.cases_of}{definitions.among_sex} caused by {definitions.agent_phrase}.
         unit: cases
         description_processing: "{definitions.processing_regions}"
         processing_level: major
 
       attr_cases_share:
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
-        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}.
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} caused by {definitions.agent_phrase}.
         unit: "%"
         short_unit: "%"
         description_processing: |-
@@ -67,7 +67,7 @@ tables:
         # The source's own attributable fraction. It only covers the all-cancers total by agent, for countries; the
         # "attr_cases_share" indicator above covers cancer sites, regions and both sexes.
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex} (population attributable fraction)
-        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}, as published by IARC.
+        description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} caused by {definitions.agent_phrase}, as published by IARC.
         unit: "%"
         short_unit: "%"
         presentation:
@@ -83,7 +83,7 @@ tables:
 
       asir_att:
         title: New {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people} (age-standardized)
-        description_short: Estimated number of new {definitions.cases_of} attributed to {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
+        description_short: Estimated number of new {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
         unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -67,8 +67,9 @@ tables:
         processing_level: major
 
       paf:
-        # The source's own attributable fraction. It only covers the all-cancers total by agent, for countries; the
-        # "attr_cases_share" indicator above covers cancer sites, regions and both sexes.
+        # The source's own attributable fraction, for the all-cancers total by individual agent (countries only). For
+        # "all infectious agents" it is blanked in the garden step because it duplicates attr_cases_share, which also
+        # covers cancer sites, regions and both sexes.
         title: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex} (population attributable fraction)
         description_short: Estimated share of new {definitions.cases_of}{definitions.among_sex} that are attributed to {definitions.agent_phrase}, as published by IARC.
         unit: "%"

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -77,7 +77,7 @@ tables:
           title_public: Share of new {definitions.cases_of} caused by {definitions.agent_phrase}{definitions.among_sex}
 
       asir:
-        title: New {definitions.cases_of} per 100,000 {definitions.people} (age-standardized)
+        title: Age-standardized rate of new {definitions.cases_of}, per 100,000 {definitions.people}
         description_short: Estimated number of new {definitions.cases_of} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
         unit: cases per 100,000 {definitions.people}
         presentation:
@@ -85,7 +85,7 @@ tables:
             note: "{definitions.footnote}"
 
       asir_att:
-        title: New {definitions.cases_of} caused by {definitions.agent_phrase} per 100,000 {definitions.people} (age-standardized)
+        title: Age-standardized rate of new {definitions.cases_of} caused by {definitions.agent_phrase}, per 100,000 {definitions.people}
         description_short: Estimated number of new {definitions.cases_of} attributed to {definitions.agent_phrase} per 100,000 {definitions.people}, age-standardized so that populations with different age structures can be compared.
         unit: cases per 100,000 {definitions.people}
         presentation:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -29,7 +29,6 @@ definitions:
 dataset:
   update_period_days: 365
   owners:
-    - Tuna Acisu
     - Lucas Rodés-Guirao
 
 tables:

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.meta.yml
@@ -67,7 +67,7 @@ tables:
       asir:
         title: Age-standardized incidence rate of {definitions.cancer} among {definitions.sex}
         description_short: Estimated number of new cases of {definitions.cancer} per 100,000 {definitions.people} in a year, age-standardized.
-        unit: cases per 100,000 people
+        unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:
             note: "{definitions.footnote}"
@@ -75,7 +75,7 @@ tables:
       asir_att:
         title: Age-standardized incidence rate of {definitions.cancer} attributable to {definitions.agent} among {definitions.sex}
         description_short: Estimated number of new cases of {definitions.cancer} attributable to {definitions.agent} per 100,000 {definitions.people} in a year, age-standardized.
-        unit: cases per 100,000 people
+        unit: cases per 100,000 {definitions.people}
         presentation:
           grapher_config:
             note: "{definitions.footnote}"

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
@@ -80,6 +80,11 @@ def run() -> None:
     # unlike the source's population attributable fraction).
     tb["attr_cases_share"] = tb["attr_cases"] / tb["cases"] * 100
 
+    # The source's population attributable fraction is only published for the all-cancers total, by agent. For "all
+    # infectious agents" it duplicates our share (same values), so we do not publish it there; it stays for the
+    # individual agents, where the source does not report the denominator needed to compute a share.
+    tb.loc[tb["agent"] == ALL_AGENTS, "paf"] = np.nan
+
     # Improve table format.
     tb = tb.format(["country", "year", "sex", "agent", "cancer"], short_name=paths.short_name)
 
@@ -137,6 +142,12 @@ def sanity_check_outputs(tb: Table) -> None:
     assert set(REGIONS) <= set(tb["country"]), error
     error = "Attributable shares must be between 0% and 100%."
     assert tb["attr_cases_share"].dropna().between(0, 100 + 1e-6).all(), error
+    error = (
+        "The source's attributable fraction should not be published for all agents (it duplicates attr_cases_share)."
+    )
+    assert tb.loc[tb["agent"] == ALL_AGENTS, "paf"].isna().all(), error
+    error = "The source's attributable fraction should be available for every individual agent."
+    assert tb.loc[(tb["agent"] != ALL_AGENTS) & (tb["cancer"] == ALL_CANCERS), "paf"].notna().all(), error
     error = "There should be no columns with only NaNs."
     assert tb.columns[tb.isna().all()].empty, error
 

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
@@ -146,8 +146,9 @@ def sanity_check_outputs(tb: Table) -> None:
         "The source's attributable fraction should not be published for all agents (it duplicates attr_cases_share)."
     )
     assert tb.loc[tb["agent"] == ALL_AGENTS, "paf"].isna().all(), error
-    error = "The source's attributable fraction should be available for every individual agent."
-    assert tb.loc[(tb["agent"] != ALL_AGENTS) & (tb["cancer"] == ALL_CANCERS), "paf"].notna().all(), error
+    is_country = ~tb["country"].isin(REGIONS)
+    error = "The source's attributable fraction should be available for every individual agent (countries only)."
+    assert tb.loc[(tb["agent"] != ALL_AGENTS) & (tb["cancer"] == ALL_CANCERS) & is_country, "paf"].notna().all(), error
     error = "There should be no columns with only NaNs."
     assert tb.columns[tb.isna().all()].empty, error
 

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
@@ -1,65 +1,155 @@
 """Load a meadow dataset and create a garden dataset."""
 
+import numpy as np
 import owid.catalog.processing as pr
+from owid.catalog import Table
+from structlog import get_logger
 
-from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
+
+# Initialize logger.
+log = get_logger()
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
-# Define regions to aggregate
+
+# Regions to aggregate.
 REGIONS = ["Europe", "Asia", "North America", "South America", "Africa", "Oceania", "World"]
+# Labels used by the source for the totals.
+ALL_AGENTS = "All infectious agents"
+ALL_CANCERS = "All cancers but non-melanoma skin cancer (C00-97, but C44)"
+EXPECTED_AGENTS = {
+    ALL_AGENTS,
+    "EBV",
+    "HPV",
+    "Helicobacter pylori",
+    "Hepatitis B virus",
+    "Hepatitis C virus",
+    "Human T-cell lymphotropic virus",
+    "Human herpesvirus type 8",
+    "Opisthorchis viverrini and Clonorchis sinensis",
+    "Schistosoma haematobium",
+}
+EXPECTED_NUM_CANCERS = 21  # 20 infection-related cancer sites plus the all-cancers total.
+EXPECTED_YEARS = {2020}
+# Number of countries in the current version of the data.
+# NOTE: A lower count on the next update usually means a parsing or harmonization regression, not a real change.
+MIN_NUM_COUNTRIES = 185
+# The source's own both-sexes total of attributable cases differs from the sum of men and women by more than 1% in
+# two countries (The Gambia and Zambia in the 2020 estimates). We keep the source values as published.
+TOLERANCE_SOURCE_SEX_TOTALS = 0.01
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("gco_infections")
-    # Load regions dataset.
-    ds_regions = paths.load_dataset("regions")
+
     # Read table from meadow dataset.
-    tb = ds_meadow["gco_infections"].reset_index()
+    tb = ds_meadow.read("gco_infections")
+
+    sanity_check_inputs(tb)
 
     #
     # Process data.
     #
-    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+    # Harmonize country names.
+    tb = paths.regions.harmonize_names(tb=tb)
 
-    aggregates = {"cases": "sum", "attr_cases": "sum"}
-    tb = geo.add_regions_to_table(
+    # Add region aggregates for the number of new cases and of attributable cases (rates and fractions can't be summed).
+    tb = paths.regions.add_aggregates(
         tb,
         index_columns=["country", "year", "sex", "agent", "cancer"],
         regions=REGIONS,
-        aggregations=aggregates,
-        ds_regions=ds_regions,
+        aggregations={"cases": "sum", "attr_cases": "sum"},
         min_num_values_per_year=1,
     )
-    # Create rows with sex = "both" for the ncases column and the attr_cases column for where the cancer is not "All cancers but non-melanoma skin cancer (C00-97, but C44)"
-    tb_filtered = tb[tb["cancer"] != "All cancers but non-melanoma skin cancer (C00-97, but C44)"]
 
-    # Group by the relevant columns and aggregate the cases and attr_cases
-    tb_both = tb_filtered.groupby(["country", "year", "agent", "cancer"], as_index=False).agg(
+    # The source reports the cancer-site breakdown for men and women separately only. Add both-sexes rows for those
+    # sites by summing new cases and attributable cases over men and women.
+    tb_sites = tb[tb["cancer"] != ALL_CANCERS]
+    tb_both = tb_sites.groupby(["country", "year", "agent", "cancer"], as_index=False, observed=True).agg(
         {"cases": "sum", "attr_cases": "sum"}
     )
-
-    # Add the sex column with the value "Both"
     tb_both["sex"] = "both"
-
-    # Append the new rows to the original DataFrame
     tb = pr.concat([tb, tb_both], ignore_index=True)
-    tb["attr_cases_share"] = (tb["attr_cases"] / tb["cases"]) * 100
 
-    tb = tb.format(["country", "year", "sex", "agent", "cancer"])
+    # Share of new cases attributable to infections (also available for regions and for the added both-sexes rows,
+    # unlike the source's population attributable fraction).
+    tb["attr_cases_share"] = tb["attr_cases"] / tb["cases"] * 100
+
+    # Improve table format.
+    tb = tb.format(["country", "year", "sex", "agent", "cancer"], short_name=paths.short_name)
+
+    sanity_check_outputs(tb)
 
     #
     # Save outputs.
     #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
-    )
+    # Initialize a new garden dataset.
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
-    # Save changes in the new garden dataset.
+    # Save garden dataset.
     ds_garden.save()
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    """Check the structure and value ranges of the meadow table."""
+    error = "Unexpected set of infectious agents in the source data."
+    assert set(tb["agent"]) == EXPECTED_AGENTS, error
+    error = f"Expected {EXPECTED_NUM_CANCERS} cancer categories, found {tb['cancer'].nunique()}."
+    assert tb["cancer"].nunique() == EXPECTED_NUM_CANCERS, error
+    error = "Unexpected years in the source data."
+    assert set(tb["year"]) == EXPECTED_YEARS, error
+    error = "Unexpected sex categories in the source data."
+    assert set(tb["sex"]) == {"both", "males", "females"}, error
+    error = f"Only {tb['country'].nunique()} countries in the source data, fewer than the {MIN_NUM_COUNTRIES} expected."
+    assert tb["country"].nunique() >= MIN_NUM_COUNTRIES, error
+
+    value_columns = ["cases", "attr_cases", "asir_att", "paf", "asir"]
+    error = "Negative values found in the source data."
+    assert (tb[value_columns].min() >= 0).all(), error
+    error = "Population attributable fractions must be shares between 0% and 100%."
+    assert tb["paf"].dropna().between(0, 100).all(), error
+    has_both = tb["cases"].notna() & tb["attr_cases"].notna()
+    error = "Attributable cases exceed the total number of new cases."
+    assert (tb.loc[has_both, "attr_cases"] <= tb.loc[has_both, "cases"] * (1 + 1e-6)).all(), error
+
+    # Soft check: the source's both-sexes totals should be close to the sum of men and women.
+    totals = tb[(tb["agent"] == ALL_AGENTS) & (tb["cancer"] == ALL_CANCERS)].pivot(
+        index="country", columns="sex", values="attr_cases"
+    )
+    relative_gap = ((totals["males"] + totals["females"] - totals["both"]) / totals["both"]).abs()
+    inconsistent = sorted(relative_gap[relative_gap > TOLERANCE_SOURCE_SEX_TOTALS].index)
+    if inconsistent:
+        log.warning(
+            "Source both-sexes attributable cases differ from men + women by more than "
+            f"{TOLERANCE_SOURCE_SEX_TOTALS:.0%} in: {inconsistent}"
+        )
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    """Check the output table, in particular the aggregates we compute ourselves."""
+    tb = tb.reset_index()
+    error = "Some region aggregates are missing."
+    assert set(REGIONS) <= set(tb["country"]), error
+    error = "Attributable shares must be between 0% and 100%."
+    assert tb["attr_cases_share"].dropna().between(0, 100 + 1e-6).all(), error
+    error = "There should be no columns with only NaNs."
+    assert tb.columns[tb.isna().all()].empty, error
+
+    # World must equal the sum of all countries (regions excluded) for the all-cancers, all-agents totals.
+    totals = tb[(tb["agent"] == ALL_AGENTS) & (tb["cancer"] == ALL_CANCERS) & (tb["sex"] == "both")]
+    countries_sum = totals[~totals["country"].isin(REGIONS)][["cases", "attr_cases"]].sum()
+    world = totals[totals["country"] == "World"][["cases", "attr_cases"]].iloc[0]
+    error = "World aggregate does not match the sum of countries."
+    assert np.allclose(world.astype(float), countries_sum.astype(float), rtol=1e-6), error
+
+    # The both-sexes rows we add for cancer sites must equal men + women.
+    sites = tb[(tb["cancer"] != ALL_CANCERS) & (tb["agent"] == ALL_AGENTS)]
+    by_sex = sites.pivot(index=["country", "cancer"], columns="sex", values="attr_cases")
+    men_plus_women = by_sex[["males", "females"]].sum(axis=1, min_count=1)
+    error = "Both-sexes attributable cases for cancer sites do not equal men + women."
+    assert np.allclose(by_sex["both"].astype(float), men_plus_women.astype(float), rtol=1e-6, equal_nan=True), error

--- a/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/garden/cancer/2024-09-06/gco_infections.py
@@ -30,7 +30,31 @@ EXPECTED_AGENTS = {
     "Opisthorchis viverrini and Clonorchis sinensis",
     "Schistosoma haematobium",
 }
-EXPECTED_NUM_CANCERS = 21  # 20 infection-related cancer sites plus the all-cancers total.
+# The 20 infection-related cancer sites plus the all-cancers total, as labeled by the source. The reader-facing names
+# in gco_infections.meta.yml are derived from these exact strings, so a renamed or added site must be reviewed there.
+EXPECTED_CANCERS = {
+    ALL_CANCERS,
+    "Adult T-cell leukemia and lymphoma",
+    "Anus squamous cell carcinoma",
+    "Bladder carcinoma",
+    "Burkitt lymphoma",
+    "Cardia gastric cancer",
+    "Cervix uteri carcinoma",
+    "Cholangiocarcinoma",
+    "Hepatocellular carcinoma",
+    "Hodgkin lymphoma",
+    "Kaposi sarcoma",
+    "Larynx cancer",
+    "Nasopharynx carcinoma",
+    "Non-Hodgkin lymphoma of gastric location",
+    "Non-cardia gastric cancer",
+    "Oral cavity cancer",
+    "Oropharyngeal carcinoma",
+    "Other Non-Hodkin lymphoma",  # NOTE: the source's typo; corrected in display text only.
+    "Penis carcinoma",
+    "Vagina carcinoma",
+    "Vulva carcinoma",
+}
 EXPECTED_YEARS = {2020}
 # Number of countries in the current version of the data.
 # NOTE: A lower count on the next update usually means a parsing or harmonization regression, not a real change.
@@ -104,8 +128,8 @@ def sanity_check_inputs(tb: Table) -> None:
     """Check the structure and value ranges of the meadow table."""
     error = "Unexpected set of infectious agents in the source data."
     assert set(tb["agent"]) == EXPECTED_AGENTS, error
-    error = f"Expected {EXPECTED_NUM_CANCERS} cancer categories, found {tb['cancer'].nunique()}."
-    assert tb["cancer"].nunique() == EXPECTED_NUM_CANCERS, error
+    error = f"Unexpected set of cancer categories in the source data: {set(tb['cancer']) ^ EXPECTED_CANCERS}"
+    assert set(tb["cancer"]) == EXPECTED_CANCERS, error
     error = "Unexpected years in the source data."
     assert set(tb["year"]) == EXPECTED_YEARS, error
     error = "Unexpected sex categories in the source data."

--- a/etl/steps/data/grapher/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/grapher/cancer/2024-09-06/gco_infections.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -14,19 +14,14 @@ def run(dest_dir: str) -> None:
     ds_garden = paths.load_dataset("gco_infections")
 
     # Read table from garden dataset.
-    tb = ds_garden["gco_infections"]
-
-    #
-    # Process data.
-    #
+    tb = ds_garden.read("gco_infections", reset_index=False)
 
     #
     # Save outputs.
     #
-    # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata, long_to_wide=False
-    )
+    # Initialize a new grapher dataset (the long table with sex, agent and cancer dimensions is expanded to one
+    # indicator per combination by the grapher channel).
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, long_to_wide=False)
 
-    # Save changes in the new grapher dataset.
+    # Save grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/meadow/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/meadow/cancer/2024-09-06/gco_infections.py
@@ -1,12 +1,16 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
+# Columns from the source that are redundant with the ones we keep (counts and crude rates for the site totals).
+COLUMNS_TO_DROP = ["id", "code", "ncases_sites", "ncases_all", "ir_att", "ir", "asr"]
+SEX_MAPPING = {"0": "both", "1": "males", "2": "females"}
 
-def run(dest_dir: str) -> None:
+
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,19 +23,17 @@ def run(dest_dir: str) -> None:
     #
     # Process data.
     #
-    # Drop unnecessary columns.
-    tb = tb.drop(columns=["id", "code", "ncases_sites", "ncases_all", "ir_att", "ir", "asr"])
+    tb = tb.drop(columns=COLUMNS_TO_DROP)
+    tb["sex"] = tb["sex"].astype(str).replace(SEX_MAPPING)
 
-    tb["sex"] = tb["sex"].astype(str).replace({"0": "both", "1": "males", "2": "females"})
-
-    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    # Improve table format.
     tb = tb.format(["country", "year", "sex", "agent", "cancer"])
 
     #
     # Save outputs.
     #
-    # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    # Initialize a new meadow dataset.
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
 
-    # Save changes in the new meadow dataset.
+    # Save meadow dataset.
     ds_meadow.save()

--- a/snapshots/cancer/2024-09-06/gco_infections.csv.dvc
+++ b/snapshots/cancer/2024-09-06/gco_infections.csv.dvc
@@ -16,6 +16,9 @@ meta:
     # Files
     url_main: https://gco.iarc.who.int/causes/infections/tools-map?mode=1&sex=0&continent=0&agent=0&cancer=0&key=asr&scale=quantile
     url_download: https://gco.iarc.who.int/causes/infections/data/v2/
+    # NOTE: Checked for a newer release in September 2026 and found none: the tool still applies the de Martel et al.
+    # (2020) attributable fractions to GLOBOCAN 2020 incidence, and its data files were last modified on 2023-08-31.
+    # Before the next update, check whether IARC has published a GLOBOCAN 2022-based version.
     date_accessed: 2024-09-06
 
     # License

--- a/snapshots/cancer/2024-09-06/gco_infections.py
+++ b/snapshots/cancer/2024-09-06/gco_infections.py
@@ -1,8 +1,12 @@
-"""Script to create a snapshot of dataset."""
+"""Script to create a snapshot of dataset.
+
+The Global Cancer Observatory tool "Cancers Attributable to Infections" loads three JSON files: estimates by
+infectious agent (for all cancers combined), by cancer site (for all agents combined), and totals. This script
+fetches the three files and stacks them into one CSV, keeping the source's own labels and column names.
+"""
 
 from pathlib import Path
 
-import click
 import pandas as pd
 import requests
 from owid.datautils.io import df_to_file
@@ -12,38 +16,34 @@ from etl.snapshot import Snapshot
 # Version for current snapshot dataset.
 SNAPSHOT_VERSION = Path(__file__).parent.name
 
+# The estimates apply attributable fractions to GLOBOCAN cancer incidence estimates for this year.
+YEAR = 2020
+# Labels used by the source for the totals.
+ALL_AGENTS = "All infectious agents"
+ALL_CANCERS = "All cancers but non-melanoma skin cancer (C00-97, but C44)"
 
-@click.command()
-@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
-def main(upload: bool) -> None:
+
+def run(upload: bool = True) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"cancer/{SNAPSHOT_VERSION}/gco_infections.csv")
     base_url = snap.metadata.origin.url_download
 
-    jsons = ["by-agent.json", "by-cancers.json", "all.json"]
     dataframes = []
-    for json in jsons:
-        # Fetch the JSON data from the URL
-        response = requests.get(base_url + json)
+    for json_file in ["by-agent.json", "by-cancers.json", "all.json"]:
+        response = requests.get(base_url + json_file, timeout=120)
+        response.raise_for_status()
+        df = pd.DataFrame(response.json())
+        df["year"] = YEAR
 
-        # Parse the JSON data
-        data = response.json()
-        # Convert JSON data to DataFrame
-        df = pd.DataFrame(data)
-        df["year"] = 2020
-
-        if json == "by-agent.json":
-            df["cancer"] = "All cancers but non-melanoma skin cancer (C00-97, but C44)"
-        elif json == "by-cancers.json":
-            df["agent"] = "All infectious agents"
-        elif json == "all.json":
+        if json_file == "by-agent.json":
+            df["cancer"] = ALL_CANCERS
+        elif json_file == "by-cancers.json":
+            df["agent"] = ALL_AGENTS
+        elif json_file == "all.json":
             df = df.rename(columns={"site": "cancer"})
         dataframes.append(df)
-    all_dfs = pd.concat(dataframes, ignore_index=True)
-    df_to_file(all_dfs, file_path=snap.path)
-    # Add file to DVC and upload to S3.
+    df_all = pd.concat(dataframes, ignore_index=True)
+
+    # Write the combined file, add it to DVC and upload it to R2.
+    df_to_file(df_all, file_path=snap.path)
     snap.dvc_add(upload=upload)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
> _Written by Claude Fable 5.1 — @lucasrodes at the wheel._

Ref owid/owid-issues#2478 · No new data at the source: the three JSON files behind the GCO "Cancers Attributable to Infections" tool are byte-identical to our 2024-09-06 snapshot (server `Last-Modified: 31 Aug 2023`; the tool still applies the de Martel et al. 2020 fractions to GLOBOCAN 2020 incidence). So this PR keeps the existing version (no new variable IDs, no chart remap) and does the maintenance the update checklist asks for.

| Chart | PROD | STAGING |
|---|---|---|
| Share of new cancers caused by infections | [prod](https://ourworldindata.org/grapher/share-of-new-cancers-caused-by-all-known-infections-by-type) | [staging](http://staging-site-data-gco-cancer-infections/grapher/share-of-new-cancers-caused-by-all-known-infections-by-type) |
| Share of new cancers caused by all known infectious agents | [prod](https://ourworldindata.org/grapher/share-of-new-cancers-caused-by-all-known-infectious-agents) | [staging](http://staging-site-data-gco-cancer-infections/grapher/share-of-new-cancers-caused-by-all-known-infectious-agents) |
| Share of new cancers caused by Helicobacter pylori bacteria | [prod](https://ourworldindata.org/grapher/share-of-new-cancers-caused-by-helicobacter-pylori-bacteria) | [staging](http://staging-site-data-gco-cancer-infections/grapher/share-of-new-cancers-caused-by-helicobacter-pylori-bacteria) |

`etl diff` against the published catalog: data identical except the deliberate removal of the source's attributable fraction for all agents (a duplicate of our share); otherwise metadata only.

**What changed**
- Garden sanity checks on the aggregates we compute: World equals the sum of countries, the both-sexes rows we add for cancer sites equal men + women, attributable cases never exceed new cases, shares within 0–100%, expected agents/cancers/years/country count. A soft warning flags that the source's own both-sexes totals differ from men + women by more than 1% in The Gambia and Zambia (source values kept as published).
- Step code brought to the current shape (`run()`, `paths.create_dataset`, `paths.regions.harmonize_names` / `add_aggregates`); snapshot script without `click` boilerplate (produces the same file).
- Indicator text rewritten in plain language. Titles follow one pattern per measure: "Number of new cancer cases (excluding non-melanoma skin cancer) caused by hepatitis B virus among women", "Share of new cases of Kaposi sarcoma caused by infections", "New cancer cases per 100,000 men (age-standardized)". Agent and site labels are no longer lowercased blindly ("hpv", "helicobacter pylori"; the source's "Non-Hodkin" typo is corrected in display text only); the all-cancers total reads "cancer cases (excluding non-melanoma skin cancer)"; "both sexes" is left implicit and men/women spelled out (style guide: women/men for all ages; confirmed by the owner). Titles say "caused by" for brevity; descriptions, where there is room, say "attributed to". `paf` (the source's fraction, all cancers by agent) keeps "(population attributable fraction)" in its internal title only; its public title matches the `attr_cases_share` pattern, and the two agree to 1e-5 where they overlap. `description_processing` on the three computed indicators; `attribution_short`. Draft `description_key` bullets are left commented out pending the owner's review. Chart titles/subtitles are pinned on the charts and are not affected.
- Snapshot `.dvc` carries a NOTE recording the September 2026 source check (nothing new; look for a GLOBOCAN 2022-based release next time).

**Checklist**
- [x] Source checked for a newer release: none (JSON files unchanged since 2023-08-31); NOTE recorded in the snapshot `.dvc`.
- [x] Chain re-run from the branch; `etl diff` vs the published catalog: data identical except `paf`, which is now blank for "all infectious agents" (3 unused duplicate indicators removed, per review); everything else metadata only.
- [x] Sanity checks on our aggregates (World = sum of countries; both sexes = men + women; attributable ≤ total; ranges).
- [x] Staging built green; the three charts render; new indicator text live on the staging API.
- [x] Codex review: no findings.
- [x] Owner decisions: men/women wording kept; "caused by" in titles, "attributed to" in descriptions; "(excluding non-melanoma skin cancer)" kept in the all-cancers labels; `description_key` bullets reviewed by the owner and enabled, plus a fifth on the four sites IARC treats as 100% attributable; owner set to @lucasrodes.
- [ ] Optional: a second topic tag (Global Health) next to Cancer in `definitions.common`.
- [ ] Review by another data scientist before merging (per the update checklist).
- [x] Reminder text updated so next year's assignee checks the source first (owid/owid-issues#2527, cron unchanged).
