### PR TITLE
🐛🤖 COVID vaccination aggregates: stop back-propagating the first cumulative report

### DIFF
--- a/etl/steps/data/garden/covid/latest/vaccinations_global.py
+++ b/etl/steps/data/garden/covid/latest/vaccinations_global.py
@@ -200,6 +200,13 @@ def _interp_ffill_fillna(tb: Table, columns: list[str], entity_col: str = "count
         entity_col=entity_col,
         time_col=time_col,
         time_mode="none",
+        # Only fill gaps *between* a country's own observations. `interpolate_table` defaults to
+        # `limit_direction="both"`, which back-propagates a country's first reported value to the
+        # start of the (global) date range -- so China's first cumulative report of 777M people fully
+        # vaccinated (2021-08-12) was being carried back to 2020-12-02 and summed into the World
+        # aggregate, which opened at 10.1% before anyone had been vaccinated anywhere. Leading NaNs
+        # belong to the `.fillna(0)` below, trailing ones to the `.ffill()`.
+        limit_area="inside",
     )
 
     tb.loc[:, columns] = tb.groupby("country")[columns].ffill().fillna(0)  # ty: ignore


### PR DESCRIPTION
@lucasrodes check the image below. Now the vaccination starts at 10% which is non-sense. It's caused by delayed reporting by China. With this PR the jump moves to the date where it started reporting. It still looks like a jump, but it's probably better than estimating their vaccination rollout.

> _Written by Claude Opus 5 — @Marigold at the wheel._

The World series on `share-people-fully-vaccinated-covid` opens at **10.142675%** on 2020-12-02 and sits flat at that exact value for thirteen days — before the first dose was administered anywhere, and while every constituent country reports zero. One argument fixes it. Split out of #6796 because, unlike the label fixes there, this moves values across every vaccination indicator and deserves its own review. Reported as finding 2 of #6779.

_Deep review, despite being a one-line change: it shifts up to 27% of values in some columns and leaves a visible step on a published chart. The mechanism is the part worth checking._

