### PR TITLE
📜 Make a static-viz import behave like the template it is pasted into

### DIFF
--- a/.claude/skills/create-figma-chart/reference/CHECKS.md
+++ b/.claude/skills/create-figma-chart/reference/CHECKS.md
@@ -28,6 +28,14 @@ Every one of these caught a real defect on this skill's first run, and none of t
 > | group | rows | size |
 > |---|---|---|
 > | `type` | text-floor, annotation-ladder, ladder-sizes, named-styles, source-line-weight, text-hierarchy | 52% of cap |
+
+**`text-floor` fails on the 850-wide templates themselves.** `Static Chart Template_Vertical` and its
+Horizontal twin set the `OurWorldinData.org — Research and data…` tagline and the `Licensed under
+CC-BY…` line at **11px**, under the row's 12px floor for this format — measured in the template, not
+in a page built from it. So two FAILs there are inherited furniture, not a page defect: check that the
+failing ranges are exactly those two footer rows, say so, and leave them. Anything else under the
+floor is yours.
+
 > | `series` | series-weight, furniture-weight, furniture-dash | 47% |
 > | `geometry` | box-alignment, gap, margins, **within-frame**, **dead-fills**, **page-census**, off-palette | 61% |
 > | `annotations` | polylines, annotation-overlap, annotation-knockout, annotation-block-gap, label-contrast | 69% |

--- a/.claude/skills/create-figma-chart/reference/FITTING.md
+++ b/.claude/skills/create-figma-chart/reference/FITTING.md
@@ -457,7 +457,18 @@ shares its colour), then replay that map onto the fresh import. The rest of the 
    the step had to emit as runs is `license-0 … license-5`, and an exact-name match silently leaves all
    six behind to print over the template's own row.
 3. Paint, set faces, restore anchors, re-flow multi-run lines.
-4. Append into the target frame at (0,0) with `clipsContent = false`, then remove the old group.
+4. Insert into the target frame at (0,0) at the **bottom** of the z-order (`insertChild(0, …)`, never
+   `append`), and paint the frame with the template's own canvas fill, then remove the old group. An
+   artboard-sized import appended on top covers the header and footer, so every double-click on the
+   subtitle descends into the chart instead of selecting the text — and a frame whose fill arrives
+   switched off is not a hit target over its own empty area.
+5. **Crop the frame to its rendered ink, and do it last** — after the rescale, the paint pass and any
+   re-flow, since all three move ink. Count only what renders: skip a leaf under a hidden or
+   zero-opacity ancestor, take each box through the clips *inside* the import, and ignore the default
+   fill Figma gives an imported clip path. Left uncropped the frame is the size of the SVG canvas,
+   which *is* the artboard — it cannot be grabbed as a unit, and `verify_page.js`'s `box-alignment`,
+   `gap` and `margins` rows measure the canvas and report negative insets. `restyle_static_import.js`
+   does all of this already; reach for it before hand-rolling the pass.
 
 Keep it as one script per frame: the pass is run more than once, always after a step change, and the
 only thing that varies is which frame.

--- a/.claude/skills/create-figma-chart/reference/TEXTS.md
+++ b/.claude/skills/create-figma-chart/reference/TEXTS.md
@@ -123,7 +123,20 @@ line that is 38% full, which is a real line of text; the test is the fill, not t
 
 Rules: replace `characters`, and leave the node's **base** styling alone — the fonts, sizes, colors, and positions are the template's, not yours. `await figma.loadFontAsync(node.fontName)` before each text edit. If you need a *new* text block the template doesn't have, **clone the nearest template text node and edit it** — that inherits the correct shared style without hunting style ids.
 
