### PR TITLE
Repair dangling map.columnSlug on ETL-authored charts

### DIFF
--- a/etl/collection/chart_upsert.py
+++ b/etl/collection/chart_upsert.py
@@ -10,6 +10,10 @@ it. Nothing is ever looked up per environment, so the same YAML addresses the
 same chart everywhere. Admin-authored edits live in
 the chart's admin layer (`charts.patchConfigId`) and are preserved across ETL re-pushes by
 construction (ETL and admin write to different rows).
+
+The one exception is `_repair_dangling_column_slugs`, which writes the admin layer — see the
+reasoning in its docstring. It is a repair of a reference ETL itself invalidated, and it runs
+only when there is something to repair.
 """
 
 import secrets
@@ -23,10 +27,16 @@ from jsonschema.exceptions import ValidationError
 from sqlalchemy import bindparam, text
 from sqlalchemy.orm import Session
 
+import etl.grapher.model as gm
 from apps.chart_sync.admin_api import AdminAPI
 from etl.collection.utils import map_indicator_path_to_id
 from etl.config import DEFAULT_GRAPHER_SCHEMA, OWIDEnv
 from etl.files import read_json_schema
+from etl.grapher.column_slugs import (
+    find_dangling_column_slugs,
+    repair_column_slugs,
+    variable_ids_to_resolve,
+)
 from etl.paths import SCHEMAS_DIR
 
 if TYPE_CHECKING:
@@ -105,11 +115,15 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
                 reason="tags are admin-managed once a chart exists; ETL only sets them at creation",
             )
 
-    # The slug is derived from the file's short name, but grapher excludes `slug` from what an
-    # ETL layer may contribute, so an existing chart keeps the slug it already had. Renaming the
-    # config file therefore looks like it renames the chart and doesn't.
+    # Two checks that both need the chart's rendered config, and only make sense for a chart
+    # that already existed — a chart created by this very push has nothing of its own yet.
     if not is_new:
-        slug_in_grapher = admin_api.get_chart_config(chart_id).get("slug")
+        rendered_config = admin_api.get_chart_config(chart_id)
+
+        # The slug is derived from the file's short name, but grapher excludes `slug` from what
+        # an ETL layer may contribute, so an existing chart keeps the slug it already had.
+        # Renaming the config file therefore looks like it renames the chart and doesn't.
+        slug_in_grapher = rendered_config.get("slug")
         if slug_in_grapher and slug_in_grapher != slug:
             log.warning(
                 "collection.chart.slug_not_applied",
@@ -119,6 +133,8 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
                 reason="an existing chart's slug cannot be changed from ETL; rename it in the admin instead",
             )
 
+        _repair_dangling_column_slugs(admin_api, owid_env, chart_id, rendered_config)
+
     log.info(
         "collection.chart.upsert_success",
         slug=slug,
@@ -126,6 +142,59 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
         admin_url=f"{owid_env.admin_site}/charts/{chart_id}/edit",
     )
     return chart_id
+
+
+def _repair_dangling_column_slugs(
+    admin_api: AdminAPI,
+    owid_env: OWIDEnv,
+    chart_id: int,
+    rendered_config: dict[str, Any],
+) -> None:
+    """Point the chart's `map.columnSlug` / `sortColumnSlug` back at a column it actually plots.
+
+    Both fields name a column by variable id, and ETL owns `dimensions` for an ETL-authored
+    chart — so a dataset re-version changes which variables the chart plots and invalidates any
+    slug that named the old one. When the slug sits in the chart's *admin* layer (left there
+    before the chart was adopted into ETL, or set in the chart editor since) nothing fixes it:
+    the admin layer wins the merge, and Grapher's re-diff on push can only drop patch entries
+    the ETL layer has adopted, which this one never is. See `etl.grapher.column_slugs` for what
+    goes wrong downstream.
+
+    Repairing it means writing the admin layer, which ETL otherwise never does. That is
+    deliberate and narrow: ETL is the only party that knows the old and new variables are the
+    same indicator, so it is the only one that can *remap* rather than delete, and the
+    reference it is repairing is one its own push invalidated. We PUT the rendered config back
+    with the field corrected — the same call the chart editor makes on save, so Grapher
+    recomputes the patch against the current parent stack — and only when something changed.
+
+    A `map.columnSlug` the config YAML declares itself needs no repair: `_build_chart_config`
+    resolves it to a current id and it lands in the ETL layer. The catch is that a stale admin
+    entry outranks it, so this runs either way.
+    """
+    # Nothing dangling is the normal case on almost every push, and settling it from the config
+    # alone keeps that path free of a database round trip.
+    if not find_dangling_column_slugs(rendered_config):
+        return
+
+    with Session(owid_env.engine) as session:
+        # A retired variable that has since been deleted comes back absent, which
+        # `repair_column_slugs` reads as "nothing to match on".
+        catalog_paths = gm.Variable.variable_ids_to_catalog_paths(session, variable_ids_to_resolve(rendered_config))
+
+    repaired_config, repairs = repair_column_slugs(rendered_config, catalog_paths)
+    if not repairs:
+        return
+
+    for repair in repairs:
+        log.warning(
+            "collection.chart.column_slug_repaired",
+            chart_id=chart_id,
+            field=repair.field,
+            old_variable_id=repair.old_id,
+            new_variable_id=repair.new_id,
+            reason=repair.reason,
+        )
+    admin_api.update_chart(chart_id, repaired_config)
 
 
 def _build_chart_config(view: "View", slug: str) -> dict[str, Any]:

--- a/etl/grapher/column_slugs.py
+++ b/etl/grapher/column_slugs.py
@@ -1,0 +1,195 @@
+"""Repairing `map.columnSlug` / `sortColumnSlug` references that name no column the chart plots.
+
+Both fields pick one of a chart's columns — which indicator the map tab colours, which one a
+bar chart sorts by — and both identify it by variable id stored as a *string* (see the note in
+`etl.grapher.model._remap_variable_ids`; it wasn't a great decision). Nothing in Grapher ties
+either field to `dimensions`, so a slug goes **dangling** the moment the dimensions change
+without it: the chart plots one variable and the slug names another.
+
+Grapher tolerates that — the map falls back to the first y column — which is exactly why it
+goes unnoticed. Two things make it worth repairing rather than leaving:
+
+- On a chart with several y columns the fallback is a *different indicator* than the one the
+  author picked, and nothing says so.
+- `_remap_variable_ids` (chart-sync) drops a dangling slug outright on the way to production,
+  so the author's choice is not just overridden but deleted.
+
+A dangling slug almost always means the same indicator at a new version, so the repair is a
+remap, not a delete: match the retired variable to a plotted one on catalog path ignoring the
+version segment. Deleting is the fallback for when no plotted column is that indicator.
+
+The functions here are pure — callers resolve variable ids to catalog paths themselves and
+pass them in — so the matching rules can be tested without a database.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+# The two config fields that name a column by variable id. `map.columnSlug` is nested, so each
+# entry carries a reader and a writer rather than a bare key.
+MAP_COLUMN_SLUG = "map.columnSlug"
+SORT_COLUMN_SLUG = "sortColumnSlug"
+COLUMN_SLUG_FIELDS = (MAP_COLUMN_SLUG, SORT_COLUMN_SLUG)
+
+
+@dataclass(frozen=True)
+class SlugRepair:
+    """One field that named a column the chart doesn't plot, and what became of it."""
+
+    field: str
+    old_id: int
+    # None means the field was removed: no plotted column is that indicator.
+    new_id: int | None
+    reason: str
+
+    def __str__(self) -> str:
+        target = f"-> {self.new_id}" if self.new_id is not None else "dropped"
+        return f"{self.field}: {self.old_id} {target} ({self.reason})"
+
+
+def indicator_identity(catalog_path: str | None) -> str | None:
+    """Strip the version from a grapher catalog path, leaving what is stable across versions.
+
+    `grapher/animal_welfare/2026-04-16/chick_culling_laws/chick_culling_laws#status`
+    becomes `grapher/animal_welfare/chick_culling_laws/chick_culling_laws#status`, so the same
+    indicator re-published under a new version matches.
+
+    Returns None when there is nothing to match on: legacy variables carry no catalog path at
+    all, and a path that isn't the usual five segments (`channel/namespace/version/dataset/
+    table#column`) is not one we can take a version out of. Every catalog path in grapher has
+    five segments today; returning None keeps an unexpected shape from being mangled into a
+    false match.
+    """
+    if not catalog_path:
+        return None
+    parts = catalog_path.split("/")
+    if len(parts) != 5:
+        return None
+    return "/".join(parts[:2] + parts[3:])
+
+
+def dimension_variable_ids(config: Mapping[str, Any]) -> list[int]:
+    """Variable ids the chart plots, in `dimensions` order."""
+    ids = []
+    for dimension in config.get("dimensions") or []:
+        variable_id = dimension.get("variableId")
+        if variable_id is not None:
+            ids.append(int(variable_id))
+    return ids
+
+
+def read_column_slug(config: Mapping[str, Any], field: str) -> int | None:
+    """The variable id a column-slug field names, or None if it's absent or not an id.
+
+    A collection config may declare either field as a catalog path (`etl.collection.model.view`
+    expands it and `chart_upsert` resolves it to an id before pushing), so a non-numeric value
+    here is authored input that hasn't been resolved yet — not something to repair.
+    """
+    if field == MAP_COLUMN_SLUG:
+        map_config = config.get("map")
+        value = map_config.get("columnSlug") if isinstance(map_config, dict) else None
+    else:
+        value = config.get(field)
+
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def find_dangling_column_slugs(config: Mapping[str, Any]) -> dict[str, int]:
+    """Which column-slug fields name a variable the chart doesn't plot, and the id each names."""
+    plotted = set(dimension_variable_ids(config))
+    dangling = {}
+    for field in COLUMN_SLUG_FIELDS:
+        slug_id = read_column_slug(config, field)
+        if slug_id is not None and slug_id not in plotted:
+            dangling[field] = slug_id
+    return dangling
+
+
+def variable_ids_to_resolve(config: Mapping[str, Any]) -> set[int]:
+    """Every variable id `repair_column_slugs` needs a catalog path for."""
+    return set(dimension_variable_ids(config)) | set(find_dangling_column_slugs(config).values())
+
+
+def repair_column_slugs(
+    config: Mapping[str, Any],
+    catalog_paths: Mapping[int, str | None],
+) -> tuple[dict[str, Any], list[SlugRepair]]:
+    """Point every dangling column-slug field at a column the chart plots, or remove it.
+
+    `catalog_paths` maps variable id to `variables.catalogPath` for the ids in
+    `variable_ids_to_resolve` — a retired variable that has since been deleted simply won't be
+    a key, which reads the same as having no catalog path: nothing to match on.
+
+    Returns a new config (the input is left alone) and one `SlugRepair` per field changed. An
+    empty repair list means the config already named plotted columns, and callers should write
+    nothing.
+    """
+    dangling = find_dangling_column_slugs(config)
+    if not dangling:
+        return dict(config), []
+
+    # Plotted columns by version-agnostic identity. An identity claimed by more than one
+    # dimension (a chart deliberately plotting two versions of one indicator) is ambiguous, and
+    # there is no basis for picking — drop those rather than guess.
+    plotted_by_identity: dict[str, list[int]] = {}
+    for variable_id in dimension_variable_ids(config):
+        identity = indicator_identity(catalog_paths.get(variable_id))
+        if identity is not None:
+            plotted_by_identity.setdefault(identity, []).append(variable_id)
+
+    repaired = dict(config)
+    repairs = []
+    for field, old_id in dangling.items():
+        identity = indicator_identity(catalog_paths.get(old_id))
+        candidates = plotted_by_identity.get(identity, []) if identity is not None else []
+
+        if len(candidates) == 1:
+            repair = SlugRepair(field, old_id, candidates[0], "same indicator, new version")
+        elif identity is None:
+            reason = (
+                "retired variable no longer exists"
+                if old_id not in catalog_paths
+                else "no catalog path to match a plotted column on"
+            )
+            repair = SlugRepair(field, old_id, None, reason)
+        elif candidates:
+            repair = SlugRepair(field, old_id, None, f"ambiguous: {len(candidates)} plotted columns match")
+        else:
+            repair = SlugRepair(field, old_id, None, "chart no longer plots this indicator")
+
+        _write_column_slug(repaired, field, repair.new_id)
+        repairs.append(repair)
+
+    return repaired, repairs
+
+
+def _write_column_slug(config: dict[str, Any], field: str, new_id: int | None) -> None:
+    """Set a column-slug field to `new_id`, or remove it when `new_id` is None."""
+    if field == MAP_COLUMN_SLUG:
+        # Copy before mutating: the caller's `map` dict is shared with the config we were given.
+        map_config = dict(config["map"])
+        if new_id is None:
+            del map_config["columnSlug"]
+        else:
+            map_config["columnSlug"] = str(new_id)
+        config["map"] = map_config
+        return
+
+    if new_id is not None:
+        config[field] = str(new_id)
+        return
+
+    del config[field]
+    # `sortBy: column` means "sort by sortColumnSlug", so leaving it behind claims a sort the
+    # config can no longer describe — Grapher falls back at render time, but our own
+    # indicator-upgrade path asserts the two travel together
+    # (`etl.indicator_upgrade.indicator_update.update_chart_config_sort`). Drop it with the slug
+    # and let the schema default (`total`) apply.
+    if field == SORT_COLUMN_SLUG and config.get("sortBy") == "column":
+        del config["sortBy"]

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -20,6 +20,7 @@ import builtins
 import copy
 import io
 import json
+from collections.abc import Iterable
 from datetime import date, datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -1461,6 +1462,18 @@ class Variable(Base):
         """Return a mapping from catalog paths to variable IDs."""
         query = select(Variable).where(Variable.catalogPath.in_(catalog_paths))
         return {var.catalogPath: var.id for var in session.scalars(query).all()}  # ty: ignore
+
+    @classmethod
+    def variable_ids_to_catalog_paths(cls, session: Session, variable_ids: Iterable[int]) -> dict[int, str | None]:
+        """Return a mapping from variable IDs to catalog paths.
+
+        Selects just the two columns rather than whole `Variable` rows, so it stays cheap when
+        asked about many ids at once. An id that isn't in the database is absent from the result
+        rather than mapped to None, so callers can tell a deleted variable from a legacy one
+        that simply never had a catalog path.
+        """
+        query = select(Variable.id, Variable.catalogPath).where(Variable.id.in_(sorted(variable_ids)))
+        return {row.id: row.catalogPath for row in session.execute(query)}
 
     @classmethod
     def infer_type(cls, values: pd.Series) -> VARIABLE_TYPE:

--- a/scripts/repair_dangling_column_slugs.py
+++ b/scripts/repair_dangling_column_slugs.py
@@ -1,0 +1,174 @@
+"""One-off repair of charts whose `map.columnSlug` / `sortColumnSlug` names no column they plot.
+
+`etl.grapher.column_slugs` explains what a dangling slug is and why it matters. This script is
+the *backlog* half: charts that already carry one, from years of admin edits and indicator
+upgrades applied straight to production. The forward half — not creating new ones — lives in
+`etl.collection.chart_upsert._repair_dangling_column_slugs`, and this script shares its
+matching rules, so both remap to the same indicator's current variable where they can and drop
+the field where they can't.
+
+    # what would change, no writes (the default)
+    .venv/bin/python scripts/repair_dangling_column_slugs.py --target .env.prod.write
+
+    # write it
+    .venv/bin/python scripts/repair_dangling_column_slugs.py --target .env.prod.write --no-dry-run
+
+WHAT IT WRITES. One `PUT /admin/api/charts/:id` per repaired chart — the same call the chart
+editor makes on save, so Grapher recomputes the chart's admin patch against its current parent
+stack. Per chart that means a new `chart_configs` version, a chart revision, an R2 re-upload
+and a static rebuild of the pages that embed it. Nothing else is touched: dimensions, and every
+config field other than the two slugs, are sent back exactly as they came.
+
+Run it against a staging server first and read the report. `--dry-run` is the default and
+prints the same report without writing.
+"""
+
+from typing import Any
+
+import click
+import structlog
+from rich import print
+from rich_click.rich_command import RichCommand
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import Session
+
+import etl.grapher.model as gm
+from apps.chart_sync.admin_api import AdminAPI
+from etl.config import OWIDEnv
+from etl.grapher.column_slugs import SlugRepair, repair_column_slugs, variable_ids_to_resolve
+
+log = structlog.get_logger()
+
+
+@click.command(name="repair-dangling-column-slugs", cls=RichCommand, help=__doc__)
+@click.option(
+    "--target",
+    required=True,
+    type=str,
+    help="Staging server name (e.g. `staging-site-mybranch`) or path to an .env file. Use `.env.prod.write` for live.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    type=bool,
+    help="Report what would change without writing. On by default.",
+)
+@click.option(
+    "--chart-id",
+    type=int,
+    default=None,
+    help="Repair **_only_** the chart with this id. Useful for trying one before the full run.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=None,
+    help="Repair at most this many charts, in ascending chart-id order.",
+)
+def cli(target: str, dry_run: bool, chart_id: int | None, limit: int | None) -> None:
+    owid_env = OWIDEnv.from_staging_or_env_file(target)
+    admin_api = AdminAPI(owid_env)
+
+    charts = _load_charts_with_column_slugs(owid_env, chart_id)
+    print(f"[bold]{len(charts)}[/bold] charts declare a column-slug field in {target}")
+
+    repairs_by_chart = _plan_repairs(owid_env, charts)
+    if not repairs_by_chart:
+        print("[green]Nothing dangling — no chart names a column it doesn't plot.[/green]")
+        return
+
+    _report(repairs_by_chart)
+
+    if limit is not None:
+        repairs_by_chart = dict(sorted(repairs_by_chart.items())[:limit])
+        print(f"[yellow]--limit {limit}: writing only chart ids {sorted(repairs_by_chart)}[/yellow]")
+
+    if dry_run:
+        print(f"\n[yellow]Dry run — nothing written. Re-run with --no-dry-run to repair {len(repairs_by_chart)} charts.[/yellow]")
+        return
+
+    for chart_id_, (repaired_config, repairs) in sorted(repairs_by_chart.items()):
+        admin_api.update_chart(chart_id_, repaired_config)
+        log.info("column_slug_repair.updated", chart_id=chart_id_, repairs=[str(r) for r in repairs])
+
+    print(f"\n[green]Repaired {len(repairs_by_chart)} charts.[/green]")
+
+
+def _load_charts_with_column_slugs(owid_env: OWIDEnv, chart_id: int | None) -> dict[int, tuple[str | None, dict]]:
+    """Charts whose *rendered* config sets either column-slug field, as `{id: (slug, config)}`.
+
+    Filtering in SQL keeps this to the ~1,300 charts that could possibly be affected rather than
+    every chart in the database; whether a slug is actually *dangling* is decided in Python,
+    against the same rules the ETL push uses. Addressed through the ORM rather than raw SQL so
+    it tracks `gm.ChartConfig` — grapher has reshaped these tables before, and a stale query
+    would fail on the column name instead of quietly reading the wrong layer.
+    """
+    query = (
+        select(gm.Chart.id, gm.ChartConfig.slug, gm.ChartConfig.config)
+        .join(gm.ChartConfig, gm.ChartConfig.id == gm.Chart.configId)
+        .where(
+            or_(
+                func.json_extract(gm.ChartConfig.config, "$.map.columnSlug").isnot(None),
+                func.json_extract(gm.ChartConfig.config, "$.sortColumnSlug").isnot(None),
+            )
+        )
+        .order_by(gm.Chart.id)
+    )
+    if chart_id is not None:
+        query = query.where(gm.Chart.id == chart_id)
+
+    with Session(owid_env.engine) as session:
+        return {row.id: (row.slug, row.config) for row in session.execute(query)}
+
+
+def _plan_repairs(
+    owid_env: OWIDEnv,
+    charts: dict[int, tuple[str | None, dict]],
+) -> dict[int, tuple[dict[str, Any], list[SlugRepair]]]:
+    """Work out the repair for every chart that needs one, without writing anything."""
+    # One lookup for every variable referenced across all the charts, rather than a query per
+    # chart. Ids that come back missing were deleted, which `repair_column_slugs` reads as
+    # "nothing to match on".
+    wanted: set[int] = set()
+    for _, config in charts.values():
+        wanted |= variable_ids_to_resolve(config)
+    catalog_paths = _load_catalog_paths(owid_env, wanted)
+
+    planned = {}
+    for chart_id, (slug, config) in charts.items():
+        repaired_config, repairs = repair_column_slugs(config, catalog_paths)
+        if repairs:
+            planned[chart_id] = (repaired_config, repairs)
+            log.info(
+                "column_slug_repair.planned",
+                chart_id=chart_id,
+                slug=slug,
+                repairs=[str(r) for r in repairs],
+            )
+    return planned
+
+
+def _load_catalog_paths(owid_env: OWIDEnv, variable_ids: set[int]) -> dict[int, str | None]:
+    if not variable_ids:
+        return {}
+    with Session(owid_env.engine) as session:
+        return gm.Variable.variable_ids_to_catalog_paths(session, variable_ids)
+
+
+def _report(repairs_by_chart: dict[int, tuple[dict[str, Any], list[SlugRepair]]]) -> None:
+    remapped = [r for _, repairs in repairs_by_chart.values() for r in repairs if r.new_id is not None]
+    dropped = [r for _, repairs in repairs_by_chart.values() for r in repairs if r.new_id is None]
+
+    print(f"\n[bold]{len(repairs_by_chart)}[/bold] charts name a column they don't plot:")
+    print(f"  [green]{len(remapped)}[/green] fields remapped to the same indicator's current variable")
+    print(f"  [yellow]{len(dropped)}[/yellow] fields dropped, by reason:")
+    for reason in sorted({r.reason for r in dropped}):
+        print(f"    {sum(1 for r in dropped if r.reason == reason)}  {reason}")
+
+    print("\n[bold]Per chart:[/bold]")
+    for chart_id, (_, repairs) in sorted(repairs_by_chart.items()):
+        print(f"  {chart_id}: " + "; ".join(str(r) for r in repairs))
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/collections/test_chart_upsert.py
+++ b/tests/collections/test_chart_upsert.py
@@ -7,11 +7,16 @@ written to `chart_configs.etlConfig`. The only external dependency is
 stay pure.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
-from etl.collection.chart_upsert import _build_chart_config, _validate_chart_config
+from etl.collection.chart_upsert import (
+    _build_chart_config,
+    _repair_dangling_column_slugs,
+    _validate_chart_config,
+)
 from etl.collection.model.core import Collection, Definitions
 from etl.collection.model.dimension import Dimension, DimensionChoice
 from etl.collection.model.view import View, ViewIndicators
@@ -261,3 +266,102 @@ def test_declared_single_chart_routes_to_chart_upsert():
     with patch("etl.collection.chart_upsert.upsert_collection_as_chart") as mock_upsert:
         collection.upsert_to_db(owid_env=object())  # type: ignore[arg-type]
     mock_upsert.assert_called_once()
+
+
+# `_repair_dangling_column_slugs` — the admin-layer repair after a push.
+#
+# It reads the chart's *rendered* config from the admin API, resolves the variable ids it
+# references to catalog paths, and PUTs the config back only when a column-slug field named a
+# column the chart no longer plots. Both external dependencies (the admin API and the DB
+# lookup) are stubbed here; `tests/test_column_slugs.py` covers the matching rules themselves.
+
+
+class _FakeAdminAPI:
+    def __init__(self, rendered_config: dict):
+        self.rendered_config = rendered_config
+        self.updated_with: dict | None = None
+
+    def get_chart_config(self, chart_id: int) -> dict:
+        return self.rendered_config
+
+    def update_chart(self, chart_id: int, chart_config: dict) -> dict:
+        self.updated_with = chart_config
+        return {"success": True}
+
+
+def _repair(rendered_config: dict, catalog_paths: dict[int, str | None]) -> _FakeAdminAPI:
+    admin_api = _FakeAdminAPI(rendered_config)
+    with (
+        patch("etl.collection.chart_upsert.Session"),
+        patch(
+            "etl.collection.chart_upsert.gm.Variable.variable_ids_to_catalog_paths",
+            return_value=catalog_paths,
+        ),
+    ):
+        _repair_dangling_column_slugs(
+            admin_api,  # type: ignore[arg-type]
+            SimpleNamespace(engine=None),  # type: ignore[arg-type]
+            chart_id=7118,
+            rendered_config=rendered_config,
+        )
+    return admin_api
+
+
+def test_repair_remaps_a_stale_map_column_slug():
+    rendered_config = {
+        "dimensions": [{"property": "y", "variableId": 1340000}],
+        "map": {"columnSlug": "1227375", "hideTimeline": True},
+    }
+    admin_api = _repair(
+        rendered_config,
+        {
+            1227375: "grapher/animal_welfare/2026-04-16/chick_culling_laws/chick_culling_laws#status",
+            1340000: "grapher/animal_welfare/2026-09-01/chick_culling_laws/chick_culling_laws#status",
+        },
+    )
+    assert admin_api.updated_with is not None
+    assert admin_api.updated_with["map"] == {"columnSlug": "1340000", "hideTimeline": True}
+
+
+def test_repair_writes_nothing_when_the_slug_names_a_plotted_column():
+    rendered_config = {
+        "dimensions": [{"property": "y", "variableId": 1340000}],
+        "map": {"columnSlug": "1340000"},
+    }
+    admin_api = _repair(rendered_config, {1340000: "grapher/ns/2026-09-01/ds/table#col"})
+    assert admin_api.updated_with is None
+
+
+def test_repair_writes_nothing_when_there_are_no_column_slugs():
+    rendered_config = {"dimensions": [{"property": "y", "variableId": 1340000}], "map": {"hideTimeline": True}}
+    admin_api = _repair(rendered_config, {1340000: "grapher/ns/2026-09-01/ds/table#col"})
+    assert admin_api.updated_with is None
+
+
+def test_repair_writes_nothing_for_a_chart_with_no_dimensions():
+    # Guards the early return: an empty id set must not reach the DB lookup or the admin API.
+    admin_api = _repair({"dimensions": []}, {})
+    assert admin_api.updated_with is None
+
+
+def test_repair_does_not_touch_the_database_when_nothing_is_dangling():
+    # The common case on every push. Deciding it from the config alone keeps the hot path free
+    # of a query, so the lookup must not even be reached.
+    rendered_config = {
+        "dimensions": [{"property": "y", "variableId": 1340000}],
+        "map": {"columnSlug": "1340000"},
+    }
+    admin_api = _FakeAdminAPI(rendered_config)
+    with (
+        patch("etl.collection.chart_upsert.Session") as mock_session,
+        patch("etl.collection.chart_upsert.gm.Variable.variable_ids_to_catalog_paths") as mock_lookup,
+    ):
+        _repair_dangling_column_slugs(
+            admin_api,  # type: ignore[arg-type]
+            SimpleNamespace(engine=None),  # type: ignore[arg-type]
+            chart_id=7118,
+            rendered_config=rendered_config,
+        )
+    mock_session.assert_not_called()
+    mock_lookup.assert_not_called()
+    assert admin_api.updated_with is None

--- a/tests/test_column_slugs.py
+++ b/tests/test_column_slugs.py
@@ -1,0 +1,171 @@
+"""Tests for `etl.grapher.column_slugs`.
+
+The functions under test are pure: the caller resolves variable ids to catalog paths and passes
+them in, so every matching rule is exercised here without a database.
+"""
+
+from etl.grapher.column_slugs import (
+    MAP_COLUMN_SLUG,
+    SORT_COLUMN_SLUG,
+    dimension_variable_ids,
+    find_dangling_column_slugs,
+    indicator_identity,
+    read_column_slug,
+    repair_column_slugs,
+    variable_ids_to_resolve,
+)
+
+# The same indicator at two versions, plus an unrelated one.
+_OLD = 1227375
+_NEW = 1340000
+_OTHER = 900000
+_PATHS = {
+    _OLD: "grapher/animal_welfare/2026-04-16/chick_culling_laws/chick_culling_laws#status",
+    _NEW: "grapher/animal_welfare/2026-09-01/chick_culling_laws/chick_culling_laws#status",
+    _OTHER: "grapher/demography/2026-01-01/population/population#population",
+}
+
+
+def _config(dimension_ids: list[int], **fields) -> dict:
+    config = {"dimensions": [{"property": "y", "variableId": i} for i in dimension_ids]}
+    config.update(fields)
+    return config
+
+
+def test_indicator_identity_strips_the_version():
+    assert indicator_identity(_PATHS[_OLD]) == indicator_identity(_PATHS[_NEW])
+    assert indicator_identity(_PATHS[_OLD]) == "grapher/animal_welfare/chick_culling_laws/chick_culling_laws#status"
+
+
+def test_indicator_identity_of_unmatchable_paths():
+    # Legacy variables carry no catalog path, and an unexpected shape is not one we can take a
+    # version out of — both mean "nothing to match on" rather than a mangled identity.
+    assert indicator_identity(None) is None
+    assert indicator_identity("") is None
+    assert indicator_identity("grapher/ns/version/table#col") is None
+
+
+def test_indicator_identity_distinguishes_different_indicators():
+    assert indicator_identity(_PATHS[_OLD]) != indicator_identity(_PATHS[_OTHER])
+
+
+def test_dimension_variable_ids_keeps_order():
+    assert dimension_variable_ids(_config([_NEW, _OTHER])) == [_NEW, _OTHER]
+    assert dimension_variable_ids({}) == []
+
+
+def test_read_column_slug_reads_both_fields():
+    config = _config([_NEW], map={"columnSlug": str(_OLD)}, sortColumnSlug=str(_OTHER))
+    assert read_column_slug(config, MAP_COLUMN_SLUG) == _OLD
+    assert read_column_slug(config, SORT_COLUMN_SLUG) == _OTHER
+
+
+def test_read_column_slug_ignores_unresolved_catalog_paths():
+    # A collection config may declare either field as a catalog path; that is authored input
+    # awaiting resolution, not a dangling reference.
+    config = _config([_NEW], map={"columnSlug": "chick_culling_laws#status"})
+    assert read_column_slug(config, MAP_COLUMN_SLUG) is None
+    assert find_dangling_column_slugs(config) == {}
+
+
+def test_read_column_slug_when_absent():
+    assert read_column_slug(_config([_NEW]), MAP_COLUMN_SLUG) is None
+    assert read_column_slug(_config([_NEW], map={"hideTimeline": True}), MAP_COLUMN_SLUG) is None
+    assert read_column_slug(_config([_NEW]), SORT_COLUMN_SLUG) is None
+
+
+def test_a_slug_naming_a_plotted_column_is_not_dangling():
+    config = _config([_NEW, _OTHER], map={"columnSlug": str(_OTHER)})
+    assert find_dangling_column_slugs(config) == {}
+    assert repair_column_slugs(config, _PATHS) == (config, [])
+
+
+def test_variable_ids_to_resolve_covers_dimensions_and_dangling_slugs():
+    config = _config([_NEW], map={"columnSlug": str(_OLD)})
+    assert variable_ids_to_resolve(config) == {_NEW, _OLD}
+
+
+def test_map_slug_is_remapped_to_the_same_indicator_at_its_new_version():
+    # The issue's case: chart 7118 after the version bump.
+    config = _config([_NEW], map={"columnSlug": str(_OLD), "hideTimeline": True})
+    repaired, repairs = repair_column_slugs(config, _PATHS)
+
+    assert repaired["map"] == {"columnSlug": str(_NEW), "hideTimeline": True}
+    assert [(r.field, r.old_id, r.new_id) for r in repairs] == [(MAP_COLUMN_SLUG, _OLD, _NEW)]
+    # The input is left alone.
+    assert config["map"]["columnSlug"] == str(_OLD)
+
+
+def test_map_slug_is_dropped_when_the_chart_no_longer_plots_that_indicator():
+    config = _config([_OTHER], map={"columnSlug": str(_OLD), "hideTimeline": True})
+    repaired, repairs = repair_column_slugs(config, _PATHS)
+
+    assert repaired["map"] == {"hideTimeline": True}
+    assert repairs[0].new_id is None
+    assert repairs[0].reason == "chart no longer plots this indicator"
+
+
+def test_map_slug_is_dropped_when_the_retired_variable_was_deleted():
+    # 129 of the dangling slugs in production point at a variable that no longer exists, so it
+    # never comes back from the catalog-path lookup.
+    config = _config([_NEW], map={"columnSlug": "42218"})
+    repaired, repairs = repair_column_slugs(config, _PATHS)
+
+    assert "columnSlug" not in repaired["map"]
+    assert repairs[0].reason == "retired variable no longer exists"
+
+
+def test_map_slug_is_dropped_when_the_retired_variable_has_no_catalog_path():
+    config = _config([_NEW], map={"columnSlug": "8815"})
+    repaired, repairs = repair_column_slugs(config, {**_PATHS, 8815: None})
+
+    assert "columnSlug" not in repaired["map"]
+    assert repairs[0].reason == "no catalog path to match a plotted column on"
+
+
+def test_map_slug_is_dropped_when_several_plotted_columns_match():
+    # A chart plotting two versions of one indicator gives no basis for picking.
+    config = _config([_OLD, _NEW], map={"columnSlug": "999999"})
+    repaired, repairs = repair_column_slugs(
+        config,
+        {**_PATHS, 999999: "grapher/animal_welfare/2023-09-01/chick_culling_laws/chick_culling_laws#status"},
+    )
+
+    assert "columnSlug" not in repaired["map"]
+    assert repairs[0].reason == "ambiguous: 2 plotted columns match"
+
+
+def test_sort_column_slug_is_remapped():
+    config = _config([_NEW], sortBy="column", sortColumnSlug=str(_OLD))
+    repaired, repairs = repair_column_slugs(config, _PATHS)
+
+    assert repaired["sortColumnSlug"] == str(_NEW)
+    assert repaired["sortBy"] == "column"
+    assert [(r.field, r.new_id) for r in repairs] == [(SORT_COLUMN_SLUG, _NEW)]
+
+
+def test_dropping_sort_column_slug_also_drops_sort_by_column():
+    # `sortBy: column` with no column to sort by is a mode the config can't describe, and our
+    # own indicator-upgrade path asserts the two travel together.
+    config = _config([_OTHER], sortBy="column", sortColumnSlug=str(_OLD))
+    repaired, _ = repair_column_slugs(config, _PATHS)
+
+    assert "sortColumnSlug" not in repaired
+    assert "sortBy" not in repaired
+
+
+def test_dropping_sort_column_slug_leaves_other_sort_modes_alone():
+    config = _config([_OTHER], sortBy="total", sortColumnSlug=str(_OLD))
+    repaired, _ = repair_column_slugs(config, _PATHS)
+
+    assert "sortColumnSlug" not in repaired
+    assert repaired["sortBy"] == "total"
+
+
+def test_both_fields_are_repaired_in_one_pass():
+    config = _config([_NEW], map={"columnSlug": str(_OLD)}, sortBy="column", sortColumnSlug=str(_OLD))
+    repaired, repairs = repair_column_slugs(config, _PATHS)
+
+    assert repaired["map"]["columnSlug"] == str(_NEW)
+    assert repaired["sortColumnSlug"] == str(_NEW)
+    assert len(repairs) == 2


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Closes #6803.

`map.columnSlug` and `sortColumnSlug` each name one of a chart's columns by variable id, and nothing in Grapher ties either to `dimensions`. So a slug goes *dangling* whenever the dimensions change without it: the chart plots one variable and the slug names another.

## Where it comes from

Not from chart sync, as the issue supposed. ETL owns `dimensions` for an ETL-authored chart, so a dataset re-version changes what the chart plots and invalidates any slug naming the old variable. When that slug sits in the chart's **admin** layer — left there before the chart was adopted into ETL, or set in the chart editor since — nothing repairs it: the admin layer wins the merge, and Grapher's re-diff on push ([`upsertEtlConfigForChart`](https://github.com/owid/owid-grapher/blob/master/adminSiteServer/apiRoutes/charts.ts)) can only drop patch entries the ETL layer has adopted, which this one never is. An ETL-declared `map.columnSlug` is masked by a stale admin one for the same reason.

## Why it isn't only cosmetic

The issue calls it harmless, and at render time it is — [`GrapherState.mapColumnSlug`](https://github.com/owid/owid-grapher/blob/master/packages/%40ourworldindata/grapher/src/core/GrapherState.tsx) falls back to the first y column when the slug names no dimension. Two things follow from that, though:

- On a chart with **several y columns** the fallback is a different indicator than the author picked, and nothing says so.
- `_remap_variable_ids` keeps a slug only if its id is in `chart_dimensions`, so **chart sync silently deletes** a dangling slug on the way to production. The author's choice isn't just overridden, it's gone.

That's why this remaps rather than drops: ETL is the only party that knows the retired and current variables are the same indicator.

## What changed

- **`etl/grapher/column_slugs.py`** — the matching rules, pure and DB-free: find the dangling fields, and remap each to the plotted column with the same catalog path ignoring the version segment, or drop it when no plotted column is that indicator (deleted variable, no catalog path, indicator no longer plotted, or an ambiguous match). Dropping `sortColumnSlug` also drops `sortBy: column`, which would otherwise claim a sort the config can't describe — `update_chart_config_sort` asserts the two travel together.
- **`etl/collection/chart_upsert.py`** — runs it after each push, reusing the rendered config already fetched for the slug check. It writes the chart's admin layer, which ETL otherwise never does; the docstrings carry the reasoning. Nothing is dangling on almost every push, and that case is settled from the config alone, so the hot path adds no query and no write.
- **`etl/grapher/model.py`** — `Variable.variable_ids_to_catalog_paths`, the inverse of the existing `catalog_paths_to_variable_ids`, shared by both callers.
- **`scripts/repair_dangling_column_slugs.py`** — the same rules over the existing backlog, `--dry-run` by default.

## Verification

The matching rules ran against **all 1,303 production charts** that set either field (read-only, over the public Datasette). 272 carry a dangling slug; every one comes out naming a column it plots, and every repair is **render-neutral** — the 6 remaps all land on the column Grapher was already falling back to:

| | |
|---|---|
| fields remapped to the current variable | 6 |
| fields dropped — retired variable no longer exists | 131 |
| fields dropped — chart no longer plots this indicator | 79 |
| fields dropped — no catalog path to match on | 57 |

So the backlog is almost entirely un-remappable legacy damage, and clearing it buys config hygiene rather than a fixed chart. The script is the deliverable; whether to spend 272 config versions, revisions, R2 uploads and a static rebuild on that is a separate call, and it has not been run against any environment.

## Still open

- **The write path is untested.** `repair_column_slugs` is covered by unit tests and the production replay above, but neither `update_chart` call has executed: this worktree has no staging server, and the local dev MySQL is on a pre-`chart_configs.config` schema, so the script can't run there either. Worth a `--chart-id` run on a staging server before the ETL-side path meets a real re-version.
- **`sortBy: column` being dropped with the slug** affects 2 production charts (`covid-variants-bar`, `depressive-symptoms-across-us-population`). Render-neutral, but a deliberate config change rather than a pure deletion.
- **A Grapher-side fix would be narrower in one respect** — dropping these in `upsertEtlConfigForChart`'s re-diff needs no admin-layer write from ETL — but Grapher can't remap, only drop, so it would lose the map-column choice on multi-y charts. Not pursued here; worth a conversation if the layering matters more than the remap.
- **Nobody checked** whether other config fields carry variable ids that the same re-version invalidates. `_remap_variable_ids` warns on unrecognised ones (`remap_variable_ids.new_field`), so the logs would show it, but no one has looked.
