### PR TITLE
✨ wizard: Add admin edit link to chart diff headers

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -8,7 +8,7 @@ import difflib
 import json
 import os
 from functools import cached_property
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pandas as pd
 import streamlit as st
@@ -31,7 +31,7 @@ from apps.wizard.app_pages.chart_diff.conflict_resolver import (
 )
 from apps.wizard.app_pages.chart_diff.utils import ANALYTICS_NUM_DAYS, SOURCE, TARGET, prettify_date
 from apps.wizard.utils.components import grapher_chart
-from etl.config import OWID_ENV
+from etl.config import OWID_ENV, OWIDEnv
 from etl.grapher.io import variable_metadata_df_from_s3
 
 log = get_logger()
@@ -558,13 +558,38 @@ class ChartDiffShow:
                 st.session_state[cache_key] = (response, cost_msg)
         st.caption(cost_msg)
 
+    def _chart_header_row(self, height: int | Literal["content"] = "content"):
+        """Row for a chart's header: title on the left, admin link pushed to the right.
+
+        A fixed `height` keeps both columns' headers the same size when one of them
+        shows the taller revision selectbox.
+        """
+        return st.container(
+            border=False,
+            height=height,
+            horizontal=True,
+            horizontal_alignment="distribute",
+            vertical_alignment="center",
+        )
+
+    def _show_edit_link(self, owid_env: OWIDEnv) -> None:
+        """Link to the chart's edit page in the admin of the given environment.
+
+        Grapher's own "Edit" entry in the share menu never shows up here: we mount the
+        chart with the npm package inside a srcdoc iframe, where none of the signals it
+        uses to detect an internal user (admin cookie, host name) can apply.
+        """
+        if not self.diff.chart_id:
+            return
+        st.markdown(f"[:material/edit: Edit]({owid_env.admin_site}/charts/{self.diff.chart_id}/edit)")
+
     def _show_chart_comparison(self) -> tuple[Any, bool]:
         """Show charts (horizontally or vertically)."""
 
         def _show_chart_old():
             last_approved_revision = self.last_approved_revision
             if (last_approved_revision is not None) and (not self.diff.in_conflict):
-                with st.container(height=40, border=False):
+                with self._chart_header_row(height=40):
                     options = {
                         "prod": self._header_production_chart_plain,
                         "last": f"Last approved on staging ({prettify_date(last_approved_revision)} - REV {last_approved_revision.id})",
@@ -576,6 +601,7 @@ class ChartDiffShow:
                         key=f"prod-review-{self.diff.chart_id}",
                         label_visibility="collapsed",
                     )
+                    self._show_edit_link(TARGET if option == "prod" else SOURCE)
 
                 if option == "prod":
                     self._show_tags_if_changed(self.diff.target_chart, self.target_session)
@@ -585,10 +611,12 @@ class ChartDiffShow:
                     grapher_chart(chart_config=last_approved_revision.config, owid_env=SOURCE)
                     return last_approved_revision.config, False
             else:
-                if self.diff.in_conflict:
-                    st.markdown(self._header_production_chart, help=CONFLICT_HELP_MESSAGE)
-                else:
-                    st.markdown(self._header_production_chart)
+                with self._chart_header_row():
+                    if self.diff.in_conflict:
+                        st.markdown(self._header_production_chart, help=CONFLICT_HELP_MESSAGE)
+                    else:
+                        st.markdown(self._header_production_chart)
+                    self._show_edit_link(TARGET)
 
                 self._show_tags_if_changed(self.diff.target_chart, self.target_session)
 
@@ -599,11 +627,12 @@ class ChartDiffShow:
             return self.diff.target_chart.config, True
 
         def _show_chart_new():
-            if self.last_approved_revision is None:
+            # Match the production column's fixed header height when it shows the
+            # revision selectbox, so both charts start at the same offset.
+            height = "content" if self.last_approved_revision is None else 40
+            with self._chart_header_row(height=height):
                 st.markdown(self._header_staging_chart)
-            else:
-                with st.container(height=40, border=False):
-                    st.markdown(self._header_staging_chart)
+                self._show_edit_link(SOURCE)
 
             self._show_tags_if_changed(self.diff.source_chart, self.source_session)
 
@@ -633,7 +662,9 @@ class ChartDiffShow:
         # Only one chart: new chart
         is_prod = True
         if self.diff.target_chart is None:
-            st.markdown(f"New version ┃ _{prettify_date(self.diff.source_chart)}_")
+            with self._chart_header_row():
+                st.markdown(f"New version ┃ _{prettify_date(self.diff.source_chart)}_")
+                self._show_edit_link(SOURCE)
             grapher_chart(chart_config=self.diff.source_chart.config, owid_env=SOURCE)
             config_ref = self.diff.source_chart.config
         # Two charts, actual diff

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -572,16 +572,20 @@ class ChartDiffShow:
             vertical_alignment="center",
         )
 