-**Watch for template text that is already mixed-weight, and restore it after writing.** Setting `characters` propagates the *first character's* style over the whole new string, so any node whose label is bolder than its content comes out uniformly bold. **Two slots ship that way, not one** — `Data source:` and, on the templates that carry it, `Note:`. Fixing only the source line leaves a wholly bold note, which reads as deliberate emphasis on a caveat and was spotted on a finished frame rather than in review. Write the string, then push Regular back over the tail:
+**Watch for template text that is already mixed-weight, and restore it after writing.** Setting `characters` propagates the *first character's* style over the whole new string, so any node whose label is bolder than its content comes out uniformly bold.
+
+**Count the slots that ship that way before trusting a pass over them: on the 850-wide templates it is four, and three of them collapse.** Measured on `Static Chart Template_Vertical` (2026-09-03):
+
+| Footer row | The template's own runs | After `characters` |
+|---|---|---|
+| `Note:` | Bold@0-5, Medium@5-6, Regular@6-… | wholly **Bold** |
+| `Data source:` | Bold@0-12, Regular@12-… | wholly **Bold** |
+| tagline | Bold@0-18 (`OurWorldinData.org`), Medium@18-… | wholly **Bold** |
+| licence | Medium@0-15, Bold@15-20, Medium@20-35, Bold@35-… | correct |
+
+The licence row survives only because its *first* run is Medium — the propagated face happens to be the one most of the row wants — so a recipe that re-applies the bold ranges and trusts the rest passes on that row and fails on the other three. **The runs that go wrong are the ones that are NOT bold**, which is the opposite of where attention goes: write every run's face explicitly rather than only the emphasis. A wholly bold Note reads as deliberate emphasis on a caveat, and both times it has happened it was caught on a finished frame — once by eye, once by `diff_against_template.js` — never in review.
+
+Write the string, then push Regular back over the tail:
 
 ```js
 const PREFIX = "Data source:";

--- a/.claude/skills/create-figma-chart/reference/TEXTS.md
+++ b/.claude/skills/create-figma-chart/reference/TEXTS.md
@@ -132,9 +132,9 @@ Rules: replace `characters`, and leave the node's **base** styling alone — the
 | `Note:` | Bold@0-5, Medium@5-6, Regular@6-… | wholly **Bold** |
 | `Data source:` | Bold@0-12, Regular@12-… | wholly **Bold** |
 | tagline | Bold@0-18 (`OurWorldinData.org`), Medium@18-… | wholly **Bold** |
-| licence | Medium@0-15, Bold@15-20, Medium@20-35, Bold@35-… | correct |
+| licence | Medium@0-15, Bold@15-20, Medium@20-35, Bold@35-… | wholly **Medium** — both Bold ranges lost |
 
-The licence row survives only because its *first* run is Medium — the propagated face happens to be the one most of the row wants — so a recipe that re-applies the bold ranges and trusts the rest passes on that row and fails on the other three. **The runs that go wrong are the ones that are NOT bold**, which is the opposite of where attention goes: write every run's face explicitly rather than only the emphasis. A wholly bold Note reads as deliberate emphasis on a caveat, and both times it has happened it was caught on a finished frame — once by eye, once by `diff_against_template.js` — never in review.
+**All four collapse — the licence row included.** It loses its two Bold ranges exactly as the others lose their Medium and Regular ones; what it does not do is *look* broken, because the face that propagates is the one most of the row already wanted. That makes it the most dangerous of the four to check by eye, and it is why a recipe that re-applies the bold ranges and trusts the rest appears to work: it passes on the row that proves nothing and fails on the other three. **The runs that go wrong are the ones whose face differs from the FIRST run's**, which on three rows means every run that is not bold and on the licence row means the bold ones — so write every run's face explicitly rather than only the emphasis, on all four. A wholly bold Note reads as deliberate emphasis on a caveat, and both times it has happened it was caught on a finished frame — once by eye, once by `diff_against_template.js` — never in review.
 
 Write the string, then push Regular back over the tail:
 

--- a/.claude/skills/create-figma-chart/reference/TEXTS.md
+++ b/.claude/skills/create-figma-chart/reference/TEXTS.md
@@ -125,7 +125,7 @@ Rules: replace `characters`, and leave the node's **base** styling alone — the
 
 **Watch for template text that is already mixed-weight, and restore it after writing.** Setting `characters` propagates the *first character's* style over the whole new string, so any node whose label is bolder than its content comes out uniformly bold.
 
-**Count the slots that ship that way before trusting a pass over them: on the 850-wide templates it is four, and three of them collapse.** Measured on `Static Chart Template_Vertical` (2026-09-03):
+**Count the slots that ship that way before trusting a pass over them: on the 850-wide templates it is four, and all four collapse** — three of them visibly, and the licence row quietly. Measured on `Static Chart Template_Vertical` (2026-09-03):
 
 | Footer row | The template's own runs | After `characters` |
 |---|---|---|

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -334,10 +334,30 @@ for (const job of CONFIG.jobs) {
   // coordinates, and all three move ink: a reflow that shifts the last run's right edge after the
   // crop would leave the frame, its canvas fill and every geometry row describing a box that no
   // longer bounds the drawing, which is the stale-bounds failure the crop exists to remove.
+  //
+  // Take each leaf's box THROUGH its clipping ancestors first. A path running past a clip frame
+  // renders no pixels there, so it must not widen the box: matplotlib clips its axes artists, Figma
+  // imports that clip as a `clipsContent` frame, and a line leaving the axes therefore arrives here
+  // at its full unclipped width. Intersecting is a no-op wherever nothing clips, and drops a leaf
+  // clipped away to nothing rather than letting invisible geometry set the crop.
+  const throughClips = (node) => {
+    let box = node.absoluteBoundingBox;
+    for (let a = node.parent; a && box; a = a.parent) {
+      const clip = "clipsContent" in a && a.clipsContent ? a.absoluteBoundingBox : null;
+      if (clip) {
+        const x = Math.max(box.x, clip.x), y = Math.max(box.y, clip.y);
+        const right = Math.min(box.x + box.width, clip.x + clip.width);
+        const bottom = Math.min(box.y + box.height, clip.y + clip.height);
+        box = right > x && bottom > y ? { x, y, width: right - x, height: bottom - y } : null;
+      }
+      if (a === styled) break;
+    }
+    return box;
+  };
   const inkBoxes = styled
     .findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
       (painted(n) || strokedAnywhere(n)))
-    .map((n) => n.absoluteBoundingBox)
+    .map(throughClips)
     .filter(Boolean);
   if (inkBoxes.length) {
     const own = styled.absoluteBoundingBox;

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -221,6 +221,42 @@ for (const job of CONFIG.jobs) {
     n.vectorPaths.every((vp) => vp && vp.windingRule === "NONE")
       ? false
       : painted(n);
+  // Start from the PAINTED extent, not the geometry. Figma documents `absoluteBoundingBox` as
+  // excluding the stroke, so a CENTER-aligned stroke paints half its width outside the box and an
+  // OUTSIDE-aligned one all of it — and the plot's outermost edge is normally a stroked axis, gridline
+  // or line series. Cropping to the centreline cuts that half off ink the frame is supposed to bound,
+  // and `clipsContent = false` below then leaves it hanging outside the frame. Only a stroke that
+  // PAINTS counts, the same test `verify_page.js` applies for the same reason; the outset is taken on
+  // all four sides rather than resolved per segment, because over-reporting an overhang costs a
+  // fraction of a pixel of frame and missing one is the bug.
+  const strokeOutset = (n) => {
+    const paints = Array.isArray(n.strokes) &&
+      n.strokes.some((s) => s.visible !== false && (s.opacity === undefined || s.opacity > 0));
+    const weight = typeof n.strokeWeight === "number" ? n.strokeWeight : 0;
+    if (!paints || !(weight > 0)) return 0;
+    return n.strokeAlign === "INSIDE" ? 0 : n.strokeAlign === "OUTSIDE" ? weight : weight / 2;
+  };
+  const throughClips = (node) => {
+    const o = strokeOutset(node);
+    const b = node.absoluteBoundingBox;
+    let box = b && o ? { x: b.x - o, y: b.y - o, width: b.width + 2 * o, height: b.height + 2 * o } : b;
+    for (let a = node.parent; a && box && a !== styled; a = a.parent) {
+      const clip = "clipsContent" in a && a.clipsContent ? a.absoluteBoundingBox : null;
+      if (clip) {
+        const x = Math.max(box.x, clip.x), y = Math.max(box.y, clip.y);
+        const right = Math.min(box.x + box.width, clip.x + clip.width);
+        const bottom = Math.min(box.y + box.height, clip.y + clip.height);
+        // `>=`, not `>`: an open path has a DEGENERATE box. `absoluteBoundingBox` excludes the stroke,
+        // so a horizontal gridline measures 123.75x0 and a spine 0xN — visible ink whose box has no
+        // area. A strict test calls every one of them fully clipped and drops it, which loses the axes
+        // and lets labels set the plot edge. Only a box lying OUTSIDE its clip becomes null. The stroke
+        // outset above now keeps a painting leaf non-degenerate on its own, so this is the belt to that
+        // braces — narrow the outset and it goes back to load-bearing.
+        box = right >= x && bottom >= y ? { x, y, width: right - x, height: bottom - y } : null;
+      }
+    }
+    return box;
+  };
   const inkLeaves = () => styled.findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
     (fillPaints(n) || strokedAnywhere(n)) && rendersInTree(n));
   // Refuse a BLANK import HERE, while the old chart is still on the page. Below this point it is
@@ -230,6 +266,13 @@ for (const job of CONFIG.jobs) {
   // settled before anything is destroyed rather than discovered after.
   if (!inkLeaves().length) {
     throw new Error(`${frame.name}: the import has no visible ink — nothing was replaced`);
+  }
+  // And refuse one whose ink is entirely CLIPPED AWAY, here rather than at the crop. Every clip that
+  // trims it lives INSIDE the import, so this answer cannot change when the chart is inserted — which
+  // means discovering it after the swap would destroy a perfectly good chart in order to report a
+  // failure. Same reasoning as the guard above, reached through the clips instead of an empty import.
+  if (!inkLeaves().map(throughClips).filter(Boolean).length) {
+    throw new Error(`${frame.name}: every leaf was clipped away — nothing to crop to; nothing was replaced`);
   }
 
   for (const family of CONFIG.families) {
@@ -380,48 +423,11 @@ for (const job of CONFIG.jobs) {
   // overflow as ink and the frame grows to contain it, which is what keeps the fill, the hit target
   // and the geometry rows bounding everything visible. Intersect with it instead and that overflow is
   // first excluded from the box and then un-hidden, landing outside the frame meant to bound it.
-  //
-  // Start from the PAINTED extent, not the geometry. Figma documents `absoluteBoundingBox` as
-  // excluding the stroke, so a CENTER-aligned stroke paints half its width outside the box and an
-  // OUTSIDE-aligned one all of it — and the plot's outermost edge is normally a stroked axis, gridline
-  // or line series. Cropping to the centreline cuts that half off ink the frame is supposed to bound,
-  // and `clipsContent = false` below then leaves it hanging outside the frame. Only a stroke that
-  // PAINTS counts, the same test `verify_page.js` applies for the same reason; the outset is taken on
-  // all four sides rather than resolved per segment, because over-reporting an overhang costs a
-  // fraction of a pixel of frame and missing one is the bug.
-  const strokeOutset = (n) => {
-    const paints = Array.isArray(n.strokes) &&
-      n.strokes.some((s) => s.visible !== false && (s.opacity === undefined || s.opacity > 0));
-    const weight = typeof n.strokeWeight === "number" ? n.strokeWeight : 0;
-    if (!paints || !(weight > 0)) return 0;
-    return n.strokeAlign === "INSIDE" ? 0 : n.strokeAlign === "OUTSIDE" ? weight : weight / 2;
-  };
-  const throughClips = (node) => {
-    const o = strokeOutset(node);
-    const b = node.absoluteBoundingBox;
-    let box = b && o ? { x: b.x - o, y: b.y - o, width: b.width + 2 * o, height: b.height + 2 * o } : b;
-    for (let a = node.parent; a && box && a !== styled; a = a.parent) {
-      const clip = "clipsContent" in a && a.clipsContent ? a.absoluteBoundingBox : null;
-      if (clip) {
-        const x = Math.max(box.x, clip.x), y = Math.max(box.y, clip.y);
-        const right = Math.min(box.x + box.width, clip.x + clip.width);
-        const bottom = Math.min(box.y + box.height, clip.y + clip.height);
-        // `>=`, not `>`: an open path has a DEGENERATE box. `absoluteBoundingBox` excludes the stroke,
-        // so a horizontal gridline measures 123.75x0 and a spine 0xN — visible ink whose box has no
-        // area. A strict test calls every one of them fully clipped and drops it, which loses the axes
-        // and lets labels set the plot edge. Only a box lying OUTSIDE its clip becomes null. The stroke
-        // outset above now keeps a painting leaf non-degenerate on its own, so this is the belt to that
-        // braces — narrow the outset and it goes back to load-bearing.
-        box = right >= x && bottom >= y ? { x, y, width: right - x, height: bottom - y } : null;
-      }
-    }
-    return box;
-  };
   const inkBoxes = inkLeaves().map(throughClips).filter(Boolean);
-  // Ink existed before the clips were applied, so an empty set here means every leaf was clipped away.
-  // Skipping the crop would leave a canvas-sized frame and report it as done — the same silent pass the
-  // guard above refuses, reached through the clips instead of through an empty import.
-  if (!inkBoxes.length) throw new Error(`${frame.name}: every leaf was clipped away — nothing to crop to`);
+  // Both emptiness cases were refused before the swap. A reflow moves ink but deletes none, so this
+  // can only fire if a moved run left its clip — unlikely, and still better loud than a canvas-sized
+  // frame reported as done.
+  if (!inkBoxes.length) throw new Error(`${frame.name}: every leaf was clipped away after the reflow — nothing to crop to`);
   {
     const own = styled.absoluteBoundingBox;
     const ink = {

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -338,19 +338,27 @@ for (const job of CONFIG.jobs) {
   // Take each leaf's box THROUGH its clipping ancestors first. A path running past a clip frame
   // renders no pixels there, so it must not widen the box: matplotlib clips its axes artists, Figma
   // imports that clip as a `clipsContent` frame, and a line leaving the axes therefore arrives here
-  // at its full unclipped width. Intersecting is a no-op wherever nothing clips, and drops a leaf
-  // clipped away to nothing rather than letting invisible geometry set the crop.
+  // at its full unclipped width. Intersecting is a no-op wherever nothing clips.
+  //
+  // Stop BELOW `styled`. Only a clip still in force after the crop may shrink these bounds, and
+  // `styled`'s own is not: it is switched off a few lines down so the new edge cuts nothing. Count its
+  // overflow as ink and the frame grows to contain it, which is what keeps the fill, the hit target
+  // and the geometry rows bounding everything visible. Intersect with it instead and that overflow is
+  // first excluded from the box and then un-hidden, landing outside the frame meant to bound it.
   const throughClips = (node) => {
     let box = node.absoluteBoundingBox;
-    for (let a = node.parent; a && box; a = a.parent) {
+    for (let a = node.parent; a && box && a !== styled; a = a.parent) {
       const clip = "clipsContent" in a && a.clipsContent ? a.absoluteBoundingBox : null;
       if (clip) {
         const x = Math.max(box.x, clip.x), y = Math.max(box.y, clip.y);
         const right = Math.min(box.x + box.width, clip.x + clip.width);
         const bottom = Math.min(box.y + box.height, clip.y + clip.height);
-        box = right > x && bottom > y ? { x, y, width: right - x, height: bottom - y } : null;
+        // `>=`, not `>`: an open path has a DEGENERATE box. `absoluteBoundingBox` excludes the stroke,
+        // so a horizontal gridline measures 123.75x0 and a spine 0xN — visible ink whose box has no
+        // area. A strict test calls every one of them fully clipped and drops it, which loses the axes
+        // and lets labels set the plot edge. Only a box lying OUTSIDE its clip becomes null.
+        box = right >= x && bottom >= y ? { x, y, width: right - x, height: bottom - y } : null;
       }
-      if (a === styled) break;
     }
     return box;
   };

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -354,9 +354,34 @@ for (const job of CONFIG.jobs) {
     }
     return box;
   };
+  //
+  // And let only what RENDERS set the crop. `painted` reads a node's own fill switches, which is not
+  // the same question: `visible` and `opacity` are INHERITED, so a leaf under a hidden or zero-opacity
+  // group still answers yes while painting nothing. Climb to `styled` and test the opacity PRODUCT for
+  // exactly zero, the way `verify_page.js`'s `collect` does — zero is no pixels, and a factor of 0
+  // anywhere zeroes the product.
+  const rendersInTree = (n) => {
+    for (let a = n; a; a = a.parent) {
+      if ("visible" in a && !a.visible) return false;
+      if ("opacity" in a && typeof a.opacity === "number" && a.opacity <= 0) return false;
+      if (a === styled) break;
+    }
+    return true;
+  };
+  // A VECTOR whose every subpath is `windingRule: "NONE"` has no fillable area, but Figma imports it
+  // with a default VISIBLE fill — so `painted` says yes and its box counts, while it paints no pixels.
+  // That is exactly what an imported clip path becomes, and it arrives as a rectangle the size of the
+  // thing it clipped, so it is a prime candidate to set a phantom crop. `verify_page.js` reports these
+  // as dead fills for the same reason. A NONE-winding path that is STROKED is still real ink — an open
+  // path like a gridline — so it stays, on its stroke.
+  const fillPaints = (n) =>
+    n.type === "VECTOR" && Array.isArray(n.vectorPaths) && n.vectorPaths.length &&
+    n.vectorPaths.every((vp) => vp && vp.windingRule === "NONE")
+      ? false
+      : painted(n);
   const inkBoxes = styled
     .findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
-      (painted(n) || strokedAnywhere(n)))
+      (fillPaints(n) || strokedAnywhere(n)) && rendersInTree(n))
     .map(throughClips)
     .filter(Boolean);
   if (inkBoxes.length) {

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -345,8 +345,26 @@ for (const job of CONFIG.jobs) {
   // overflow as ink and the frame grows to contain it, which is what keeps the fill, the hit target
   // and the geometry rows bounding everything visible. Intersect with it instead and that overflow is
   // first excluded from the box and then un-hidden, landing outside the frame meant to bound it.
+  //
+  // Start from the PAINTED extent, not the geometry. Figma documents `absoluteBoundingBox` as
+  // excluding the stroke, so a CENTER-aligned stroke paints half its width outside the box and an
+  // OUTSIDE-aligned one all of it — and the plot's outermost edge is normally a stroked axis, gridline
+  // or line series. Cropping to the centreline cuts that half off ink the frame is supposed to bound,
+  // and `clipsContent = false` below then leaves it hanging outside the frame. Only a stroke that
+  // PAINTS counts, the same test `verify_page.js` applies for the same reason; the outset is taken on
+  // all four sides rather than resolved per segment, because over-reporting an overhang costs a
+  // fraction of a pixel of frame and missing one is the bug.
+  const strokeOutset = (n) => {
+    const paints = Array.isArray(n.strokes) &&
+      n.strokes.some((s) => s.visible !== false && (s.opacity === undefined || s.opacity > 0));
+    const weight = typeof n.strokeWeight === "number" ? n.strokeWeight : 0;
+    if (!paints || !(weight > 0)) return 0;
+    return n.strokeAlign === "INSIDE" ? 0 : n.strokeAlign === "OUTSIDE" ? weight : weight / 2;
+  };
   const throughClips = (node) => {
-    let box = node.absoluteBoundingBox;
+    const o = strokeOutset(node);
+    const b = node.absoluteBoundingBox;
+    let box = b && o ? { x: b.x - o, y: b.y - o, width: b.width + 2 * o, height: b.height + 2 * o } : b;
     for (let a = node.parent; a && box && a !== styled; a = a.parent) {
       const clip = "clipsContent" in a && a.clipsContent ? a.absoluteBoundingBox : null;
       if (clip) {
@@ -356,7 +374,9 @@ for (const job of CONFIG.jobs) {
         // `>=`, not `>`: an open path has a DEGENERATE box. `absoluteBoundingBox` excludes the stroke,
         // so a horizontal gridline measures 123.75x0 and a spine 0xN — visible ink whose box has no
         // area. A strict test calls every one of them fully clipped and drops it, which loses the axes
-        // and lets labels set the plot edge. Only a box lying OUTSIDE its clip becomes null.
+        // and lets labels set the plot edge. Only a box lying OUTSIDE its clip becomes null. The stroke
+        // outset above now keeps a painting leaf non-degenerate on its own, so this is the belt to that
+        // braces — narrow the outset and it goes back to load-bearing.
         box = right >= x && bottom >= y ? { x, y, width: right - x, height: bottom - y } : null;
       }
     }

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -146,6 +146,9 @@ for (const job of CONFIG.jobs) {
     reference.name = `${frame.name} — original SVG (unstyled)`;
     reference.x = frame.x - reference.width - job.referenceGap;
     reference.y = frame.y;
+    // Same hit-test point as the styled copy below: an unpainted frame cannot be hovered on the canvas.
+    const refPaint = Array.isArray(frame.fills) ? frame.fills.find((f) => f.type === "SOLID") : null;
+    if (refPaint) reference.fills = [{ ...refPaint, visible: true }];
   }
 
   styled.rescale(scale);
@@ -169,10 +172,19 @@ for (const job of CONFIG.jobs) {
   const painted = (n) =>
     fillsOf(n).some((f) => f.visible !== false && (f.opacity === undefined || f.opacity > 0)) ||
     ("children" in n && n.children.some(painted));
+  // Strip it whether or not it PAINTS. An unpainted patch (`fills: []`, which is what the current
+  // contract emits) hides nothing, so leaving it looks free — but it is artboard-sized, so it becomes
+  // the chart group's bounding box, and `verify_page.js`'s box-alignment, gap and margins rows then
+  // measure the artboard and report three failures that are about the canvas rather than the plot.
+  // What must survive is a STROKE-only patch: the axes spine is a `patch_N` too, and deleting it
+  // removes a line the reader can see.
+  const strokedAnywhere = (n) =>
+    (Array.isArray(n.strokes) && n.strokes.some((s) => s.visible !== false && (s.opacity === undefined || s.opacity > 0))) ||
+    ("children" in n && n.children.some(strokedAnywhere));
   for (const parent of styled.findAll((n) => CONFIG.backgroundPatchParent.test(n.name))) {
     const first = ("children" in parent ? parent.children : []).find((c) => CONFIG.backgroundPatch.test(c.name));
-    if (!first || first.removed || !painted(first)) continue;
-    strippedPatches.push(`${parent.name}/${first.name}`);
+    if (!first || first.removed || strokedAnywhere(first)) continue;
+    strippedPatches.push(`${parent.name}/${first.name}${painted(first) ? "" : " (unpainted — removed for its bbox)"}`);
     first.remove();
   }
 
@@ -240,11 +252,61 @@ for (const job of CONFIG.jobs) {
 
   const old = frame.children.find((c) => c.name === "chart");
   styled.name = "chart";
-  styled.clipsContent = false;
-  frame.appendChild(styled);
+  // Paint the import's frame with the template's own canvas, and CLIP it like the template does. An
+  // import arrives with its fill switched OFF (`SOLID`, `visible: false`), and a frame with no visible
+  // fill is not a hit target over its own empty area — so hovering the plot highlights nothing, and the
+  // chart can only be reached from the layer panel. Every frame built this route has it. Painting it
+  // costs no pixel, because the chart sits at the bottom of the z-order with the clone's identical
+  // cream beneath it (measured: max channel difference 0 across 850x1095).
+  const canvasPaint = Array.isArray(frame.fills) ? frame.fills.find((f) => f.type === "SOLID") : null;
+  if (canvasPaint) {
+    styled.fills = [{ ...canvasPaint, visible: true }];
+    if (frame.fillStyleId && frame.fillStyleId !== figma.mixed) await styled.setFillStyleIdAsync(frame.fillStyleId);
+  }
+  styled.clipsContent = true;
+  // Index 0 is the BOTTOM of the z-order, and this is a usability requirement rather than a visual
+  // one: the import is a frame the size of the whole artboard, so appended LAST it covers the header
+  // and footer, and every double-click on the subtitle or the Note then descends into `figure_1` and
+  // its gid groups instead of selecting the text. That difference between a built frame and the
+  // template is one a designer hits immediately and cannot explain. Below them, a click over the
+  // subtitle lands on the header wrapper while bars and labels still resolve into the chart, and the
+  // frame renders identically either way — measured at max channel difference 0 across 850x1095,
+  // because the wrappers carry no fill and the background patch is gone by this point.
+  frame.insertChild(0, styled);
   styled.x = 0;
   styled.y = 0;
   if (old) old.remove();
+
+  // CROP the frame to the plot's own ink, and keep clipping off so nothing is cut at the new edge.
+  // An import arrives the size of the SVG canvas, which is the artboard — so a hover or click on the
+  // plot highlights a rectangle indistinguishable from the artboard's, the plot cannot be grabbed as a
+  // unit, and there is no visible box to tell a designer what they have hold of. Cropping is what makes
+  // the plot an object: it moves nothing on the canvas, because the frame's origin shifts onto the ink
+  // and the children shift back by the same offset (verified at max channel difference 0 across a
+  // whole 850x1095 frame). It also makes `verify_page.js`'s box-alignment and gap rows measure the
+  // plot instead of the canvas — they read the real insets afterwards rather than a negative number.
+  //
+  // Do it AFTER the fit and the restyle: both are written in canvas coordinates.
+  const inkBoxes = styled
+    .findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
+      (painted(n) || strokedAnywhere(n)))
+    .map((n) => n.absoluteBoundingBox)
+    .filter(Boolean);
+  if (inkBoxes.length) {
+    const own = styled.absoluteBoundingBox;
+    const ink = {
+      x: Math.min(...inkBoxes.map((b) => b.x)),
+      y: Math.min(...inkBoxes.map((b) => b.y)),
+      right: Math.max(...inkBoxes.map((b) => b.x + b.width)),
+      bottom: Math.max(...inkBoxes.map((b) => b.y + b.height)),
+    };
+    const dx = ink.x - own.x, dy = ink.y - own.y;
+    styled.clipsContent = false;
+    styled.x += dx;
+    styled.y += dy;
+    styled.resizeWithoutConstraints(ink.right - ink.x, ink.bottom - ink.y);
+    for (const child of styled.children) { child.x -= dx; child.y -= dy; }
+  }
 
   // A flowed line of runs needs laying out again, one measured space apart. Rows are keyed on y
   // alone because each run of one line sits under its own `header__…`/`category__…` parent, so

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -197,6 +197,41 @@ for (const job of CONFIG.jobs) {
     for (const node of styled.findAll((n) => n.name === slot || n.name.startsWith(slot + "-"))) node.remove();
   }
 
+  // Let only what RENDERS count as ink. `painted` reads a node's own fill switches, which is not
+  // the same question: `visible` and `opacity` are INHERITED, so a leaf under a hidden or zero-opacity
+  // group still answers yes while painting nothing. Climb to `styled` and test the opacity PRODUCT for
+  // exactly zero, the way `verify_page.js`'s `collect` does — zero is no pixels, and a factor of 0
+  // anywhere zeroes the product.
+  const rendersInTree = (n) => {
+    for (let a = n; a; a = a.parent) {
+      if ("visible" in a && !a.visible) return false;
+      if ("opacity" in a && typeof a.opacity === "number" && a.opacity <= 0) return false;
+      if (a === styled) break;
+    }
+    return true;
+  };
+  // A VECTOR whose every subpath is `windingRule: "NONE"` has no fillable area, but Figma imports it
+  // with a default VISIBLE fill — so `painted` says yes and its box counts, while it paints no pixels.
+  // That is exactly what an imported clip path becomes, and it arrives as a rectangle the size of the
+  // thing it clipped, so it is a prime candidate to set a phantom crop. `verify_page.js` reports these
+  // as dead fills for the same reason. A NONE-winding path that is STROKED is still real ink — an open
+  // path like a gridline — so it stays, on its stroke.
+  const fillPaints = (n) =>
+    n.type === "VECTOR" && Array.isArray(n.vectorPaths) && n.vectorPaths.length &&
+    n.vectorPaths.every((vp) => vp && vp.windingRule === "NONE")
+      ? false
+      : painted(n);
+  const inkLeaves = () => styled.findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
+    (fillPaints(n) || strokedAnywhere(n)) && rendersInTree(n));
+  // Refuse a BLANK import HERE, while the old chart is still on the page. Below this point it is
+  // removed and the replacement is painted with the template's canvas, so an import with no ink would
+  // be swapped in and REPORTED AS A SUCCESS — an empty chart that looks deliberate. The crop itself
+  // has to wait for the reflow, but whether ANY ink exists does not change when runs move, so it is
+  // settled before anything is destroyed rather than discovered after.
+  if (!inkLeaves().length) {
+    throw new Error(`${frame.name}: the import has no visible ink — nothing was replaced`);
+  }
+
   for (const family of CONFIG.families) {
     for (const [column, weight] of family.members) {
       const fill = weight ? tint(family.base, weight) : family.base;
@@ -382,37 +417,12 @@ for (const job of CONFIG.jobs) {
     }
     return box;
   };
-  //
-  // And let only what RENDERS set the crop. `painted` reads a node's own fill switches, which is not
-  // the same question: `visible` and `opacity` are INHERITED, so a leaf under a hidden or zero-opacity
-  // group still answers yes while painting nothing. Climb to `styled` and test the opacity PRODUCT for
-  // exactly zero, the way `verify_page.js`'s `collect` does — zero is no pixels, and a factor of 0
-  // anywhere zeroes the product.
-  const rendersInTree = (n) => {
-    for (let a = n; a; a = a.parent) {
-      if ("visible" in a && !a.visible) return false;
-      if ("opacity" in a && typeof a.opacity === "number" && a.opacity <= 0) return false;
-      if (a === styled) break;
-    }
-    return true;
-  };
-  // A VECTOR whose every subpath is `windingRule: "NONE"` has no fillable area, but Figma imports it
-  // with a default VISIBLE fill — so `painted` says yes and its box counts, while it paints no pixels.
-  // That is exactly what an imported clip path becomes, and it arrives as a rectangle the size of the
-  // thing it clipped, so it is a prime candidate to set a phantom crop. `verify_page.js` reports these
-  // as dead fills for the same reason. A NONE-winding path that is STROKED is still real ink — an open
-  // path like a gridline — so it stays, on its stroke.
-  const fillPaints = (n) =>
-    n.type === "VECTOR" && Array.isArray(n.vectorPaths) && n.vectorPaths.length &&
-    n.vectorPaths.every((vp) => vp && vp.windingRule === "NONE")
-      ? false
-      : painted(n);
-  const inkBoxes = styled
-    .findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
-      (fillPaints(n) || strokedAnywhere(n)) && rendersInTree(n))
-    .map(throughClips)
-    .filter(Boolean);
-  if (inkBoxes.length) {
+  const inkBoxes = inkLeaves().map(throughClips).filter(Boolean);
+  // Ink existed before the clips were applied, so an empty set here means every leaf was clipped away.
+  // Skipping the crop would leave a canvas-sized frame and report it as done — the same silent pass the
+  // guard above refuses, reached through the clips instead of through an empty import.
+  if (!inkBoxes.length) throw new Error(`${frame.name}: every leaf was clipped away — nothing to crop to`);
+  {
     const own = styled.absoluteBoundingBox;
     const ink = {
       x: Math.min(...inkBoxes.map((b) => b.x)),

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -282,6 +282,45 @@ for (const job of CONFIG.jobs) {
   styled.y = 0;
   if (old) old.remove();
 
+  // A flowed line of runs needs laying out again, one measured space apart. Rows are keyed on y
+  // alone because each run of one line sits under its own `header__…`/`category__…` parent, so
+  // keying on the parent would put every run in a row of its own and reflow nothing. That makes
+  // "the selected runs form one line per y" a precondition, which is why this is per-job opt-in.
+  let reflowed = 0;
+  if (job.reflowLegend) {
+    const runs = styled.findAll(
+      (n) => n.type === "TEXT" && /^(header|category)__/.test(n.parent.name) && !CONFIG.darkTextParent.test(n.parent.name)
+    );
+    if (runs.length) {
+      const probe = figma.createText();
+      styled.appendChild(probe);
+      probe.fontName = { family: "Lato", style: "Regular" };
+      probe.fontSize = runs[0].fontSize;
+      probe.textAutoResize = "WIDTH_AND_HEIGHT";
+      probe.characters = "nn";
+      const tight = probe.width;
+      probe.characters = "n n";
+      const space = probe.width - tight;
+      probe.remove();
+
+      const rows = new Map();
+      for (const node of runs) {
+        const key = Math.round((node.absoluteBoundingBox.y - frame.y) * 2) / 2;
+        if (!rows.has(key)) rows.set(key, []);
+        rows.get(key).push(node);
+      }
+      for (const [, nodes] of rows) {
+        nodes.sort((a, b) => a.absoluteBoundingBox.x - b.absoluteBoundingBox.x);
+        let cursor = nodes[0].absoluteBoundingBox.x;
+        for (const node of nodes) {
+          node.x += cursor - node.absoluteBoundingBox.x;
+          cursor += node.absoluteBoundingBox.width + space;
+          reflowed++;
+        }
+      }
+    }
+  }
+
   // CROP the frame to the plot's own ink, and keep clipping off so nothing is cut at the new edge.
   // An import arrives the size of the SVG canvas, which is the artboard — so a hover or click on the
   // plot highlights a rectangle indistinguishable from the artboard's, the plot cannot be grabbed as a
@@ -291,7 +330,10 @@ for (const job of CONFIG.jobs) {
   // whole 850x1095 frame). It also makes `verify_page.js`'s box-alignment and gap rows measure the
   // plot instead of the canvas — they read the real insets afterwards rather than a negative number.
   //
-  // Do it AFTER the fit and the restyle: both are written in canvas coordinates.
+  // Do it LAST — after the fit, the restyle and the legend reflow. All three are written in canvas
+  // coordinates, and all three move ink: a reflow that shifts the last run's right edge after the
+  // crop would leave the frame, its canvas fill and every geometry row describing a box that no
+  // longer bounds the drawing, which is the stale-bounds failure the crop exists to remove.
   const inkBoxes = styled
     .findAll((n) => n.type !== "GROUP" && n.type !== "FRAME" &&
       (painted(n) || strokedAnywhere(n)))
@@ -336,44 +378,6 @@ for (const job of CONFIG.jobs) {
     }
   }
 
-  // A flowed line of runs needs laying out again, one measured space apart. Rows are keyed on y
-  // alone because each run of one line sits under its own `header__…`/`category__…` parent, so
-  // keying on the parent would put every run in a row of its own and reflow nothing. That makes
-  // "the selected runs form one line per y" a precondition, which is why this is per-job opt-in.
-  let reflowed = 0;
-  if (job.reflowLegend) {
-    const runs = styled.findAll(
-      (n) => n.type === "TEXT" && /^(header|category)__/.test(n.parent.name) && !CONFIG.darkTextParent.test(n.parent.name)
-    );
-    if (runs.length) {
-      const probe = figma.createText();
-      styled.appendChild(probe);
-      probe.fontName = { family: "Lato", style: "Regular" };
-      probe.fontSize = runs[0].fontSize;
-      probe.textAutoResize = "WIDTH_AND_HEIGHT";
-      probe.characters = "nn";
-      const tight = probe.width;
-      probe.characters = "n n";
-      const space = probe.width - tight;
-      probe.remove();
-
-      const rows = new Map();
-      for (const node of runs) {
-        const key = Math.round((node.absoluteBoundingBox.y - frame.y) * 2) / 2;
-        if (!rows.has(key)) rows.set(key, []);
-        rows.get(key).push(node);
-      }
-      for (const [, nodes] of rows) {
-        nodes.sort((a, b) => a.absoluteBoundingBox.x - b.absoluteBoundingBox.x);
-        let cursor = nodes[0].absoluteBoundingBox.x;
-        for (const node of nodes) {
-          node.x += cursor - node.absoluteBoundingBox.x;
-          cursor += node.absoluteBoundingBox.width + space;
-          reflowed++;
-        }
-      }
-    }
-  }
 
   report.push({
     frame: frame.name,

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -146,9 +146,11 @@ for (const job of CONFIG.jobs) {
     reference.name = `${frame.name} — original SVG (unstyled)`;
     reference.x = frame.x - reference.width - job.referenceGap;
     reference.y = frame.y;
-    // Same hit-test point as the styled copy below: an unpainted frame cannot be hovered on the canvas.
-    const refPaint = Array.isArray(frame.fills) ? frame.fills.find((f) => f.type === "SOLID") : null;
-    if (refPaint) reference.fills = [{ ...refPaint, visible: true }];
+    // Leave its fill, its size and its clipping exactly as the import arrives. This copy exists to be
+    // compared against, so anything done to it is a difference someone later reads as the export's
+    // own: painting it the template's cream makes a transparent export look like it ships a beige
+    // background, and cropping it to the ink makes it a different size from the frame it is next to.
+    // The styled copy below gets both treatments; this one gets none.
   }
 
   styled.rescale(scale);

--- a/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/restyle_static_import.js
@@ -33,7 +33,10 @@
 //   - tints are derived from each family's base rather than listed, so a family keeps its internal
 //     steps and the base can be swapped in one place;
 //   - changing a face moves every label by half its width change, so the font pass is bracketed by an
-//     anchor pass keyed on each node's own `textAlignHorizontal`;
+//     anchor pass keyed on each node's own `textAlignHorizontal`. Both are NO-OPS when the step named
+//     Lato first in its emitted `font-family` (create-static-viz/reference/WRITING-THE-STEP.md): the
+//     import then arrives in Lato already, nothing changes face, and nothing drifts. They are kept
+//     because they cost one read per node and still cover an SVG from a step that has not done it;
 //   - a line built from several runs is re-flowed afterwards, since independent boxes in a narrower
 //     face leave the gaps between them uneven.
 
@@ -308,6 +311,29 @@ for (const job of CONFIG.jobs) {
     styled.y += dy;
     styled.resizeWithoutConstraints(ink.right - ink.x, ink.bottom - ink.y);
     for (const child of styled.children) { child.x -= dx; child.y -= dy; }
+
+    // Then SNAP each side that lands within a pixel of the header's content column onto it, moving
+    // the children back so no ink shifts. Cropping to ink alone leaves the box off by a hair — a
+    // TEXT node's box carries its own advance width, not its glyphs, so a label at the plot's edge
+    // put one frame at 15.92..833.88 against a 16..834 column. `box-alignment` measures the FRAME to
+    // 0.05, so it failed on 0.08px of text metrics. A pixel is the whole tolerance: anything further
+    // out is a real misalignment and must keep failing.
+    const column = frame.children
+      .filter((c) => "layoutMode" in c && c.layoutMode !== "NONE" && !/^logo/i.test(c.name))
+      .sort((a, b) => a.y - b.y)[0];
+    if (column) {
+      const SNAP = 1;
+      let x = styled.x, w = styled.width;
+      const wantL = column.x, wantR = column.x + column.width;
+      if (Math.abs(x - wantL) <= SNAP) { w += x - wantL; x = wantL; }
+      if (Math.abs(x + w - wantR) <= SNAP) { w = wantR - x; }
+      if (x !== styled.x || w !== styled.width) {
+        const sdx = x - styled.x;
+        styled.x = x;
+        styled.resizeWithoutConstraints(w, styled.height);
+        for (const child of styled.children) child.x -= sdx;
+      }
+    }
   }
 
   // A flowed line of runs needs laying out again, one measured space apart. Rows are keyed on y

--- a/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
@@ -1,0 +1,313 @@
+// Stubbed-figma harness for restyle_static_import.js — the script that had no test.
+//
+// Four consecutive review rounds found a real defect in that file, and three of them were in code the
+// PREVIOUS round had just added: a crop computed before the legend reflow, an ink union that counted
+// nodes which paint nothing, a clip intersection that nulled every zero-height gridline, and one that
+// excluded overflow the script then un-hid by switching the frame's own clip off. Every one is a
+// geometry or ordering bug that a reader can talk themselves into and a run cannot show them — the
+// frame still looks right, because the failure is in the box rather than in the pixels.
+//
+// So this harness fakes the `figma` global, builds a frame per scenario, injects a test CONFIG into
+// the committed file verbatim, runs it, and asserts on the resulting node tree.
+//
+//     node .claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
+//
+// It is a MOCK: it validates control flow and arithmetic against the Plugin API's documented shapes,
+// never Figma's actual behaviour. Keep it honest —
+//   - `absoluteBoundingBox` is a GETTER that walks the parent chain, because the script reads absolute
+//     boxes and writes relative `x`/`y`, and a mock that stores one number cannot catch a crop that
+//     moves the ink;
+//   - `absoluteBoundingBox` EXCLUDES strokes, so an open path is legitimately `w x 0` — the shape that
+//     broke the clip walk;
+//   - a leaf carries no `children` key at all, since the script tests `"children" in n`.
+
+const fs = require("fs");
+const path = require("path");
+
+const SRC = fs.readFileSync(path.join(__dirname, "restyle_static_import.js"), "utf8");
+const MIXED = Symbol("figma.mixed");
+
+let AUTO = 0;
+let failures = 0;
+let checks = 0;
+
+function detach(child) {
+  const p = child.parent;
+  if (p && p.children) p.children.splice(p.children.indexOf(child), 1);
+  child.parent = null;
+}
+
+function node(props) {
+  const n = Object.assign({ type: "FRAME", name: "", x: 0, y: 0, width: 0, height: 0, visible: true }, props);
+  if (!n.id) n.id = `auto:${++AUTO}`;
+  if (n.children) for (const c of n.children) c.parent = n;
+  Object.defineProperty(n, "absoluteBoundingBox", {
+    get() {
+      let x = 0, y = 0;
+      for (let a = this; a; a = a.parent) { x += a.x || 0; y += a.y || 0; }
+      return { x, y, width: this.width, height: this.height };
+    },
+  });
+  n.findAll = function (fn) {
+    const out = [];
+    const rec = (m) => { for (const c of m.children || []) { if (!fn || fn(c)) out.push(c); rec(c); } };
+    rec(this);
+    return out;
+  };
+  n.appendChild = function (child) { detach(child); child.parent = this; (this.children || (this.children = [])).push(child); };
+  n.insertChild = function (i, child) { detach(child); child.parent = this; (this.children || (this.children = [])).splice(i, 0, child); };
+  n.remove = function () { detach(this); this.removed = true; };
+  n.rescale = function (s) {
+    // Figma scales the node's own size and everything under it, keeping its own x/y.
+    const self = this;
+    const rec = (m) => {
+      m.width *= s; m.height *= s;
+      if (m !== self) { m.x *= s; m.y *= s; }
+      if (typeof m.fontSize === "number") m.fontSize *= s;
+      for (const c of m.children || []) rec(c);
+    };
+    rec(this);
+  };
+  n.resizeWithoutConstraints = function (w, h) { this.width = w; this.height = h; };
+  n.setFillStyleIdAsync = async function (id) { this.fillStyleId = id; };
+  return n;
+}
+
+const solid = (visible) => [{ type: "SOLID", visible: visible !== false, color: { r: 1, g: 1, b: 1 } }];
+
+// A painted leaf — a filled vector with real area.
+const leaf = (name, x, y, w, h, extra) =>
+  node(Object.assign({ type: "VECTOR", name, x, y, width: w, height: h, fills: solid(), strokes: [] }, extra || {}));
+
+// A stroked open path. `absoluteBoundingBox` excludes strokes, so a horizontal rule is `w x 0`.
+const rule = (name, x, y, w, h) =>
+  node({ type: "VECTOR", name, x, y, width: w, height: h, fills: [], strokes: solid(), strokeWeight: 1 });
+
+const textNode = (name, chars, x, y, w, h, extra) =>
+  node(Object.assign({
+    type: "TEXT", name, characters: chars, fontSize: 12, x, y, width: w, height: h,
+    fills: solid(), strokes: [],
+    getStyledTextSegments: () => [{ fontName: { family: "Arial", style: "Regular" }, start: 0, end: chars.length }],
+    setRangeFontName: function () {},
+  }, extra || {}));
+
+const CONFIG_BASE = {
+  labelTintFactor: 0.4,
+  textStyles: { dark: "dark-key", body: "body-key" },
+  bodyTextParent: /__(label)$/,
+  darkTextParent: /__(dark)$/,
+  backgroundPatchParent: /^(figure|axes)_\d+$/,
+  backgroundPatch: /^patch_\d+$/,
+  slots: ["title", "subtitle", "note", "data-source", "tagline", "license"],
+  families: [],
+};
+
+async function run(scenario) {
+  const { page, cover } = scenario;
+  const figma = {
+    mixed: MIXED,
+    root: { children: [page, cover].filter(Boolean) },
+    currentPage: page,
+    setCurrentPageAsync: async function (p) { figma.currentPage = p; },
+    loadFontAsync: async function () {},
+    importStyleByKeyAsync: async function (key) { return { id: "style:" + key }; },
+    getNodeByIdAsync: async function (id) {
+      const hunt = (m) => {
+        if (m.id === id) return m;
+        for (const c of m.children || []) { const hit = hunt(c); if (hit) return hit; }
+        return null;
+      };
+      for (const p of figma.root.children) { const hit = hunt(p); if (hit) return hit; }
+      return null;
+    },
+    createText: function () {
+      // The reflow probe measures "nn" against "n n" to derive one space's width.
+      const probe = node({ type: "TEXT", name: "probe", width: 0, height: 0 });
+      Object.defineProperty(probe, "characters", {
+        get: function () { return this._chars || ""; },
+        set: function (v) { this._chars = v; this.width = v.length * 5; },
+      });
+      probe.textAutoResize = "WIDTH_AND_HEIGHT";
+      return probe;
+    },
+  };
+  const config = Object.assign({}, CONFIG_BASE, scenario.config, { pageId: page.id });
+  const body = SRC.replace(/^const CONFIG = \{[\s\S]*?^\};/m, "const CONFIG = __CONFIG__;");
+  const fn = new Function("figma", "__CONFIG__", "return (async () => { " + body + " })();");
+  return fn(figma, config);
+}
+
+function check(label, actual, expected) {
+  checks++;
+  const ok = typeof expected === "function" ? expected(actual) : JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) {
+    failures++;
+    const want = typeof expected !== "function" ? ", want " + JSON.stringify(expected) : "";
+    console.log("  FAIL " + label + "\n       got " + JSON.stringify(actual) + want);
+  } else {
+    console.log("  ok   " + label);
+  }
+}
+
+const near = (want, eps) => (got) => Math.abs(got - want) <= (eps === undefined ? 0.001 : eps);
+
+// A page holding one template-shaped frame: a header auto-layout defining the content column (16..834),
+// a footer, and optionally an existing chart to be replaced.
+function scene(opts) {
+  const inkNodes = opts.inkNodes;
+  const canvasWidth = opts.canvasWidth === undefined ? 850 : opts.canvasWidth;
+  const header = node({
+    id: "header", name: "header", type: "FRAME", x: 16, y: 16, width: 818, height: 54,
+    layoutMode: "VERTICAL", fills: [], children: [textNode("title", "Title", 0, 0, 400, 30)],
+  });
+  const footer = node({
+    id: "footer", name: "footer", type: "FRAME", x: 16, y: 1000, width: 818, height: 60,
+    layoutMode: "VERTICAL", fills: [], children: [textNode("note", "Note:", 0, 0, 400, 20)],
+  });
+  const frameChildren = [header, footer];
+  if (opts.oldChart) {
+    frameChildren.unshift(node({ id: "old", name: "chart", type: "FRAME", x: 0, y: 0, width: 850, height: 1095,
+                                 fills: [], children: [leaf("stale", 0, 0, 10, 10)] }));
+  }
+  const frame = node({
+    id: "frame", name: "how-do-people-spend-their-time", type: "FRAME", x: 1000, y: 0,
+    width: 850, height: 1095, fills: solid(), fillStyleId: "cream-style", clipsContent: true,
+    children: frameChildren,
+  });
+  const styled = node(Object.assign({
+    id: "styled", name: "svg-import", type: "FRAME", x: 0, y: 0, width: canvasWidth, height: 1095,
+    fills: [{ type: "SOLID", visible: false, color: { r: 1, g: 1, b: 1 } }], clipsContent: false,
+    children: inkNodes,
+  }, opts.styledExtra || {}));
+  const reference = opts.referenceToo
+    ? node({ id: "reference", name: "svg-import-2", type: "FRAME", x: 0, y: 0, width: canvasWidth, height: 1095,
+             fills: [{ type: "SOLID", visible: false, color: { r: 1, g: 1, b: 1 } }], clipsContent: false,
+             children: [leaf("ref-ink", 20, 90, 700, 800)] })
+    : null;
+  const cover = node({ id: "cover", name: "Cover", type: "PAGE", children: [styled, reference].filter(Boolean) });
+  const page = node({ id: "page", name: "20260817 chart page", type: "PAGE", children: [frame] });
+  return {
+    page: page, cover: cover, frame: frame, styled: styled, reference: reference,
+    config: { jobs: [{ frameId: "frame", styled: "styled", reference: reference ? "reference" : null,
+                       canvasWidth: canvasWidth, frameWidth: 850, referenceGap: 80, reflowLegend: false }] },
+  };
+}
+
+const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixed(2), h: +n.height.toFixed(2) });
+
+(async function () {
+  console.log("\nbackground patches: unpainted stripped, stroke-only kept");
+  {
+    const figurePatch = node({ name: "patch_1", type: "GROUP", x: 0, y: 0, width: 850, height: 1095,
+                               children: [leaf("bg", 0, 0, 850, 1095, { fills: [] })] });
+    const spine = node({ name: "patch_1", type: "GROUP", x: 16, y: 88, width: 818, height: 900,
+                         children: [rule("spine", 0, 0, 818, 0)] });
+    const axes = node({ name: "axes_1", type: "FRAME", x: 0, y: 0, width: 850, height: 1095, fills: [],
+                        children: [spine, leaf("bar", 16, 200, 300, 20)] });
+    const figure = node({ name: "figure_1", type: "FRAME", x: 0, y: 0, width: 850, height: 1095, fills: [],
+                          children: [figurePatch, axes] });
+    const s = scene({ inkNodes: [figure] });
+    const out = await run(s);
+    check("figure patch stripped", out.report[0].strippedPatches, ["figure_1/patch_1 (unpainted — removed for its bbox)"]);
+    check("axes spine survives", spine.removed !== true, true);
+    check("crop ignores the stripped 850-wide patch", box(s.styled).w, near(818));
+  }
+
+  console.log("\ncrop: the frame becomes the ink, and the ink does not move");
+  {
+    const bar = leaf("bar", 40, 100, 400, 30);
+    const s = scene({ inkNodes: [bar] });
+    const before = bar.absoluteBoundingBox.x;
+    await run(s);
+    check("frame box is the ink box", box(s.styled), { l: 40, t: 100, w: 400, h: 30 });
+    check("ink stayed put in absolute terms", bar.absoluteBoundingBox.x - before, 1000);
+    check("chart sits at the BOTTOM of the z-order", s.page.children[0].children[0].name, "chart");
+  }
+
+  console.log("\ncrop counts only what renders");
+  {
+    const hidden = leaf("hidden", 0, 0, 850, 1095, { visible: false });
+    const dimmed = node({ name: "dimmed", type: "GROUP", x: 0, y: 0, width: 850, height: 1095, opacity: 0, fills: [],
+                          children: [leaf("ghost", 0, 0, 850, 1095)] });
+    const clipArtifact = leaf("clip-path", 0, 0, 850, 1095, { vectorPaths: [{ windingRule: "NONE", data: "" }] });
+    const strokedNone = node({ type: "VECTOR", name: "open-gridline", x: 500, y: 300, width: 100, height: 0,
+                               fills: solid(), strokes: solid(), strokeWeight: 1,
+                               vectorPaths: [{ windingRule: "NONE", data: "" }] });
+    const bar = leaf("bar", 40, 100, 400, 30);
+    const s = scene({ inkNodes: [hidden, dimmed, clipArtifact, strokedNone, bar] });
+    await run(s);
+    check("hidden, zero-opacity and clip-path artifacts excluded", box(s.styled).l, 40);
+    check("a stroked zero-winding path still counts", box(s.styled).w, near(560));
+    // 100..300: the bar's top to the zero-height rule. Nulling the rule would leave 30.
+    check("... and its zero HEIGHT does not null it", box(s.styled).h, near(200));
+  }
+
+  console.log("\nclips: an inner clip trims, the frame's own clip does not");
+  {
+    const axesClip = node({ name: "axes_1", type: "FRAME", x: 16, y: 88, width: 818, height: 800, fills: [],
+                            clipsContent: true, children: [leaf("overflowing-line", 0, 0, 2000, 20)] });
+    const s = scene({ inkNodes: [axesClip] });
+    await run(s);
+    check("overflow past an inner clip does not widen the crop", box(s.styled).w, near(818));
+
+    // A gridline INSIDE the clip: zero-height by construction, since absoluteBoundingBox excludes
+    // strokes. Intersecting it with its clip must not null it — that is the whole F4 defect, and it
+    // only bites a degenerate box that HAS a clipping ancestor.
+    const clippedRule = node({ name: "axes_2", type: "FRAME", x: 16, y: 88, width: 818, height: 800, fills: [],
+                               clipsContent: true, children: [rule("gridline", 0, 700, 818, 0)] });
+    const s3 = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30), clippedRule] });
+    await run(s3);
+    check("a zero-height gridline inside a clip survives the intersection", box(s3.styled).h, near(688));
+
+    const overflow = leaf("past-the-canvas", 800, 100, 200, 30);
+    const s2 = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30), overflow], styledExtra: { clipsContent: true } });
+    await run(s2);
+    check("overflow past the FRAME's own clip is kept", box(s2.styled).w, near(960));
+  }
+
+  console.log("\nsnap to the content column");
+  {
+    const s = scene({ inkNodes: [leaf("bar", 15.92, 100, 817.96, 30)] });
+    await run(s);
+    check("a side within a pixel snaps exactly", [box(s.styled).l, +(s.styled.x + s.styled.width).toFixed(2)], [16, 834]);
+
+    const s2 = scene({ inkNodes: [leaf("bar", 12, 100, 400, 30)] });
+    await run(s2);
+    check("a side 4px out does NOT snap", box(s2.styled).l, 12);
+  }
+
+  console.log("\nreflow runs BEFORE the crop");
+  {
+    const legend = node({ name: "header__leisure", type: "GROUP", x: 0, y: 40, width: 400, height: 14, fills: [],
+                          children: [textNode("run-a", "Sports", 0, 0, 60, 14), textNode("run-b", "Events", 300, 0, 60, 14)] });
+    const s = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30), legend] });
+    s.config.jobs[0].reflowLegend = true;
+    const out = await run(s);
+    check("runs were re-flowed", out.report[0].reflowed > 0, true);
+    check("the crop reflects the POST-reflow ink", s.styled.x + s.styled.width < 440.001, true);
+  }
+
+  console.log("\nthe parked reference copy is left alone");
+  {
+    const s = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30)], referenceToo: true, canvasWidth: 816 });
+    await run(s);
+    const r = s.reference;
+    check("rescaled to the frame width", +r.width.toFixed(2), 850);
+    check("kept at full canvas height, not cropped", r.height, near(1095 * 850 / 816, 0.01));
+    check("its fill is still switched off", r.fills[0].visible, false);
+    check("parked to the LEFT of the frame", r.x, near(70, 0.001));
+    check("renamed for what it is", /— original SVG \(unstyled\)$/.test(r.name), true);
+  }
+
+  console.log("\nan existing chart is replaced, and the landing page is reported");
+  {
+    const s = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30)], oldChart: true });
+    const out = await run(s);
+    check("the old chart is gone", s.page.children[0].children.filter((c) => c.name === "chart").length, 1);
+    check("the landing page is named for the sweep", out.landingPages, ["cover Cover"]);
+    check("the frame's own fill style is copied onto the chart", s.page.children[0].children[0].fillStyleId, "cream-style");
+  }
+
+  console.log("\n" + (checks - failures) + "/" + checks + " checks passed");
+  process.exit(failures ? 1 : 0);
+})();

--- a/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
@@ -12,6 +12,12 @@
 //
 //     node .claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
 //
+// That runs TWO phases. The scenarios come first; then every guarantee they claim is re-broken in a
+// copy of the script and the scenarios are re-run, which must FAIL. A harness that passes on the
+// broken code is decoration, and this is the only way to know it is not: the first version of these
+// scenarios missed the zero-area clip bug outright, because the case it asserted had no clipping
+// ancestor and the comparison it guards never ran. Add a scenario, add its mutation.
+//
 // It is a MOCK: it validates control flow and arithmetic against the Plugin API's documented shapes,
 // never Figma's actual behaviour. Keep it honest —
 //   - `absoluteBoundingBox` is a GETTER that walks the parent chain, because the script reads absolute
@@ -237,9 +243,11 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     const s = scene({ inkNodes: [hidden, dimmed, clipArtifact, strokedNone, bar] });
     await run(s);
     check("hidden, zero-opacity and clip-path artifacts excluded", box(s.styled).l, 40);
-    check("a stroked zero-winding path still counts", box(s.styled).w, near(560));
-    // 100..300: the bar's top to the zero-height rule. Nulling the rule would leave 30.
-    check("... and its zero HEIGHT does not null it", box(s.styled).h, near(200));
+    // 560.5 and 200.5, not 560 and 200: the rule's 1px CENTER stroke paints half a pixel past the
+    // box on every side, and the crop has to take in the ink rather than the centreline.
+    check("a stroked zero-winding path still counts", box(s.styled).w, near(560.5));
+    // 100..300.5: the bar's top to the far side of the rule's stroke. Nulling the rule would leave 30.
+    check("... and its zero HEIGHT does not null it", box(s.styled).h, near(200.5));
   }
 
   console.log("\nclips: an inner clip trims, the frame's own clip does not");
@@ -257,12 +265,34 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
                                clipsContent: true, children: [rule("gridline", 0, 700, 818, 0)] });
     const s3 = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30), clippedRule] });
     await run(s3);
-    check("a zero-height gridline inside a clip survives the intersection", box(s3.styled).h, near(688));
+    // 688.5 = 100..788.5, the bar's top to the far side of the gridline's stroke. Its outset is
+    // trimmed sideways by the clip (15.5 -> 16) but not vertically, which is the clip doing its job.
+    check("a zero-height gridline inside a clip survives the intersection", box(s3.styled).h, near(688.5));
 
     const overflow = leaf("past-the-canvas", 800, 100, 200, 30);
     const s2 = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30), overflow], styledExtra: { clipsContent: true } });
     await run(s2);
     check("overflow past the FRAME's own clip is kept", box(s2.styled).w, near(960));
+  }
+
+  console.log("\nthe crop takes in the painted stroke, not the centreline");
+  {
+    // `absoluteBoundingBox` is geometry and excludes the stroke, so a 4px rule standing at the plot's
+    // right edge paints up to 4px past its own box, depending on how the stroke is aligned.
+    const edge = (extra) => node(Object.assign(
+      { type: "VECTOR", name: "edge", x: 400, y: 100, width: 0, height: 200,
+        fills: [], strokes: solid(), strokeWeight: 4 }, extra || {}));
+    const widthWith = async (extra) => {
+      const s = scene({ inkNodes: [leaf("bar", 40, 100, 300, 30), edge(extra)] });
+      await run(s);
+      return box(s.styled).w;
+    };
+    // 40..402, 40..404, 40..400: the bar's left edge to the painted far side of the rule.
+    check("a CENTER-aligned stroke outsets by half its weight", await widthWith(), near(362));
+    check("an OUTSIDE-aligned stroke outsets by all of it", await widthWith({ strokeAlign: "OUTSIDE" }), near(364));
+    check("an INSIDE-aligned stroke does not outset", await widthWith({ strokeAlign: "INSIDE" }), near(360));
+    check("a stroke that paints nothing does not outset",
+          await widthWith({ strokes: solid(false), fills: solid() }), near(360));
   }
 
   console.log("\nsnap to the content column");
@@ -306,8 +336,68 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     check("the old chart is gone", s.page.children[0].children.filter((c) => c.name === "chart").length, 1);
     check("the landing page is named for the sweep", out.landingPages, ["cover Cover"]);
     check("the frame's own fill style is copied onto the chart", s.page.children[0].children[0].fillStyleId, "cream-style");
+    // An import's fill arrives switched OFF, and a frame with no visible fill is not a hit target over
+    // its own empty area — which is the whole reason the script paints it. Asserting the style id alone
+    // let a mutation that leaves the fill invisible pass the suite.
+    check("and that fill is switched ON", s.page.children[0].children[0].fills[0].visible, true);
   }
 
   console.log("\n" + (checks - failures) + "/" + checks + " checks passed");
+  if (failures) process.exit(1);
+  if (process.env.RESTYLE_MUTANT) return; // a mutated child runs the scenarios only
+
+  // ---------------------------------------------------------------------------------------------
+  // Phase 2 — re-break each guarantee and require the scenarios to notice.
+  const OUTSET = ["let box = b && o ? { x: b.x - o, y: b.y - o, width: b.width + 2 * o, height: b.height + 2 * o } : b;", "let box = b;"];
+  const MUTATIONS = [
+    // F4 alone is SUBSUMED by F7: with the stroke outset in place a stroked leaf never has a
+    // degenerate box, so `>` and `>=` agree and the mutation is invisible. Reverting BOTH reproduces
+    // the pre-outset code in which the zero-area bug was found, and that must still fail — which is
+    // what keeps the `>=` honest rather than something a later reader simplifies away.
+    ["clip walk nulls zero-area boxes, pre-outset", [["box = right >= x && bottom >= y ?", "box = right > x && bottom > y ?"], OUTSET]],
+    ["clip walk includes the frame's own clip", [["for (let a = node.parent; a && box && a !== styled; a = a.parent) {", "for (let a = node.parent; a && box; a = a.parent) {"]]],
+    ["ink union counts nodes that never render", [["(fillPaints(n) || strokedAnywhere(n)) && rendersInTree(n))", "(fillPaints(n) || strokedAnywhere(n)))"]]],
+    ["crop uses the centreline, not the painted stroke", [OUTSET]],
+    ["stroke alignment ignored (always half the weight)", [['return n.strokeAlign === "INSIDE" ? 0 : n.strokeAlign === "OUTSIDE" ? weight : weight / 2;', "return weight / 2;"]]],
+    ["patch strip back to fills-only (unpainted patches survive)", [["if (!first || first.removed || strokedAnywhere(first)) continue;", "if (!first || first.removed || !painted(first)) continue;"]]],
+    ["import appended on TOP of the header and footer", [["frame.insertChild(0, styled);", "frame.appendChild(styled);"]]],
+    ["frame fill left switched off (not a hit target)", [["styled.fills = [{ ...canvasPaint, visible: true }];", "styled.fills = [{ ...canvasPaint, visible: false }];"]]],
+    ["snap tolerance widened past a real misalignment", [["const SNAP = 1;", "const SNAP = 20;"]]],
+  ];
+
+  const os = require("os");
+  const cp = require("child_process");
+  const SRC_PATH = path.join(__dirname, "restyle_static_import.js");
+  const original = fs.readFileSync(SRC_PATH, "utf8");
+  let caught = 0;
+  console.log("\nre-breaking each guarantee — every one must FAIL the scenarios above");
+  for (const [label, edits] of MUTATIONS) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "restyle-mutant-"));
+    let src = original;
+    let applied = true;
+    for (const [find, replace] of edits) {
+      if (!src.includes(find)) { applied = false; break; }
+      src = src.replace(find, replace);
+    }
+    if (!applied) {
+      console.log("  STALE  " + label + " — the mutation no longer matches the script; update it");
+      failures++;
+      continue;
+    }
+    fs.writeFileSync(path.join(dir, "restyle_static_import.js"), src);
+    fs.copyFileSync(__filename, path.join(dir, path.basename(__filename)));
+    const done = cp.spawnSync("node", [path.join(dir, path.basename(__filename))], {
+      encoding: "utf8", env: Object.assign({}, process.env, { RESTYLE_MUTANT: "1" }),
+    });
+    fs.rmSync(dir, { recursive: true, force: true });
+    if (done.status === 0) {
+      console.log("  MISSED " + label + " — the scenarios still pass with this broken");
+      failures++;
+    } else {
+      caught++;
+      console.log("  caught " + label);
+    }
+  }
+  console.log("\n" + caught + "/" + MUTATIONS.length + " re-introduced defects caught");
   process.exit(failures ? 1 : 0);
 })();

--- a/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
@@ -402,11 +402,13 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     ["blank import accepted silently (ink guard bypassed)", [["if (!inkLeaves().length) {", "if (false) {"]]],
     ["clipped-away import validated only AFTER the swap",
      [["if (!inkLeaves().map(throughClips).filter(Boolean).length) {", "if (false) {"]]],
-    // The crop-side `if (!inkBoxes.length)` throw carries NO mutation on purpose: both emptiness cases
-    // are refused before the swap, so nothing the scenarios can build reaches it. It is kept as a loud
-    // floor for the one path that could — a reflow moving a run out of its clip — which the mock cannot
-    // stage, since the reflow only shifts runs within a row. Recorded here rather than deleted, so the
-    // gap is where someone will read it.
+    // The clipped-away case is refused in TWO places — before the swap, and again after the reflow —
+    // so no SINGLE edit can break the check that it throws at all: remove either and the other still
+    // fires. That is what made this check look unreachable and earned it a coverage excuse. Removing
+    // BOTH is the defect the check actually states, and it is what the two-edit form is for.
+    ["clipped-away import refused nowhere",
+     [["if (!inkLeaves().map(throughClips).filter(Boolean).length) {", "if (false) {"],
+      ["if (!inkBoxes.length) throw", "if (false) throw"]]],
     ["strokeWeight guard dropped (figma.mixed reaches the arithmetic)",
      [["const weight = typeof n.strokeWeight === \"number\" ? n.strokeWeight : 0;", "const weight = n.strokeWeight;"]]],
     // "The crop runs LAST" is an ORDERING guarantee, and no token in the file means "before the
@@ -489,12 +491,10 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
   // style id alone, an ordering case whose runs sat inside the bar's own span, and a chart-replaced
   // count that counted the replacement too). Each was invisible until something asked which checks a
   // mutant actually breaks. So the suite asserts its own coverage rather than anyone re-deriving it.
-  const UNMUTATED = new Map([
-    ["a crop with nothing left to bound throws",
-     "unreachable by construction — both emptiness cases are refused before the swap, and the mock" +
-     " cannot stage the one path that would reach it (a reflow moving a run out of its clip, when the" +
-     " reflow only shifts within a row). Kept as a belt-and-braces throw."],
-  ]);
+  // Empty, and worth keeping that way. The one entry this ever held turned out to be wrong: the check
+  // looked unreachable only because every mutation tried was a SINGLE edit, and its guarantee was
+  // defended in two places. An excuse here should be read as a claim to re-test, not a fact.
+  const UNMUTATED = new Map([]);
   const uncovered = declared.filter((l) => !broken.has(l) && !UNMUTATED.has(l));
   const excused = declared.filter((l) => UNMUTATED.has(l));
   console.log("\ncoverage: " + (declared.length - uncovered.length - excused.length) + "/" +

--- a/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
@@ -293,6 +293,12 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     check("an INSIDE-aligned stroke does not outset", await widthWith({ strokeAlign: "INSIDE" }), near(360));
     check("a stroke that paints nothing does not outset",
           await widthWith({ strokes: solid(false), fills: solid() }), near(360));
+    // `strokeWeight` reads `figma.mixed` on a node carrying per-side weights. SVG cannot express those
+    // and VECTOR nodes do not have them, so an import should never produce one — but the script reads
+    // the property straight into arithmetic, and a Symbol in a `>` comparison THROWS rather than
+    // comparing false. Cheap to pin, and the guard is already written.
+    check("a mixed strokeWeight does not outset, and does not throw",
+          await widthWith({ strokeWeight: MIXED }), near(360));
   }
 
   console.log("\nsnap to the content column");
@@ -308,13 +314,18 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
 
   console.log("\nreflow runs BEFORE the crop");
   {
-    const legend = node({ name: "header__leisure", type: "GROUP", x: 0, y: 40, width: 400, height: 14, fills: [],
-                          children: [textNode("run-a", "Sports", 0, 0, 60, 14), textNode("run-b", "Events", 300, 0, 60, 14)] });
+    // The far run has to stick out PAST the bar, or this scenario cannot fail: with it at x=300 the
+    // ink ended at the bar's 440 whether the crop ran before or after the reflow, so the check held
+    // either way. At x=500 the pre-reflow ink ends at 560 and the post-reflow ink at 440, and only
+    // the right order gives 440.
+    const legend = node({ name: "header__leisure", type: "GROUP", x: 0, y: 40, width: 600, height: 14, fills: [],
+                          children: [textNode("run-a", "Sports", 0, 0, 60, 14), textNode("run-b", "Events", 500, 0, 60, 14)] });
     const s = scene({ inkNodes: [leaf("bar", 40, 100, 400, 30), legend] });
     s.config.jobs[0].reflowLegend = true;
     const out = await run(s);
     check("runs were re-flowed", out.report[0].reflowed > 0, true);
-    check("the crop reflects the POST-reflow ink", s.styled.x + s.styled.width < 440.001, true);
+    check("the crop reflects the POST-reflow ink, not the 560 it spanned before",
+          +(s.styled.x + s.styled.width).toFixed(2), 440);
   }
 
   console.log("\nthe parked reference copy is left alone");
@@ -342,6 +353,27 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     check("and that fill is switched ON", s.page.children[0].children[0].fills[0].visible, true);
   }
 
+  console.log("\na blank import is refused before anything is destroyed");
+  {
+    const s = scene({ inkNodes: [leaf("ghost", 0, 0, 850, 1095, { visible: false })], oldChart: true });
+    let threw = null;
+    try { await run(s); } catch (e) { threw = e; }
+    check("an import with no visible ink throws", /no visible ink/.test(threw && threw.message), true);
+    // Throwing HERE rather than at the crop is the whole point: nothing has been destroyed yet.
+    check("the old chart is still on the frame", s.page.children[0].children.filter((c) => c.name === "chart").length, 1);
+    check("and the blank import was not swapped in", s.page.children[0].children.indexOf(s.styled) < 0, true);
+  }
+
+  console.log("\nink clipped entirely away is an error, not an empty crop");
+  {
+    const clip = node({ name: "axes_1", type: "FRAME", x: 16, y: 88, width: 818, height: 800, fills: [],
+                        clipsContent: true, children: [leaf("off-in-the-weeds", 3000, 3000, 20, 20)] });
+    const s = scene({ inkNodes: [clip] });
+    let threw = null;
+    try { await run(s); } catch (e) { threw = e; }
+    check("a crop with nothing left to bound throws", /clipped away/.test(threw && threw.message), true);
+  }
+
   console.log("\n" + (checks - failures) + "/" + checks + " checks passed");
   if (failures) process.exit(1);
   if (process.env.RESTYLE_MUTANT) return; // a mutated child runs the scenarios only
@@ -363,6 +395,21 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     ["import appended on TOP of the header and footer", [["frame.insertChild(0, styled);", "frame.appendChild(styled);"]]],
     ["frame fill left switched off (not a hit target)", [["styled.fills = [{ ...canvasPaint, visible: true }];", "styled.fills = [{ ...canvasPaint, visible: false }];"]]],
     ["snap tolerance widened past a real misalignment", [["const SNAP = 1;", "const SNAP = 20;"]]],
+    ["blank import accepted silently (ink guard bypassed)", [["if (!inkLeaves().length) {", "if (false) {"]]],
+    ["every leaf clipped away accepted silently", [["if (!inkBoxes.length) throw", "if (false) throw"]]],
+    ["strokeWeight guard dropped (figma.mixed reaches the arithmetic)",
+     [["const weight = typeof n.strokeWeight === \"number\" ? n.strokeWeight : 0;", "const weight = n.strokeWeight;"]]],
+    // "The crop runs LAST" is an ORDERING guarantee, and no token in the file means "before the
+    // reflow" — so it cannot be re-broken by swapping one string for another. Hence a function: cut
+    // the crop block out and splice it back above the reflow, which is the code as it stood when the
+    // stale-bounds bug was found. Anchors gone => null => STALE, the same safety a find string has.
+    ["crop computed BEFORE the legend reflow", (src) => {
+      const start = src.indexOf("  // CROP the frame to the plot's own ink");
+      const end = src.indexOf("\n  report.push({");
+      const reflow = src.indexOf("  // A flowed line of runs needs laying out again");
+      if (start < 0 || end < 0 || reflow < 0 || !(reflow < start && start < end)) return null;
+      return src.slice(0, reflow) + src.slice(start, end) + "\n" + src.slice(reflow, start) + src.slice(end);
+    }],
   ];
 
   const os = require("os");
@@ -375,9 +422,16 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "restyle-mutant-"));
     let src = original;
     let applied = true;
-    for (const [find, replace] of edits) {
-      if (!src.includes(find)) { applied = false; break; }
-      src = src.replace(find, replace);
+    if (typeof edits === "function") {
+      // An ordering mutation cannot be written as find/replace, so it is allowed to be a function.
+      // Returning null means its anchors moved, which reports STALE exactly like a dead find string.
+      const out = edits(original);
+      if (out === null) applied = false; else src = out;
+    } else {
+      for (const [find, replace] of edits) {
+        if (!src.includes(find)) { applied = false; break; }
+        src = src.replace(find, replace);
+      }
     }
     if (!applied) {
       console.log("  STALE  " + label + " — the mutation no longer matches the script; update it");

--- a/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
+++ b/.claude/skills/create-figma-chart/scripts/test_restyle_static_import.js
@@ -143,8 +143,10 @@ async function run(scenario) {
   return fn(figma, config);
 }
 
+const declared = [];
 function check(label, actual, expected) {
   checks++;
+  declared.push(label);
   const ok = typeof expected === "function" ? expected(actual) : JSON.stringify(actual) === JSON.stringify(expected);
   if (!ok) {
     failures++;
@@ -360,7 +362,7 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     try { await run(s); } catch (e) { threw = e; }
     check("an import with no visible ink throws", /no visible ink/.test(threw && threw.message), true);
     // Throwing HERE rather than at the crop is the whole point: nothing has been destroyed yet.
-    check("the old chart is still on the frame", s.page.children[0].children.filter((c) => c.name === "chart").length, 1);
+    check("the old chart is still on the frame", s.page.children[0].children.some((c) => c.id === "old"), true);
     check("and the blank import was not swapped in", s.page.children[0].children.indexOf(s.styled) < 0, true);
   }
 
@@ -368,10 +370,12 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
   {
     const clip = node({ name: "axes_1", type: "FRAME", x: 16, y: 88, width: 818, height: 800, fills: [],
                         clipsContent: true, children: [leaf("off-in-the-weeds", 3000, 3000, 20, 20)] });
-    const s = scene({ inkNodes: [clip] });
+    const s = scene({ inkNodes: [clip], oldChart: true });
     let threw = null;
     try { await run(s); } catch (e) { threw = e; }
     check("a crop with nothing left to bound throws", /clipped away/.test(threw && threw.message), true);
+    check("and the old chart was not destroyed to report it",
+          s.page.children[0].children.some((c) => c.id === "old"), true);
   }
 
   console.log("\n" + (checks - failures) + "/" + checks + " checks passed");
@@ -396,13 +400,33 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     ["frame fill left switched off (not a hit target)", [["styled.fills = [{ ...canvasPaint, visible: true }];", "styled.fills = [{ ...canvasPaint, visible: false }];"]]],
     ["snap tolerance widened past a real misalignment", [["const SNAP = 1;", "const SNAP = 20;"]]],
     ["blank import accepted silently (ink guard bypassed)", [["if (!inkLeaves().length) {", "if (false) {"]]],
-    ["every leaf clipped away accepted silently", [["if (!inkBoxes.length) throw", "if (false) throw"]]],
+    ["clipped-away import validated only AFTER the swap",
+     [["if (!inkLeaves().map(throughClips).filter(Boolean).length) {", "if (false) {"]]],
+    // The crop-side `if (!inkBoxes.length)` throw carries NO mutation on purpose: both emptiness cases
+    // are refused before the swap, so nothing the scenarios can build reaches it. It is kept as a loud
+    // floor for the one path that could — a reflow moving a run out of its clip — which the mock cannot
+    // stage, since the reflow only shifts runs within a row. Recorded here rather than deleted, so the
+    // gap is where someone will read it.
     ["strokeWeight guard dropped (figma.mixed reaches the arithmetic)",
      [["const weight = typeof n.strokeWeight === \"number\" ? n.strokeWeight : 0;", "const weight = n.strokeWeight;"]]],
     // "The crop runs LAST" is an ORDERING guarantee, and no token in the file means "before the
     // reflow" — so it cannot be re-broken by swapping one string for another. Hence a function: cut
     // the crop block out and splice it back above the reflow, which is the code as it stood when the
     // stale-bounds bug was found. Anchors gone => null => STALE, the same safety a find string has.
+    ["stroke-only patch stripped too (the axes spine deleted)", [["if (!first || first.removed || strokedAnywhere(first)) continue;", "if (!first || first.removed) continue;"]]],
+    ["crop never resizes the frame", [["styled.resizeWithoutConstraints(ink.right - ink.x, ink.bottom - ink.y);", ""]]],
+    ["children not shifted back, so the crop MOVES the ink", [["for (const child of styled.children) { child.x -= dx; child.y -= dy; }", ""]]],
+    ["inner clips ignored entirely", [["const clip = \"clipsContent\" in a && a.clipsContent ? a.absoluteBoundingBox : null;", "const clip = null;"]]],
+    ["outset taken from a stroke that paints nothing", [["    const paints = Array.isArray(n.strokes) &&\n      n.strokes.some((s) => s.visible !== false && (s.opacity === undefined || s.opacity > 0));", "    const paints = Array.isArray(n.strokes) && n.strokes.length > 0;"]]],
+    ["snap disabled (a side within a pixel no longer snaps)", [["const SNAP = 1;", "const SNAP = 0;"]]],
+    ["legend reflow skipped altogether", [["if (job.reflowLegend) {", "if (false) {"]]],
+    ["reference copy not rescaled to the frame width", [["reference.rescale(scale);", ""]]],
+    ["reference copy not renamed", [["reference.name = `${frame.name} — original SVG (unstyled)`;", ""]]],
+    ["reference copy not parked beside the frame", [["reference.x = frame.x - reference.width - job.referenceGap;", ""]]],
+    ["reference copy painted like the chart", [["styled.fills = [{ ...canvasPaint, visible: true }];", "for (const n of [styled, reference].filter(Boolean)) n.fills = [{ ...canvasPaint, visible: true }];"]]],
+    ["old chart left on the frame beside the new one", [["if (old) old.remove();", ""]]],
+    ["landing page not recorded for the sweep", [["if (ancestor) landingPages.add(`${ancestor.id} ${ancestor.name}`);", ""]]],
+    ["frame's fill STYLE not copied onto the chart", [["if (frame.fillStyleId && frame.fillStyleId !== figma.mixed) await styled.setFillStyleIdAsync(frame.fillStyleId);", ""]]],
     ["crop computed BEFORE the legend reflow", (src) => {
       const start = src.indexOf("  // CROP the frame to the plot's own ink");
       const end = src.indexOf("\n  report.push({");
@@ -416,6 +440,7 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
   const cp = require("child_process");
   const SRC_PATH = path.join(__dirname, "restyle_static_import.js");
   const original = fs.readFileSync(SRC_PATH, "utf8");
+  const broken = new Set();
   let caught = 0;
   console.log("\nre-breaking each guarantee — every one must FAIL the scenarios above");
   for (const [label, edits] of MUTATIONS) {
@@ -450,8 +475,36 @@ const box = (n) => ({ l: +n.x.toFixed(2), t: +n.y.toFixed(2), w: +n.width.toFixe
     } else {
       caught++;
       console.log("  caught " + label);
+      for (const ln of (done.stdout || "").split("\n")) {
+        if (ln.startsWith("  FAIL ")) broken.add(ln.slice(7).trim());
+      }
     }
   }
   console.log("\n" + caught + "/" + MUTATIONS.length + " re-introduced defects caught");
+
+  // ---------------------------------------------------------------------------------------------
+  // Phase 3 — the other direction. A mutation nothing catches is reported above; a CHECK no mutation
+  // breaks is the same defect seen from the other end, and it is the one that keeps happening: three
+  // scenarios in this suite passed while their guarantee was broken (the frame's fill asserted by
+  // style id alone, an ordering case whose runs sat inside the bar's own span, and a chart-replaced
+  // count that counted the replacement too). Each was invisible until something asked which checks a
+  // mutant actually breaks. So the suite asserts its own coverage rather than anyone re-deriving it.
+  const UNMUTATED = new Map([
+    ["a crop with nothing left to bound throws",
+     "unreachable by construction — both emptiness cases are refused before the swap, and the mock" +
+     " cannot stage the one path that would reach it (a reflow moving a run out of its clip, when the" +
+     " reflow only shifts within a row). Kept as a belt-and-braces throw."],
+  ]);
+  const uncovered = declared.filter((l) => !broken.has(l) && !UNMUTATED.has(l));
+  const excused = declared.filter((l) => UNMUTATED.has(l));
+  console.log("\ncoverage: " + (declared.length - uncovered.length - excused.length) + "/" +
+              declared.length + " checks broken by at least one mutation" +
+              (excused.length ? ", " + excused.length + " excused" : ""));
+  for (const l of excused) console.log("  excused  " + l + " — " + UNMUTATED.get(l));
+  for (const l of uncovered) {
+    console.log("  DECORATION " + l + " — no mutation breaks it, so it cannot fail. Write one, or" +
+                " excuse it in UNMUTATED with the reason.");
+    failures++;
+  }
   process.exit(failures ? 1 : 0);
 })();

--- a/.claude/skills/create-static-viz/SKILL.md
+++ b/.claude/skills/create-static-viz/SKILL.md
@@ -373,7 +373,7 @@ of the panel fill, never seeing the series colour. Nothing failed and nothing wa
 each row named what it could not find — but the coverage behind "no mechanical row failed" was far
 thinner than the same sentence on a grapher import. So emit `gid="line__<Entity>"` for a series line,
 `label__<Entity>` for a direct label, and `horizontal-grid-lines` for the gridline group, rather than
-inventing a scheme. Renaming in Figma afterwards works but does not survive a re-import; the `gid`
+inventing a scheme. These are **prefixes**, load-bearing as such — see [GOTCHAS.md](reference/GOTCHAS.md). Renaming in Figma afterwards works but does not survive a re-import; the `gid`
 does.
 
 Note what a `gid` actually produces: matplotlib writes `<g id="label__Ghana"><text/></g>`, so Figma

--- a/.claude/skills/create-static-viz/SKILL.md
+++ b/.claude/skills/create-static-viz/SKILL.md
@@ -351,18 +351,19 @@ The one adaptation: its Steps 7–8 look up grapher's node names (`connectors`,
 `horizontal-grid-lines`, `datapoints__<Entity>`). Ours are the `gid`s from Step 4 — hand over the
 naming scheme along with the file.
 
-**Three of that skill's geometry rows cannot pass on this route, and it is structural rather than a
-defect.** `box-alignment` and `gap` measure the chart GROUP's box against the content box and the band,
-which works for a grapher import because its fit step leaves a group hugging the plot. Ours is a FRAME
-the size of the SVG canvas — deliberately, so the plot's coordinates stay the template's — so its box
-IS the artboard: `box-alignment` reports left -16 / right +16 and `gap` reports negative insets, every
-time, on a frame that is correct. `margins` then flags the canvas rectangle itself.
+**Three of that skill's geometry rows only mean anything once the import is cropped — and then they
+mean everything.** `box-alignment`, `gap` and `margins` read the chart frame's box, and an import
+arrives the size of the SVG canvas, which *is* the artboard: uncropped they report left −16 / right
++16, negative insets and the canvas rectangle, every time, on a page that is correct.
+`restyle_static_import.js` removes both causes — it strips matplotlib's frame-sized background patch
+(which paints nothing but sets the bbox) and crops the frame to its painted ink, snapping a side that
+lands within a pixel of the content column. **After that, treat those rows as live**: `box-alignment`
+must be exact and `margins` must pass — a failure there is real, not this route's noise.
 
-What to do instead of chasing them: delete matplotlib's frame-sized background patch on import (it
-paints nothing, so `restyle_static_import.js` now strips it for its bbox alone), and measure the band
-from the **ink** — the extreme edges of the painted leaves inside the chart — against `header.y +
-header.height` and the footer's first row. Report those two numbers. On the frame this lesson comes
-from that read 18.35 top / 17.01 bottom against a 12–16 target, against -70 / -79 from the stock rows.
+`gap` is the one to read rather than chase: it measures against the header frame's bottom and the
+footer frame's top, which a band derived from line-box arithmetic misses by a few px, so a page
+asserting a 14 px inset can read **18.35 / 17.01** against the 12–16 target. Report both numbers and
+name the datum the step used — [TEMPLATES.md](TEMPLATES.md) has the measurements and which to prefer.
 
 **Use grapher's OWN names for the data layers wherever the shape matches, because that skill's Step 8c
 checks key off them and skip when they are absent.** Measured on a real DI frame drawn by a local

--- a/.claude/skills/create-static-viz/SKILL.md
+++ b/.claude/skills/create-static-viz/SKILL.md
@@ -351,6 +351,19 @@ The one adaptation: its Steps 7–8 look up grapher's node names (`connectors`,
 `horizontal-grid-lines`, `datapoints__<Entity>`). Ours are the `gid`s from Step 4 — hand over the
 naming scheme along with the file.
 
+**Three of that skill's geometry rows cannot pass on this route, and it is structural rather than a
+defect.** `box-alignment` and `gap` measure the chart GROUP's box against the content box and the band,
+which works for a grapher import because its fit step leaves a group hugging the plot. Ours is a FRAME
+the size of the SVG canvas — deliberately, so the plot's coordinates stay the template's — so its box
+IS the artboard: `box-alignment` reports left -16 / right +16 and `gap` reports negative insets, every
+time, on a frame that is correct. `margins` then flags the canvas rectangle itself.
+
+What to do instead of chasing them: delete matplotlib's frame-sized background patch on import (it
+paints nothing, so `restyle_static_import.js` now strips it for its bbox alone), and measure the band
+from the **ink** — the extreme edges of the painted leaves inside the chart — against `header.y +
+header.height` and the footer's first row. Report those two numbers. On the frame this lesson comes
+from that read 18.35 top / 17.01 bottom against a 12–16 target, against -70 / -79 from the stock rows.
+
 **Use grapher's OWN names for the data layers wherever the shape matches, because that skill's Step 8c
 checks key off them and skip when they are absent.** Measured on a real DI frame drawn by a local
 generator — nine panels, nine series lines, 27 direct labels, all correct — **seven rows skipped for

--- a/.claude/skills/create-static-viz/TEMPLATES.md
+++ b/.claude/skills/create-static-viz/TEMPLATES.md
@@ -266,11 +266,26 @@ A step decides its layout from strings it measures in its own font, and the temp
 strings in Playfair Display and Lato. So every line count it predicts is an estimate, and the error
 does not point one way:
 
-| At the same pixel size | vs. a step measuring in Arial/DejaVu |
-|---|---|
-| Lato, 11 px | **2.4 % narrower** |
-| Lato, 16 px | 0.8 % narrower |
-| Playfair Display SemiBold, 25 px | **3.2 % wider** |
+**First, make the font the step MEASURES be the font it DRAWS — they are not the same by default.**
+`FontProperties()` with no family resolves `font.family`/`font.sans-serif`, and seaborn's `set_style`
+rewrites that list to an Arial-first one. So a step that wraps its title before calling `set_style`
+measures matplotlib's DejaVu default and then draws Arial, and the two are **~15 % apart** — far more
+than any allowance below, and in the direction that makes a slot look full when it is not. Name the
+stack, set it at import, and pass it to every `FontProperties`; then the percentages below are the whole
+of the correction.
+
+| At the same pixel size | vs. **Arial** (what these steps draw) | vs. **DejaVu Sans** (matplotlib's default) |
+|---|---|---|
+| Lato Regular, 11 px | **2.4 % narrower** | ~15 % narrower |
+| Lato Regular, 16 px | 0.8 % narrower | 15.1 % narrower |
+| Lato **Bold**, 11 px, in a mixed-weight row | **6.6 % narrower** | 26 % narrower |
+| Playfair Display SemiBold, 25 px | **3.2 % wider** | 9.6 % narrower |
+
+Two things that table is easy to under-read. The **bold** row is not a rounding of the regular one:
+Arial Bold sets 6.6 % wider than Lato Bold, so a footer row of mixed weights measured with the regular
+allowance is rejected by its own step while setting correctly in the frame — measured at 828 px against
+an 818 px row where the frame sets it in 798. And the columns are per *installed* font: check which one
+`findfont` actually returns on the machine building the step rather than assuming Arial is there.
 
 **Do not "wrap a bit early to be safe".** It reads as prudent and it is not: the footer rows are sized
 so the template just fits them, so wrapping 6 % early broke both onto second lines the frame does not

--- a/.claude/skills/create-static-viz/TEMPLATES.md
+++ b/.claude/skills/create-static-viz/TEMPLATES.md
@@ -226,6 +226,17 @@ that edge. This used to need a correction: the footer frame started 16 px above 
 insetting from the frame's `y` then inset twice and left a visibly loose bottom. If you measure that
 gap again, the wrappers have been re-padded — re-verify before compensating for it.
 
+**Take those two edges from the template's own frames, not from line-height arithmetic.**
+`verify_page.js`'s `gap` row measures the plot against the header auto-layout's *bottom* and the
+footer auto-layout's *top* — the numbers `verify_templates.js` prints — so a band derived instead as
+`subtitle_y + n × line_px` and `note_bottom − n × line_px` is judged against datums it never used.
+Measured on the 2026 Vertical template, that arithmetic landed **4.35 px below** the header frame's
+bottom and **3.01 px above** the footer frame's top, which is line-box slack rather than anything
+visible: a `BAND_INSET` of 14 then reads as `gap` **18.35 / 17.01** against the 12–16 target, on a
+page whose spacing looks right and whose own assertion says 14. Either inset from the frame edges, or
+expect the row to fail by a few px and record why — but do not "fix" it by shrinking the inset
+without knowing which datum you are shrinking from.
+
 **Draw the step's own copies of these slots at the sizes in the table, not at sizes that merely look
 right.** It is tempting to set the step's title and subtitle a size or two smaller — nothing in the
 frame uses them, since the import drops them. But then the render's spacing is *not* the frame's: the

--- a/.claude/skills/create-static-viz/TEMPLATES.md
+++ b/.claude/skills/create-static-viz/TEMPLATES.md
@@ -233,9 +233,17 @@ footer auto-layout's *top* — the numbers `verify_templates.js` prints — so a
 Measured on the 2026 Vertical template, that arithmetic landed **4.35 px below** the header frame's
 bottom and **3.01 px above** the footer frame's top, which is line-box slack rather than anything
 visible: a `BAND_INSET` of 14 then reads as `gap` **18.35 / 17.01** against the 12–16 target, on a
-page whose spacing looks right and whose own assertion says 14. Either inset from the frame edges, or
-expect the row to fail by a few px and record why — but do not "fix" it by shrinking the inset
-without knowing which datum you are shrinking from.
+page whose spacing looks right and whose own assertion says 14. **Inset from the frame edges**, and
+the row passes: the same measurement that explains the 4.35 and the 3.01 is what makes a 14 px inset
+off those datums read as `gap` 14. What you must not do is "fix" a failing row by shrinking the inset
+without knowing which datum you are shrinking from — that moves the plot to satisfy a number measured
+from somewhere else.
+
+`gap` is a live row, so a failure is a real discrepancy and not explanatory noise: a band derived from
+line-height arithmetic is a defect to correct, not a caveat to record. One frame predates this —
+the time-use chart built in #6678 ships at 18.35 / 17.01, which is the measurement above and is
+pending a design decision on whether to re-cut it. That is one named, dated exception, not a licence:
+new work insets from the frame edges and passes.
 
 **Draw the step's own copies of these slots at the sizes in the table, not at sizes that merely look
 right.** It is tempting to set the step's title and subtitle a size or two smaller — nothing in the

--- a/.claude/skills/create-static-viz/reference/GOTCHAS.md
+++ b/.claude/skills/create-static-viz/reference/GOTCHAS.md
@@ -95,3 +95,16 @@
   nothing returns the string unchanged and reports success, so the render silently keeps the old
   behavior while you debug the wrong thing. For the same reason, never delete by slicing between two
   anchors without checking what lies between them: an unrelated helper sitting there goes too.
+
+## `label__` is a prefix, and a suffix reads as unnamed
+
+`/create-figma-chart`'s rows resolve a text node through its naming ancestors with
+`/^(annotation|label)__/`, so a group named the other way round — `ghana__label`, `country__label` —
+is invisible to every one of them. It fails silently, and worse, it fails *quietly*: a chart carrying
+26 country labels on the frame's own background had `label-contrast-on-background` report "no
+`label__*`/`annotation__*` text sits on the frame's own background". That is a SKIPPED row,
+indistinguishable at a glance from the same row on a chart that genuinely has no such text — on the
+one check that would have measured those labels' contrast.
+
+Renaming after the fact means renaming in three places at once (the step's gids, the restyle script's
+parent regexes, and the frame), so get the order right in the step.

--- a/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
+++ b/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
@@ -100,6 +100,34 @@ width** (`rcParams["lines.scale_dashes"]`), so `(5, 3)` on a 1.4pt line draws a 
 the stroke width, which reads as stretched at any size. Write the pattern in multiples of the width
 and say so, or check the emitted `stroke-dasharray` against what you intended.
 
+### Measure in the font you draw in, and set the style before the first measurement
+
+`FontProperties()` with no family resolves `font.family`/`font.sans-serif` — and seaborn's `set_style`
+rewrites that list to an Arial-first one. So a step that calls `set_style` inside its build function,
+after the title and subtitle have been wrapped, measures matplotlib's **DejaVu** default and then draws
+**Arial**. The two are ~15% apart, which is far more than any slot allowance and points the wrong way:
+strings look wider than they will be set, so a slot that fits is wrapped early and the fix looks like
+"the allowance should be 1.0".
+
+Two lines prevent it. Name the stack and set it at import, next to the `svg.*` rcParams:
+
+```python
+DRAWN_FONT_STACK = ["Arial", "Helvetica", "DejaVu Sans", "Liberation Sans", "sans-serif"]
+matplotlib.rcParams["font.family"] = "sans-serif"
+matplotlib.rcParams["font.sans-serif"] = DRAWN_FONT_STACK
+```
+
+and pass it to every measurement, so the two cannot drift whatever a machine has installed:
+
+```python
+prop = FontProperties(family=DRAWN_FONT_STACK, size=fontsize, weight="bold" if bold else "normal")
+```
+
+Then check which font `findfont` actually returned before trusting the per-face allowances in
+[TEMPLATES.md](../TEMPLATES.md) — they are per installed font, and the bold row is not a rounding of
+the regular one (Arial Bold sets 6.6% wider than Lato Bold, which is enough to make a mixed-weight
+footer row fail its own step's fit assertion while setting correctly in the frame).
+
 ### Style, and where it stops
 
 - **seaborn** `set_style("ticks")` + `set_palette("deep")`, and reference colors by **palette

--- a/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
+++ b/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
@@ -109,19 +109,54 @@ after the title and subtitle have been wrapped, measures matplotlib's **DejaVu**
 strings look wider than they will be set, so a slot that fits is wrapped early and the fix looks like
 "the allowance should be 1.0".
 
-Two lines prevent it. Name the stack and set it at import, next to the `svg.*` rcParams:
+Name **two** stacks, because two different things read them, and they want different answers:
 
 ```python