![World COVID-19 vaccination share, published vs this PR](https://gist.githubusercontent.com/Marigold/69656883d5b1934a91a812b4755bbb94/raw/a8a9462ced83aea462ef5ef67b02e02557f5f8cf/covid-vaccination-world-before-after.svg)

Both published series open well above zero on 2020-12-02 — 8.2% with at least one dose, 10.1% fully vaccinated — on a day when no country reported a single vaccinated person. Both are China's *later* figures, dragged backwards. Once every large country has reported, the two versions converge and stay converged.

## How it works

`interpolate_table` defaults to `limit_direction="both"`, so `.interpolate()` fills a series' **leading** NaNs with its first valid value, not just the gaps between observations. `_prepare_table_for_aggregates` calls it after `expand_time_column(..., method="full_range")`, which gives every country rows over the *global* date range — so a country's first cumulative report gets carried back to 2020-12-02 and summed into every regional aggregate from that day on.

China dominates the effect: its first `people_fully_vaccinated` figure is 777,046,000 on 2021-08-12, and that whole number was being attributed to December 2020. It shows up in the aggregate as an internal contradiction — 809.8M people fully vaccinated against 11.5M total doses administered.

`limit_area="inside"` confines interpolation to gaps a country's own observations bracket. Leading NaNs then fall through to the `.fillna(0)` on the next line and trailing ones to the `.ffill()`, which is what the function's existing comment already says it does:

```python
# cumulative metrics: Interpolate, forward filling (for latest) + zero-filling (for remaining NaNs, likely at start)
```

The two other `interpolate_table` call sites in the step are fine as they stand. Line 150 uses `time_mode="full_range_entity"`, so back-fill can only reach a country's own first observation, and only diffs are kept from it. Line 339 goes through this same helper and is fixed by the same change.

## What moves

Not just the World series, and not just that one indicator — every country's pre-first-report window, in every cumulative column:

| Column | Values changed |
|---|---|
| `total_vaccinations_no_boosters_interpolated` | 55,503 / 203,057 (27.3%) |
| `people_fully_vaccinated_interpolated` | 11,217 / 203,057 (5.5%) |
| `people_fully_vaccinated` / `_per_hundred` | 5,798 / 203,057 (2.9%) |
| `people_unvaccinated` | 2,295 / 203,057 (1.1%) |

Three examples from `etl diff`, each in the right direction:

- Saudi Arabia `people_fully_vaccinated_interpolated`, 2021-01-21: **1,445,087 → 0**. That was its June figure, back-dated five months.
- Upper-middle-income `people_unvaccinated`, 2021-03-15: **2.40bn → 3.02bn**. The denominator had been eaten by China's back-dated total.
- Montenegro `total_vaccinations_no_boosters_interpolated`, 2021-05-28: **122,195 → 191,178**. This one is `total_vaccinations` minus `total_boosters`, and the subtrahend was the one being back-dated, so the result was too *small*.

## Verified

- Rebuilt the garden step and diffed against the published catalog. The World fully-vaccinated share now opens at 0 on 2020-12-02, first becomes non-zero on 2020-12-13 (0.000121%, matching the US's 9,669 people — the first real report anywhere), and reaches 63.4% by January 2023 against 63.4% before. Every changed value sits in a country's pre-first-report window.
- Confirmed on staging before this was split out: `share-people-fully-vaccinated-covid` opens at 0.
- Traced the 809,798,016 to its source rather than inferring it — no country reports a non-zero `people_fully_vaccinated` before 2020-12-13 in the snapshot, so the figure could only have been manufactured downstream.
- **Not verified:** the downstream `garden/covid/latest/compact` step was not rebuilt. It only reads these columns through and the schema is unchanged, so it cannot break structurally, but its values move the same way.

## Decisions worth a second look

**The fix leaves a visible step in each series** — one per chart, on the day China first reported that metric:

| Chart | Step | Cause |
|---|---|---|
| `share-people-vaccinated-covid` | 12.10% → 20.05% on **2021-06-10** (+7.95pp) | China's first-ever report of people with ≥1 dose: **622,000,000**, worth 7.79pp of the 7.98bn denominator on its own |
| `share-people-fully-vaccinated-covid` | 13.05% → 22.93% on **2021-08-12** (+9.88pp) | China's first report of people fully vaccinated: **777,046,000** |

The same 622M is what produces the published artifact: 622,000,000 / 7,984,068,096 = **7.79pp** of the 8.16% the published one-dose series opens at, the remaining 0.37pp being other countries' first reports dragged back the same way. Production smears China's June figure back across the six months it had not reported; this PR puts it on the day it was reported.

Both are honest about what was reported and neither is what happened. China reported *doses* daily throughout — 845 million by 2021-06-10 — it just never said how many *people* until that day:

```
China 2021-06-08   total_vaccinations 808,962,000   people_vaccinated NaN
China 2021-06-09   total_vaccinations 824,856,000   people_vaccinated NaN
China 2021-06-10   total_vaccinations 845,299,000   people_vaccinated 622,000,000   <- first report
```

Zero before those dates is not right either, strictly — it is just the only value we can state without inventing one. Two alternatives, neither taken here:

- **Back-cast China from its doses series.** At the first report, people/doses = 622M/845M = 73.6%. That ratio is not stable — early in a rollout almost every dose is a first dose (ratio approaching 1.0) and it falls as second doses accumulate — so a fixed-ratio back-cast would understate the early months. It is a modelled number presented as reported data.
- **Stop zero-filling a country that has never reported.** Zero-filling is right for the many countries that genuinely had not started, but wrong for China, which was vaccinating and simply not reporting *this* metric; the honest value there is unknown, not zero. That would leave the World series undefined until the large reporters are in, so it would start in mid-2021 rather than tracing a falsely low early curve. This is the most defensible of the three, but it is a real change to how aggregation works and deserves its own decision rather than riding along with a bug fix.

I left the step in. If the discontinuity is judged worse than the alternatives, that is a call for whoever owns the COVID data.

<details>
<summary>Reproducing the diagnosis</summary>

No country reports a non-zero cumulative figure before 2020-12-13, so the 809.8M in the aggregate on 2020-12-02 could not have come from the data:

```bash
.venv/bin/python -c "
import pandas as pd
df = pd.read_csv('data/snapshots/covid/latest/vaccinations_global.csv', parse_dates=['date'])
print(df[df.people_fully_vaccinated.fillna(0) > 0].nsmallest(3, 'date')[['location','date','people_fully_vaccinated']])
print(df[df.location=='China'].dropna(subset=['people_fully_vaccinated']).nsmallest(1, 'date')[['location','date','people_fully_vaccinated']])
"
```

The published symptom, before the fix — thirteen identical days, then movement in the seventh decimal place:

```bash
curl -sL "https://ourworldindata.org/grapher/share-people-fully-vaccinated-covid.csv?csvType=filtered&useColumnShortNames=true&country=OWID_WRL" | head -20
```

The internal contradiction that pins it as an aggregation artifact rather than a source error — more people fully vaccinated than doses administered:

```
World 2020-12-02  people_fully_vaccinated=809,798,016  total_vaccinations=11,496,278
```

</details>