-    def _show_edit_link(self, owid_env: OWIDEnv) -> None:
-        """Link to the chart's edit page in the admin of the given environment.
+    def _show_edit_link(self, owid_env: OWIDEnv, chart_id: int | None) -> None:
+        """Link to a chart's edit page in the admin of the given environment.
+
+        `chart_id` must be the id the chart has *in that environment*: a chart created on
+        staging gets a fresh numeric id when it is synced to production, so the production
+        twin's id and `diff.chart_id` (always the source chart's) can differ.
 
         Grapher's own "Edit" entry in the share menu never shows up here: we mount the
         chart with the npm package inside a srcdoc iframe, where none of the signals it
         uses to detect an internal user (admin cookie, host name) can apply.
         """
-        if not self.diff.chart_id:
+        if not chart_id:
             return
-        st.markdown(f"[:material/edit: Edit]({owid_env.admin_site}/charts/{self.diff.chart_id}/edit)")
+        st.markdown(f"[:material/edit: Edit]({owid_env.admin_site}/charts/{chart_id}/edit)")
 
     def _show_chart_comparison(self) -> tuple[Any, bool]:
         """Show charts (horizontally or vertically)."""
@@ -601,7 +605,11 @@ class ChartDiffShow:
                         key=f"prod-review-{self.diff.chart_id}",
                         label_visibility="collapsed",
                     )
-                    self._show_edit_link(TARGET if option == "prod" else SOURCE)
+                    if option == "prod":
+                        assert self.diff.target_chart is not None
+                        self._show_edit_link(TARGET, self.diff.target_chart.id)
+                    else:
+                        self._show_edit_link(SOURCE, self.diff.chart_id)
 
                 if option == "prod":
                     self._show_tags_if_changed(self.diff.target_chart, self.target_session)
@@ -616,7 +624,8 @@ class ChartDiffShow:
                         st.markdown(self._header_production_chart, help=CONFLICT_HELP_MESSAGE)
                     else:
                         st.markdown(self._header_production_chart)
-                    self._show_edit_link(TARGET)
+                    assert self.diff.target_chart is not None
+                    self._show_edit_link(TARGET, self.diff.target_chart.id)
 
                 self._show_tags_if_changed(self.diff.target_chart, self.target_session)
 
@@ -632,7 +641,7 @@ class ChartDiffShow:
             height = "content" if self.last_approved_revision is None else 40
             with self._chart_header_row(height=height):
                 st.markdown(self._header_staging_chart)
-                self._show_edit_link(SOURCE)
+                self._show_edit_link(SOURCE, self.diff.chart_id)
 
             self._show_tags_if_changed(self.diff.source_chart, self.source_session)
 
@@ -664,7 +673,7 @@ class ChartDiffShow:
         if self.diff.target_chart is None:
             with self._chart_header_row():
                 st.markdown(f"New version ┃ _{prettify_date(self.diff.source_chart)}_")
-                self._show_edit_link(SOURCE)
+                self._show_edit_link(SOURCE, self.diff.chart_id)
             grapher_chart(chart_config=self.diff.source_chart.config, owid_env=SOURCE)
             config_ref = self.diff.source_chart.config
         # Two charts, actual diff


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Chart diff renders charts with the `@ourworldindata/grapher` npm package, mounted inside Streamlit's `srcdoc` iframe. Grapher decides whether to put an "Edit" entry in its share menu by looking for the admin cookie or a `localhost`/`staging` hostname — in an `about:srcdoc` document there is no host and no readable cookie, so that entry can never show up here. This renders the link on the wizard side instead: right-aligned in each chart's header row, pointing at the admin of the environment that chart came from.

_Skim — one file, layout only._

## How it works

Each chart header becomes a `st.container(horizontal=True, horizontal_alignment="distribute")`, which keeps the title on the left and pushes the link to the right edge of the column. The two headers that used `st.container(height=40, border=False)` to line up with the revision selectbox keep that fixed height through the same helper. On the production column the link follows the selectbox: production admin when "Production" is selected, staging admin for a "last approved on staging" revision.

Each link takes the chart id from the environment it points at, not `diff.chart_id`: a chart created on staging gets a fresh numeric id when it is synced to production, so the production twin's id can differ (`_is_cross_env_twin` in `chart_diff.py`).

Rejected: giving grapher an explicit `showAdminControls` option (or passing its undocumented `env: "dev"`) so its own share-menu entry comes back. That costs a grapher release for a wizard-only need, and the wizard already has the chart id and the environment in Python.

## Verified

On this branch's staging wizard, with a chart edited on staging to produce a diff: both links render flush right on the header line, and they point where they should — `https://admin.owid.io/admin/charts/7118/edit` on the production side, `http://staging-site-enhance-add-admin-edit/admin/charts/7118/edit` on the new-version side.

Not exercised: the revision-selectbox variant of the production header (needs a previously approved staging revision). Its fixed 40px height was checked in a standalone Streamlit sandbox instead — the row keeps the selectbox and the link on one line without clipping or scrolling.

## How to test it

[Chart diff for chart 7118 on this branch's staging](http://staging-site-enhance-add-admin-edit/etl/wizard/chart-diff?chart_id=7118) — the chart's subtitle was edited on that server to create the diff. Look at the right end of each chart's header row.

## Decisions worth a second look

The production-side link goes to the production admin. That is the useful target when you want to inspect or fix the live chart, but it does put a one-click path to editing production charts on the chart-diff page.