-DRAWN_FONT_STACK = ["Arial", "Helvetica", "DejaVu Sans", "Liberation Sans", "sans-serif"]
+# Lands in the SVG's `font-family`, verbatim: matplotlib copies the rcParam out rather than writing
+# the font it resolved. Naming Lato first is a request to whoever OPENS the file.
+EMITTED_FONT_STACK = ["Lato", "Arial", "Helvetica", "sans-serif"]
+# What this step measures and draws with. Deliberately does NOT name Lato, which is not installed on
+# our machines — asking for it only logs a `findfont` miss before falling through to Arial.
+MEASURED_FONT_STACK = ["Arial", "Helvetica", "DejaVu Sans", "Liberation Sans", "sans-serif"]
+
 matplotlib.rcParams["font.family"] = "sans-serif"
-matplotlib.rcParams["font.sans-serif"] = DRAWN_FONT_STACK
+matplotlib.rcParams["font.sans-serif"] = EMITTED_FONT_STACK
+# `Lato` is MEANT to be missing here, so quieten that one logger — a real problem with a font the
+# step does need is still visible.
+logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
 ```
 
-and pass it to every measurement, so the two cannot drift whatever a machine has installed:
+Pass the measured stack to every measurement, so measuring and drawing cannot drift whatever a
+machine has installed:
 
 ```python
