### PR TITLE
Build the venv lazily, not when a worktree is created

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Our World in Data's ETL system - a content-addressable data pipeline with DAG-ba
 
 ## Critical Rules
 
-- **Always use `.venv/bin/`** for all Python commands (`etl`, `python`, `pytest`)
+- **Always use `.venv/bin/`** for all Python commands (`etl`, `python`, `pytest`). If it isn't there — `.venv/bin/etlr: no such file or directory`, most likely in a fresh worktree — run `make .venv` to build it (~17s), then retry. Never bare `uv sync`; see Package Management.
 - **Never mask problems** - no empty tables, no commented-out code, no silent exceptions
 - **Trace issues upstream**: snapshot → meadow → garden → grapher
 - **`dag/archive/*.yml` is a generated record** — it is reconstructed from git history by `etl archive-dag`, so never hand-edit it. It lists steps that were once active (with the commit where they were last active) purely for recovery; to bring one back, `git checkout` that commit.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #  Makefile
 #
 
-.PHONY: etl docs full lab test-default publish grapher dot watch clean clobber deploy activate owid_mcp vsce-compile vsce-sync install-hooks setup.worktree setup.config
+.PHONY: etl docs full lab test-default publish grapher dot watch clean clobber deploy activate owid_mcp vsce-compile vsce-sync install-hooks setup.worktree
 
 include default.mk
 
@@ -33,8 +33,7 @@ help:
 	@echo '  make chart-sync 	Start Chart-sync on port 8083'
 	@echo '  make query SQL="..." Run SQL query on staging MySQL for current branch'
 	@echo '  make install-hooks	Activate pre-commit hook (auto-runs with make .venv)'
-	@echo '  make setup.worktree	Set up a fresh worktree: .env, a copy-on-write clone of data/, and the venv'
-	@echo '  make setup.config	Just the cheap half of the above (.env + data/), no venv — offline, ~6s'
+	@echo '  make setup.worktree	Give this worktree the main checkout .env + a copy-on-write clone of data/ (auto-runs with make .venv)'
 	@echo '  make test      	Run all linting and unit tests'
 	@echo '  make test-all  	Run all linting and unit tests (including for modules in lib/)'
 	@echo '  make check-all 	Format, lint, and typecheck (including for modules in lib/)'
@@ -285,11 +284,14 @@ install-hooks:
 # gitignored config, and `data/`. Idempotent — anything already present is left
 # alone, so it is safe to re-run and safe to adjust a worktree's own `.env` after.
 #
-# The cheap half of `setup.worktree` below, split out for two reasons: it is a
-# prerequisite of `.venv`, so a worktree nobody provisioned fixes its own config on
-# the first `make` (nothing depends on a hook having fired), and it is what to point
-# a `post-checkout` hook at if you want worktrees to appear instantly rather than
-# waiting on a venv build. Everything here is offline and effectively free.
+# `setup.worktree` is the agreed name for "make this checkout usable", so anything
+# that creates a worktree can provision it without knowing what this repo needs: a
+# worktree manager's setup script, a machine-wide `post-checkout` hook, or a person.
+# Everything it does is offline and effectively free, which is what makes it safe to
+# run from a hook.
+#
+# It is also a prerequisite of `.venv`, so a worktree nobody provisioned fixes its
+# own config on the first `make` — nothing depends on a hook having fired.
 #
 # Config is *copied*, not symlinked, so a worktree can diverge from the main
 # checkout (a different `STAGING`, a scratch credential) without editing everyone's
@@ -310,10 +312,14 @@ install-hooks:
 # avoiding, so we require one filesystem and a copy-on-write one. GNU `cp` has no
 # `-c` at all, hence the `--reflink=always` branch, which does fail honestly.
 #
-# The venv can't live in *this* target — it is a prerequisite of `.venv`, so that
-# would be a dependency cycle (`make` says so: "Circular setup.config <- .venv").
-# `setup.worktree` below is the umbrella that has both.
-setup.config:
+# The venv is deliberately NOT built here. It is the one slow, network-dependent
+# step (~17s for 412 packages), most worktrees never need one, and building it from
+# a `post-checkout` hook makes `git worktree add` block on a network install. Any
+# make target depends on `.venv`, so it gets built the moment something actually
+# needs it — see the note in CLAUDE.md for what to do when `.venv/bin/...` is
+# missing. It also *can't* live here: this target is a prerequisite of `.venv`, so
+# that would be a dependency cycle.
+setup.worktree:
 	@PRIMARY="$$(dirname "$$(cd "$$(git rev-parse --git-common-dir)" && pwd)")"; \
 	if [ "$$PRIMARY" = "$$PWD" ]; then \
 		echo '==> This is the main checkout, nothing to provision'; \
@@ -350,18 +356,7 @@ setup.config:
 		fi; \
 	fi
 