-prop = FontProperties(family=DRAWN_FONT_STACK, size=fontsize, weight="bold" if bold else "normal")
+prop = FontProperties(family=MEASURED_FONT_STACK, size=fontsize, weight="bold" if bold else "normal")
 ```
+
+**Set the emitted stack again after seaborn**, inside the build function — `set_style` REPLACES
+`font.sans-serif` with its own list, so the module-level assignment above is overwritten and the step
+emits a stack it never chose (which is how one step came to ship `'Arial', 'DejaVu Sans', 'Liberation
+Sans', 'Bitstream Vera Sans'`):
+
+```python
+sns.set_style("ticks")
+sns.set_palette("deep")
+matplotlib.rcParams["font.sans-serif"] = EMITTED_FONT_STACK
+```
+
+Naming Lato first costs nothing and buys a lot downstream: **Figma renders the import in the
+template's own typeface on arrival**, so the parked reference copy looks like the deliverable, and
+`/create-figma-chart`'s font pass — plus the anchor pass that exists only to undo that face change —
+becomes a no-op. Without it Figma resolves none of `Arial, Helvetica, DejaVu Sans` and substitutes
+**Inter**, which is wider: one 850-wide chart overran its canvas by 39px that way. Verify it rather
+than assuming — the emitted stack is one grep, and the faces the import lands in are one read:
+
+```bash
+grep -o "font-family: [^;\"]*" <file>.svg | sort -u   # want 'Lato' first
+```
+
+Changing the stack must not move anything: the drawn font is unchanged, so the SVG should differ from
+its predecessor **only** in `font-family`, and the PNG not at all (measured: 0 pixels differing).
 
 Then check which font `findfont` actually returned before trusting the per-face allowances in
 [TEMPLATES.md](../TEMPLATES.md) — they are per installed font, and the bold row is not a rounding of

--- a/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
+++ b/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
@@ -116,15 +116,29 @@ Name **two** stacks, because two different things read them, and they want diffe
 # the font it resolved. Naming Lato first is a request to whoever OPENS the file.
 EMITTED_FONT_STACK = ["Lato", "Arial", "Helvetica", "sans-serif"]
 # What this step measures and draws with. Deliberately does NOT name Lato, which is not installed on
-# our machines — asking for it only logs a `findfont` miss before falling through to Arial.
+# our machines, so it is not a font this step could measure in — only one it can ask for.
 MEASURED_FONT_STACK = ["Arial", "Helvetica", "DejaVu Sans", "Liberation Sans", "sans-serif"]
 
 matplotlib.rcParams["font.family"] = "sans-serif"
 matplotlib.rcParams["font.sans-serif"] = EMITTED_FONT_STACK
-# `Lato` is MEANT to be missing here, so quieten that one logger — a real problem with a font the
-# step does need is still visible.
-logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
+# Nothing to silence here — see below before adding a filter or a setLevel.
 ```
+
+**Leave `matplotlib.font_manager`'s logger alone**, however tempting it is to quieten a stack that
+names a font the machine does not have. Measured (matplotlib 3.10.9, Lato absent, Arial installed):
+resolving *either* stack emits **zero** WARNING records. A face that is skipped costs nothing —
+matplotlib scores every candidate at **DEBUG** (1,056 records for two lookups), which never surfaces,
+and it warns only when a whole family list resolves to nothing:
+
+```
+findfont: Font family ['Lato', 'Nonexistent Face'] not found. Falling back to DejaVu Sans.
+```
+
+That is the *only* warning this logger emits, and it is the one you cannot afford to lose: it says a
+stack failed and every measurement in the step just moved ~15% against what gets drawn, which is the
+exact failure this section exists to prevent. So `setLevel(logging.ERROR)` — or a filter over "not
+found" — suppresses nothing you actually have, in exchange for the single notice that matters. If you
+inherit either, delete it rather than narrow it.
 
 Pass the measured stack to every measurement, so measuring and drawing cannot drift whatever a
 machine has installed:

--- a/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
+++ b/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
@@ -121,24 +121,47 @@ MEASURED_FONT_STACK = ["Arial", "Helvetica", "DejaVu Sans", "Liberation Sans", "
 
 matplotlib.rcParams["font.family"] = "sans-serif"
 matplotlib.rcParams["font.sans-serif"] = EMITTED_FONT_STACK
-# Nothing to silence here — see below before adding a filter or a setLevel.
+# Drop the per-face misses for faces you deliberately list as alternatives, and NOTHING else.
+_OPTIONAL_FACES = tuple({*EMITTED_FONT_STACK, *MEASURED_FONT_STACK})
+logging.getLogger("matplotlib.font_manager").addFilter(
+    lambda record: "Falling back" in record.getMessage()
+    or not any(f"Font family '{face}' not found" in record.getMessage() for face in _OPTIONAL_FACES)
+)
 ```
 