-# The one command for a fresh worktree: config, data/ and the venv. Everything a
-# checkout needs, whoever asks — a person, a worktree manager's setup script, or a
-# machine-wide `post-checkout` hook, which all call this same conventional name.
-#
-# Note what this costs, because the hook pays it at `git worktree add` time: the
-# venv is a ~19-second network install (~2.4 GB), against ~6 seconds and ~0 bytes
-# for config and the data/ clone. If you'd rather your worktrees appear instantly
-# and build the venv on first use, point the hook at `setup.config` instead — the
-# split exists for exactly that choice.
-setup.worktree: setup.config .venv
-
-.venv: .venv-default install-hooks setup.config
+.venv: .venv-default install-hooks setup.worktree
 	@true
 
 # Backward-compatible alias

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -494,7 +494,7 @@ def branch_out_worktree(
     except GitCommandError as e:
         raise click.ClickException(f"Failed to create worktree at '{worktree_path}':\n{e}")
 
-    # --share-data before provisioning: `setup.config` clones `data/` only when it finds
+    # --share-data before provisioning: `setup.worktree` clones `data/` only when it finds
     # none, and stands down when one is already there. Symlinking first is what makes the
     # two agree; the other order leaves the clone and silently ignores --share-data.
     if share_data:
@@ -506,11 +506,10 @@ def branch_out_worktree(
 def provision_worktree(worktree_path: Path) -> None:
     """Give a fresh worktree the gitignored config (and `data/`) it can't inherit from git.
 
-    Defers to `make setup.config` so there is one definition of what a checkout needs, rather
-    than a copy here that drifts from it — the same target a post-checkout hook or a worktree
-    manager calls. `setup.config` and not `setup.worktree`, because that one also builds the
-    venv, which `install_worktree_venv` does after the PR is created; calling it here would
-    run `uv sync` twice.
+    Defers to `make setup.worktree` so there is one definition of what a checkout needs,
+    rather than a copy here that drifts from it — the same target a post-checkout hook or a
+    worktree manager calls. It does not build the venv; `install_worktree_venv` does that after
+    the PR is created.
 
     Falls back to copying `.env` directly when the target isn't there, which happens when the
     worktree's base branch predates it (a stale local base, or a base other than master).
@@ -518,10 +517,10 @@ def provision_worktree(worktree_path: Path) -> None:
     has no credentials fails later, and confusingly.
     """
     try:
-        subprocess.run(["make", "setup.config"], cwd=worktree_path, check=True)
+        subprocess.run(["make", "setup.worktree"], cwd=worktree_path, check=True)
         return
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        log.warning(f"`make setup.config` did not run in the new worktree ({e}); copying .env directly.")
+        log.warning(f"`make setup.worktree` did not run in the new worktree ({e}); copying .env directly.")
 
     for name in [".env", *sorted(path.name for path in BASE_DIR.glob(".env.prod*"))]:
         src = BASE_DIR / name

--- a/docs/getting-started/working-environment.md
+++ b/docs/getting-started/working-environment.md
@@ -235,14 +235,17 @@ It is installed as a symlink at `$GIT_DIR/hooks/pre-commit`, git's default locat
 ```bash
 git worktree add ../etl-mybranch -b mybranch
 cd ../etl-mybranch
-make setup.worktree   # .env, a copy-on-write clone of data/, and the venv
+make setup.worktree   # .env and a copy-on-write clone of data/ — offline, a few seconds
+make .venv            # only when you actually need the venv (~17 s)
 ```
 
-`setup.worktree` is the single entrypoint — there is nothing else to run. `make setup.config` is the cheap half of it (config and `data/`, offline, ~6 s) if you want a worktree available immediately and the venv built on first use.
+`make .venv` runs `setup.worktree` itself, so a single `make .venv` does everything — and so does any other make target, since they all depend on `.venv`. You only need `setup.worktree` on its own when you want the config without paying for a venv.
 
 Copying 16 GB of `data/` sounds absurd and isn't: on a copy-on-write filesystem (APFS on macOS) `cp -c` clones the files, sharing the original's blocks until something writes to them. Measured on a 16 GB / ~32,000-file `data/`: **4 seconds and ~0 bytes**. So a real copy is *better* than symlinking it — each worktree gets an independent `data/`, and two of them running the same step cannot overwrite each other's output. `setup.worktree` checks the filesystem before copying and leaves `data/` absent when cloning isn't possible, rather than making a real 16 GB copy — see the trap below, `cp -c` cannot be trusted to refuse.
 
-The venv is the one expensive part: ~19 seconds and ~2.4 GB over the network, against ~6 seconds and ~0 bytes for config and `data/`. That is why the cheap half has its own name — `make setup.config` — and why `.venv` depends on *that* rather than on `setup.worktree`: a worktree nobody provisioned still fixes its own config on the first `make`, and depending the other way round would be a dependency cycle.
+The venv is deliberately not part of `setup.worktree`. It is the one slow, network-dependent step — about 17 seconds for 412 packages, against a few seconds and ~0 bytes for config and `data/` — and plenty of worktrees never need one. Since every make target depends on `.venv`, it gets built the moment something actually needs it. If you reach for `.venv/bin/etlr` in a worktree that hasn't built one yet you'll get `no such file or directory`; `make .venv` fixes it.
+
+Two things not to try instead. **Symlinking `.venv`** to the main checkout looks tempting and is a trap twice over: the venv holds an *absolute* editable pointer to the main checkout, so `.venv/bin/etlr` would silently run the main checkout's code rather than your branch's — and `uv sync` follows the symlink rather than replacing it, so any make target in that worktree rewrites the *shared* venv, uninstalling packages the main checkout needs. **Cloning `.venv`** copy-on-write is no faster than building it (a venv is ~103,000 small files, so per-file clone cost dominates) and has the same wrong-code problem.
 
 ### Copy-on-write: there is nothing to turn on
 
@@ -306,9 +309,9 @@ make -n setup.worktree >/dev/null 2>&1 && make setup.worktree
 exit 0
 ```
 
-With this in place `git worktree add` alone produces a working worktree — config, `data/` and venv — in about 26 seconds. Point it at `setup.config` instead if you would rather `git worktree add` stay near-instant.
+With this in place `git worktree add` alone gives a worktree its config and `data/` in a few seconds, and the venv follows the first time you run a make target in it.
 
-Two things to know if you do this. `core.hooksPath` **replaces** `$GIT_DIR/hooks` rather than adding to it, so a dispatcher of this kind should end by exec'ing the repo's own `$GIT_DIR/hooks/<name>` — otherwise it silently disables every per-repo hook, including this repo's pre-commit. And keep `setup.worktree` cheap and offline for the same reason: it runs inside a git hook, which is why the cheap half is separately callable as `setup.config`.
+Two things to know if you do this. `core.hooksPath` **replaces** `$GIT_DIR/hooks` rather than adding to it, so a dispatcher of this kind should end by exec'ing the repo's own `$GIT_DIR/hooks/<name>` — otherwise it silently disables every per-repo hook, including this repo's pre-commit. And keep `setup.worktree` cheap and offline for the same reason: it runs inside a git hook, which is why it does not build the venv.
 
 ## GitHub Actions
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Follow-up to #6812. `setup.worktree` built the venv, so `git worktree add` blocked ~17 s on a network install — and plenty of worktrees never need a venv at all. Worse, that cost is the only reason a *second* target existed: `setup.config` was purely an escape hatch from it.

The venv comes back out, `setup.config` is gone, and there is one target again.

```
git worktree add    6 s    config + a 16 GB copy-on-write clone of data/
make .venv         19 s    only in the worktrees where you actually work
```

Nothing is lost as an entrypoint: `make .venv` runs `setup.worktree` itself, and every other make target depends on `.venv`, so the venv appears the moment something needs it.

## The rough edge, and the fix for it

A fresh worktree has no `.venv`, so `.venv/bin/etlr` fails until a make target runs. CLAUDE.md said *"Always use `.venv/bin/`"* and nothing about that case — the only repair hint sat 300 lines away under Package Management, phrased as a prohibition (*"Never run bare `uv sync`"*) rather than a fix. It now says to run `make .venv` and retry. This is the one thing worth a second opinion: it fails loudly and recovers in one command, which I think beats paying 17 s on every worktree, but it is a real papercut.

## Two alternatives, both measured and both rejected

Recorded in the docs so nobody re-derives them:

- **Symlinking `.venv`** to the main checkout fails twice over. The venv holds an *absolute* editable pointer, so from a neutral cwd `.venv/bin/python -c "import etl"` resolves to `/Users/mojmir/projects/etl/etl/__init__.py` — your branch's code silently ignored. And `uv sync` **follows the symlink instead of replacing it**: in an isolated two-project test it uninstalled the target venv's dependency and installed its own, i.e. any make target in such a worktree rewrites the shared venv.
- **Cloning `.venv`** copy-on-write takes 16.3 s versus 17.5 s to build it — no gain, because a venv is ~103,000 small files and clonefile costs per file (`data/` clones in 4 s only because it is 32,000 much larger ones). Same wrong-code problem too.

## Verification

Fresh `git worktree add` on this branch: config copied, `data/` cloned, **no `.venv`**, 6 s. Then `make .venv` → 19 s and `.venv/bin/etlr` present. `make check` clean.

## Worth knowing

- **Orca / worktree managers:** no setup script is needed for this to work. If you would rather your worktrees arrive with a venv already built, point the repo's setup script at `make .venv` — it runs after creation, so it doesn't block `git worktree add` the way the hook did.
- **Not checked:** whether anything outside `make` invokes `.venv/bin/...` in a just-created worktree (CI runs in a plain clone, where `setup.worktree` no-ops).