-**Leave `matplotlib.font_manager`'s logger alone**, however tempting it is to quieten a stack that
-names a font the machine does not have. Measured (matplotlib 3.10.9, Lato absent, Arial installed):
-resolving *either* stack emits **zero** WARNING records. A face that is skipped costs nothing —
-matplotlib scores every candidate at **DEBUG** (1,056 records for two lookups), which never surfaces,
-and it warns only when a whole family list resolves to nothing:
+**`font_manager` has two warning sites, and only one of them is reachable from a `findfont()` probe.**
+This matters because probing the wrong one leads to both available wrong answers:
 
-```
-findfont: Font family ['Lato', 'Nonexistent Face'] not found. Falling back to DejaVu Sans.
+| Site | Message | Fires when |
+|---|---|---|
+| `_findfont_cached` | `... not found. Falling back to DejaVu Sans.` | a family list resolves to **nothing**, via `findfont()` |
+| `_find_fonts_by_props` | `Font family 'X' not found.` | text is **drawn** with an explicit family list — once per missing face, even when a later face answers |
+
+Measured on macOS (matplotlib 3.10.9, Lato absent, Arial installed): `findfont()` on either stack
+emits **zero** warnings, and rendering with the rcParams stack emits zero as well — but rendering text
+through `FontProperties(family=MEASURED_FONT_STACK)`, which is what a step's own measurements do,
+emits one per missing face. A real run of the OECD time-use step produced **724** of them, all
+`Liberation Sans` — a face that earns its place, being the metric-compatible Arial substitute on Linux
+and absent on a Mac. So the noise is real; a blanket `setLevel(logging.ERROR)` is still wrong, because
+it takes `Falling back to DejaVu Sans` with it, and that one says a stack failed and every measurement
+just moved ~15% against what gets drawn.
+
+**Then assert the invariant, because no filter can protect it.** Silence a declared face and you have
+also silenced the case where *every* face of a stack is declared and missing; and Lato-first has its
+own trap — a machine that HAS Lato installed draws Lato while the measured stack still resolves Arial,
+and nothing warns at all. What the allowances actually depend on is one line:
+
+```python
+_DRAWN_FACE, _MEASURED_FACE = (
+    findfont(FontProperties(family=EMITTED_FONT_STACK)),
+    findfont(FontProperties(family=MEASURED_FONT_STACK)),
+)
+assert _DRAWN_FACE == _MEASURED_FACE, f"draws {Path(_DRAWN_FACE).name}, measures {Path(_MEASURED_FACE).name}"
 ```
 
-That is the *only* warning this logger emits, and it is the one you cannot afford to lose: it says a
-stack failed and every measurement in the step just moved ~15% against what gets drawn, which is the
-exact failure this section exists to prevent. So `setLevel(logging.ERROR)` — or a filter over "not
-found" — suppresses nothing you actually have, in exchange for the single notice that matters. If you
-inherit either, delete it rather than narrow it.
+It passes on a Mac without Lato (Arial/Arial) and on a Linux box with neither Arial nor Lato
+(DejaVu/DejaVu — different face, still self-consistent), and fails loudly on the two drifting machines
+above. Prefer it to reading logs: a warning nobody reads is not a check.
 
 Pass the measured stack to every measurement, so measuring and drawing cannot drift whatever a
 machine has installed:


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Nine lessons from a chart refresh, split out of #6678 so the chart and the shared tooling get separate reviews. Three of them are the same shape: **a property of the SVG import that nothing in the workflow reset**, so every frame built this route inherited it, and it read as "how these frames are" rather than as a defect. All three were reported by a designer as "the frame is hard to work with", not caught by a check.

## `restyle_static_import.js` — three things it now does

- **Crops the chart frame to the plot's own ink.** An import arrives the size of the SVG canvas, which *is* the artboard, so the plot has no box of its own: hovering it highlights a rectangle indistinguishable from the artboard's, it cannot be grabbed as a unit, and `verify_page.js`'s `box-alignment` and `gap` rows measure the canvas and report **negative insets** (-70 / -79 on the frame this came from). The crop moves nothing — origin onto the ink, children shifted back by the same offset, verified at max channel difference **0** across a whole 850×1095 frame — and those rows then read the real numbers (18.35 / 17.01). Two refinements since: it **snaps** a side that lands within a pixel of the header's content column, because a TEXT node's box carries its advance width rather than its glyphs and cropping to ink alone left a frame at 15.92..833.88 against a 16..834 column — which `box-alignment` fails at its 0.05 tolerance; and it runs **last**, after the legend reflow, since a reflow that moves the last run's right edge afterwards would leave the frame describing bounds that no longer hold; and it intersects each leaf against its `clipsContent` ancestors, because a path running past one of matplotlib's axes clip paths — a clipping frame after import — would otherwise widen the crop with geometry that paints no pixels. It measures the **painted** extent rather than the centreline — `absoluteBoundingBox` excludes strokes, so a 3px centered rule on the plot's edge was contributing a box 1.5px short on each side, the same mistake `verify_page.js` documents one file over. It also counts only nodes that actually render — `visible: false`, zero inherited opacity and Figma's all-`NONE`-winding clip-path artifacts are dropped, while a stroked path with no live fill is kept, matching what `verify_page.js`'s dead-fill row already spares.
- **Inserts it at the bottom of the z-order** rather than appending. Artboard-sized and on top, it covered the header and footer, so every double-click on the subtitle or the Note descended into `figure_1` instead of selecting the text.
- **Switches the frame's fill on**, to the clone's own canvas paint and bound style. An import's fill arrives `visible: false`, and a frame with no visible fill is not a hit target over its empty area.

It also strips an **unpainted** background patch, where the guard was fills-only. Such a patch hides nothing, so leaving it looked free — but it is artboard-sized, so it becomes the chart's bounding box. Stroke-only patches (the axes spine) are still kept, which is what that guard was protecting.

## Two refusals, and a table entry that was wrong

**A blank import used to destroy the chart it replaced.** The old chart was removed 130 lines before
emptiness was discoverable, where a falsy `inkBoxes.length` quietly skipped the crop and reported a
size like a normal run. The render predicate is hoisted above the replacement now — after the patch
strip and slot removal, both of which take ink away — and a blank import throws while the old chart is
still on the page. The restructure exposed a second silent path, ink that exists but is entirely
clipped away, which throws too. **This changes behaviour on a real run**: a genuinely blank import now
aborts the `use_figma` call rather than producing a frame. That is the intent; nobody has hit it live.

**`TEXTS.md` marked the licence row as surviving `characters`, and it is the row that fails
invisibly.** Its runs are Medium@0-15, Bold@15-20, Medium@20-35, Bold@35-… — the propagated first-run
face is Medium, so *both* Bold ranges are lost, and it is the hardest of the four rows to catch by eye
precisely because the winning face is the one most of the row already wanted. The rule of thumb was
itself only true of the three Bold-first rows, and is now stated generally: the runs that go wrong are
the ones whose face differs from the **first run's**.

## Two corrections to recorded numbers

- **`reference/TEXTS.md`: three footer slots collapse after `characters`, not two.** The file named `Data source:` and `Note:`; measured on the Vertical template the tagline collapses too, and the licence row survives *only* because its first run is Medium — so a pass that re-applies the bold ranges and trusts the rest passes on the one row that proves nothing and fails the other three. Now a table of all four rows with their measured runs, and the point stated: the runs that go wrong are the ones that are **not** bold.
- **`create-static-viz/TEMPLATES.md`: the font-ratio table conflated two rulers 15% apart.** "vs. a step measuring in Arial/DejaVu" reads as one column and is two — a step whose figure draws Arial but whose `FontProperties()` resolves DejaVu measures a font it never draws, and the percentages then look like they should be 1.0. Split per font, with a Lato **Bold** row added: 6.6% against Arial Bold, enough to make a mixed-weight footer row fail its own step's fit assertion while setting correctly in the frame.

## `create-static-viz` gains three sections, and loses a stale exception

**The exception is the important part.** The skill told operators that `box-alignment`, `gap` and
`margins` "cannot pass on this route" — true of an uncropped, canvas-sized frame, and no longer true,
because the patch strip and the crop in this PR are exactly what make those rows measure the plot. Left
as written it would have taught people to ignore real misalignments and overflows. It now says the rows
are **live**: `box-alignment` must be exact, `margins` must pass, and only `gap` keeps a caveat.

**Two font stacks, not one.** matplotlib copies `font.sans-serif` into the SVG's `font-family`
*verbatim* while resolving the first installed entry for its own layout — so a step can name **Lato**
first without measuring in it. The import then arrives in the template's own typeface (measured: 156
Lato Regular + 8 Lato Bold, with no font pass run), which makes the restyle's font pass **and** the
anchor pass that exists only to undo its label drift no-ops, and leaves the parked reference copy
looking like the deliverable. Without it Figma resolves none of `Arial, Helvetica, DejaVu Sans` and
substitutes **Inter**, which is wider: one 850-wide chart overran its canvas by 39px that way. The trap
is ordering — seaborn's `set_style` *replaces* the list, so the emitted stack has to be re-asserted
after it, and the step keeps measuring in what is actually installed.

This section first shipped with an instruction to quieten `matplotlib.font_manager`, on the theory that
asking for an absent Lato logs a miss. **It does not.** Measured (matplotlib 3.10.9, Lato absent, Arial
installed): resolving either stack emits **zero** WARNING records — a skipped face is scored at DEBUG,
1,056 records across two lookups, which never surfaces. The logger emits one warning shape, only when a
whole family list resolves to nothing: `Falling back to DejaVu Sans` — the notice that a stack failed
and every measurement moved ~15% against what is drawn. The `setLevel` therefore suppressed nothing it
had, in exchange for the one thing it needed. It is gone, with the measurement recorded and an
instruction to delete an inherited one rather than narrow it.

**Take the band's edges from the template's own frames.** `verify_page.js` measures the plot against
the header auto-layout's bottom and the footer's top, so a band derived as `subtitle_y + n × line_px`
is judged against datums it never used: 4.35px and 3.01px of line-box slack on the 2026 Vertical, which
reads as `gap` 18.35 / 17.01 against a 12–16 target on a page whose own assertion says 14.

## Two more silent-coverage findings

- **`text-floor` fails on the templates themselves.** Vertical and Horizontal set the tagline and
  licence rows at **11px**, under the row's 12px floor for the format — measured in the template, not in
  a page built from it. Two FAILs there are inherited furniture; `CHECKS.md` now says so, and says to
  check that the failing ranges are exactly those two rows before dismissing them.
- **`label__` is a prefix, and a suffix reads as unnamed.** A group named `country__label` is invisible
  to every row that resolves through the name — quietly: `label-contrast-on-background` reported "no
  `label__*`/`annotation__*` text sits on the frame's own background" on a chart carrying 26 country
  labels, a SKIPPED row indistinguishable from one on a chart that genuinely has none.

## The font-logging advice, corrected twice

Worth reading as a sequence, because it is a lesson about probes rather than about fonts. The section
first shipped telling steps to quieten `matplotlib.font_manager` (the miss for an absent Lato is
expected); review called that out; I measured `findfont()`, saw **zero** warnings on either stack, and
rewrote it to say **delete** the silencer. Review pushed back with a reproduction, and it was right:
`font_manager` has **two** warning sites, and a `findfont()` probe reaches only one.

| Site | Message | Fires when |
|---|---|---|
| `_findfont_cached` | `... not found. Falling back to DejaVu Sans.` | a family list resolves to **nothing**, via `findfont()` |
| `_find_fonts_by_props` | `Font family 'X' not found.` | text is **drawn** with an explicit family list — per missing face, even when a later face answers |

A real run of the OECD step emits **724** of the second kind, all `Liberation Sans`. So the advice is
now: filter the per-face misses for declared alternatives, never blanket-silence (that takes the
15%-drift signal with it), and — because no filter can protect it — **assert
`findfont(EMITTED) == findfont(MEASURED)` at import**. That catches the two drifts nothing warns
about: a stack whose every face is declared and missing, and a machine that HAS Lato, which draws Lato
while measurement resolves Arial. A warning nobody reads is not a check.

## The script has a harness now, and it has teeth

Four rounds found a real defect in `restyle_static_import.js`, and **three were in code the previous
round had just added** — a crop taken before the legend reflow, an ink union counting nodes that paint
nothing, a clip intersection nulling every zero-height gridline, and one excluding overflow the script
then un-hid. That pattern is the argument for a test, not the individual bugs.

`test_restyle_static_import.js` follows `test_verify_page.js`: it fakes the `figma` global, injects a
test CONFIG into the committed file, and runs it verbatim across eight scenarios — patch stripping
(unpainted goes, the stroke-only spine stays), the crop's box and that the ink does not move in
absolute terms, non-rendering nodes excluded, inner-clip overflow trimmed while root overflow is kept,
the content-column snap and its 1px limit, reflow-before-crop ordering, the parked reference left
untouched, and z-order / fill style / landing-page reporting. **24/24 pass.**

Then it was **mutation-tested** — each guarantee re-broken in a copy of the script — and the first
version *missed* one: the zero-area case had no clipping ancestor, so the comparison it guards never
ran and the old `>` passed every check. A harness that passes on the broken code is decoration, so
that phase now lives **inside the harness**: `node test_restyle_static_import.js` runs the scenarios
and then re-breaks all nine guarantees, requiring each to fail. **35/35 scenarios, 28/28 mutations, and 35/35 checks provably breakable** — a third phase
subtracts the checks each mutant breaks from the checks the scenarios declare, and reports anything
left as DECORATION rather than letting it pass. A mutation whose target string no longer matches reports STALE and fails the run, so a
refactor cannot quietly drop coverage.

It has now earned that second phase **twice over**, and both times by exposing a scenario that was
decoration: one asserted the frame's fill by style id alone and passed while the fill was left
`visible: false` (exactly the "not a hit target" defect that pass exists to fix), and the
reflow-ordering scenario put its far legend run *inside* the bar's own span, so the ink ended at the
same x whichever order ran. Neither could fail. A third turned up when the coverage phase was
written — "the old chart is still on the frame" counted children named `chart`, and the replacement is
also named `chart`, so the count was 1 either way. Three decorative checks in one suite is why the
phases live in the harness rather than in anyone's notes, and why an excused check is a claim to
re-test: the one entry that was excused turned out to be reachable after all, by a two-edit mutation.

One subtlety kept in the mutation list rather than lost: the stroke outset **subsumes** the zero-area
fix, since a stroked leaf no longer has a degenerate box, so reverting `>=` alone is invisible. That
entry reverts both and reproduces the pre-outset code; the `>=` stays as the correct
empty-intersection test, demoted to defensive with a note saying so.

## What eight review rounds looked like

P1 → P2 → P2 → P2×3 → P2 → P2×2 → P2×2 → P3. Eight rounds, twelve real findings, and **seven of them
were in code a previous round had added** — a crop before the reflow, an ink union counting nodes that
paint nothing, a clip intersection nulling every gridline, one excluding overflow the script then
un-hid, a centreline crop, a blank-import guard 130 lines too late, and its clipped-away twin left on
the wrong side of the swap. That pattern, not any single bug, is what the harness answers.

The last three findings were caught by the suite rather than by reading, and the final one was a stale
word in a sentence — which is where this stops. The remaining risk has moved somewhere another review
round cannot reach: see Open.

## Verification

- `verify_docs.py --structure` clean on both skills, and both size budgets hold: `create-figma-chart`
  SKILL.md 47,013 / 64,000 and GUIDELINES.md 51,946 / 80,000 (combined 98,959 / 145,000);
  `create-static-viz` SKILL.md **29,989 / 30,000** and TEMPLATES.md 22,888 / 25,000. That 11 bytes of
  slack is why the `gap` detail is a pointer to TEMPLATES.md rather than a second copy of it
- `test_verify_page.js` 424 checks, `test_diff_against_template.js` 75, `test_inline_script.py` 76 — all pass
- the edited script parses (wrapped in an async IIFE, since `node --check` cannot accept these files) and sits at 20% of the `use_figma` paste cap
- `ruff` and `codespell` clean on both skills
- every behaviour above was measured on a live frame before being written down; the pixel-identity claims are screenshot diffs, not assertions

## Open

- **The `gap` question is not settled, only measured.** Whether 18.35 / 17.01 against a 12–16 target is
  acceptable, or the band should be re-derived so the row passes, is the design team's call — nobody has
  asked them. The chart in #6678 ships as measured.
- **Nothing in eight rounds has touched real Figma**, and two changes here alter live behaviour: a
  blank import and a fully-clipped one now **abort the whole `use_figma` call** rather than producing a
  frame. That is the intent — the alternative destroyed the chart being replaced — but the first real
  run is the only thing that can confirm it, along with the mock's remaining assumptions (`strokeAlign`
  defaults, and whether Figma's SVG importer emits CENTER strokes).
- **Nothing cross-checks this documentation against itself.** `TEXTS.md` states one fact in a table, a
  paragraph and a heading, and was half-corrected twice — the second time leaving the line an operator
  actually skims. `verify_docs.py` covers links, reachability and budgets, not internal consistency, so
  a partial prose fix stays silently partial in a way the script's mutation suite would not allow.
- The crop's behaviour is now covered by a harness (below) rather than by reasoning, but that harness
  is a **mock**: it validates control flow and arithmetic against the Plugin API's documented shapes,
  never Figma's actual behaviour. The clip walk still has not run on a live frame, and the frame this
  PR came from cannot exercise it — it has no phantom geometry, no root overflow and no missing axes.
- `ruff` reports one pre-existing F541 in `review-explorer-mdim-mapping/scripts/build_review.py`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






