### PR TITLE
🐛🤖 chart-critic: stop re-reporting what has been fixed, explained or already said

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,6 @@ gh pr edit <number> --body "..."
 
 **Cleaning up after merge**: `etl pr-clean` lists local branches whose PR was merged or closed (it checks the GitHub PR state, so squash-merges are detected), then deletes the selected branch(es). For branches created in a worktree (`etl pr "..." --worktree`), it also removes the worktree and copies that worktree's Claude sessions back into the main repo's `~/.claude/projects/` dir so they stay resumable.
 
-**Post `@codex review` as a separate PR comment** (not in the PR description) when the PR is ready for a review pass. Do not repost it after every push/update unless the user asks or the changes are substantial enough to warrant a fresh review.
-
 To run the full **review → wait → fix → re-review** loop hands-off (and watch CI) in the background while you keep working, use the `pr-babysitter` skill — it spawns a background agent that triggers Codex, judges and fixes the valid findings, and loops to a cap (never merges). Fire it proactively after pushing a substantial chunk to a PR branch.
 
 ### Commit Message Emojis

--- a/apps/chart_critic/bundle.py
+++ b/apps/chart_critic/bundle.py
@@ -33,7 +33,30 @@ GRAPHER_URL = "https://ourworldindata.org/grapher"
 
 # Fields worth showing the model. The long forms (titleLong, citationLong, fullMetadata) add
 # tokens without adding judgement.
-COLUMN_FIELDS = ("titleShort", "descriptionShort", "unit", "shortUnit", "timespan", "type", "conversionFactor")
+#
+# ``descriptionKey`` and ``descriptionProcessing`` are here for one specific reason: they are where
+# OWID documents the data that *looks* wrong and is not. The critic filed the Central African
+# Republic's life expectancy oscillating between 14.7 and 57.4 years as an error (owid/etl#6779);
+# it is the UN's deliberate crisis-mortality adjustment, and the investigation ended in
+# owid/etl#6813 writing that explanation into the indicator's key facts — for readers, who hit the
+# same spike. Showing the model those fields closes the loop: the answer to a false positive is to
+# document the data, and the documentation is then what stops it being raised again. The
+# alternative, a list of findings to suppress, would be maintained for the critic alone and would
+# leave the reader with the unexplained spike.
+#
+# Measured over eight charts: ~520 extra input tokens each, about $0.0004 a chart. The render
+# dominates the bill by an order of magnitude.
+COLUMN_FIELDS = (
+    "titleShort",
+    "descriptionShort",
+    "descriptionKey",
+    "descriptionProcessing",
+    "unit",
+    "shortUnit",
+    "timespan",
+    "type",
+    "conversionFactor",
+)
 CHART_FIELDS = ("title", "subtitle", "note", "xAxisLabel", "yAxisLabel")
 
 # Cap how many indicators of a wide chart get summarised, so a 100-column chart cannot blow up

--- a/apps/chart_critic/cli.py
+++ b/apps/chart_critic/cli.py
@@ -41,9 +41,11 @@ from apps.chart_critic.critic import (
     DEFAULT_MODEL,
     FALLBACK_PRICES,
     build_agent,
+    claim_tokens,
     format_views,
     issue_params,
     prompt_parts,
+    same_claim,
 )
 from apps.utils.llms.costs import estimate_llm_cost
 from etl.db import read_sql
@@ -214,28 +216,39 @@ def _link_keys(slug: str, params: str) -> set[str]:
         return keys
 
 
-def _claim_tokens(claim: str) -> set[str]:
-    # Crude singular/plural folding. Without it "the unit for all three indicators is incorrectly
-    # set to 'doses'" and "the indicator unit is incorrectly set to 'doses'" scored below the
-    # merge threshold and were reported as two findings.
-    return {w.rstrip("s") for w in re.findall(r"[a-z0-9]{4,}", claim.lower())}
-
-
 def _merge(issues: list[dict[str, Any]], new: dict[str, Any]) -> None:
     """Fold a finding into the list, merging it with the same finding from an earlier pass.
 
     The model rewords freely between passes — "life expectancy of around 18–20 years" and
-    "under 20 years" are one finding — so matching on a prefix counts them separately. Overlap
-    of the significant words is crude but survives the rewording.
+    "under 20 years" are one finding — so matching on a prefix counts them separately.
+    :func:`critic.same_claim` is the shared notion of "the same finding", and the digest
+    recognises what it has already posted with the same test.
     """
-    tokens = _claim_tokens(new["claim"])
+    tokens = claim_tokens(new["claim"])
     for existing in issues:
-        other = _claim_tokens(existing["claim"])
-        overlap = len(tokens & other) / max(len(tokens | other), 1)
-        if existing["kind"] == new["kind"] and overlap >= 0.4:
+        if existing["kind"] == new["kind"] and same_claim(tokens, claim_tokens(existing["claim"])):
             existing["passes"] += 1
             return
     issues.append(new | {"passes": 1})
+
+
+def _resolve_cache_ttl(cache_ttl: float | None, changed_since: int | None) -> float:
+    """How long a cached bundle stays fresh, when the caller did not say.
+
+    A ``--changed-since`` sweep must not replay a cached bundle, and the reason is that
+    selection's whole premise: a chart is in it *because* its configuration changed inside the
+    window, so a bundle fetched inside that same window describes the chart as it was *before*
+    the change. With a daily cron and a 24-hour TTL the previous run's bundle is always a few
+    minutes inside the TTL, so it is not an edge case but the normal path — every finding a
+    report on yesterday's chart. It reached the channel: a subtitle fixed during the day was
+    flagged again the next morning, on a chart whose fix is what nominated it for review.
+
+    It is ~17 charts a day, so re-fetching them costs nothing worth saving. Any explicit
+    ``--cache-ttl`` still wins, including for a sweep of a hand-picked list.
+    """
+    if cache_ttl is not None:
+        return cache_ttl
+    return 0.0 if changed_since is not None else cache.DEFAULT_TTL_HOURS
 
 
 def _review_one(
@@ -457,9 +470,12 @@ def _review_one(
 @click.option(
     "--cache-ttl",
     type=float,
-    default=cache.DEFAULT_TTL_HOURS,
-    show_default=True,
-    help="Hours a cached chart bundle stays fresh. Use -1 to keep bundles indefinitely.",
+    default=None,
+    help=(
+        f"Hours a cached chart bundle stays fresh [default: {cache.DEFAULT_TTL_HOURS}, "
+        "or 0 with --changed-since, which reviews charts because they just changed]. "
+        "Use -1 to keep bundles indefinitely."
+    ),
 )
 def cli(
     slugs: str | None,
@@ -480,7 +496,7 @@ def cli(
     dry_run: bool,
     no_cache: bool,
     clear_cache: bool,
-    cache_ttl: float,
+    cache_ttl: float | None,
     run_eval: bool,
     changed_since: int | None,
     include_data_updates: bool,
@@ -494,6 +510,8 @@ def cli(
 
     if cheap:
         model = CHEAP_MODEL
+
+    cache_ttl = _resolve_cache_ttl(cache_ttl, changed_since)
 
     if run_eval:
         # Five passes, because that is what was measured to reach 8/8: at two passes the two

--- a/apps/chart_critic/critic.py
+++ b/apps/chart_critic/critic.py
@@ -1,6 +1,6 @@
 """Ask a model whether a published chart would mislead a reader.
 
-The prompt is doing the work here, so the three things it must contain are worth stating:
+The prompt is doing the work here, so what it must contain is worth stating:
 
 1. **Today's date.** Without it the model reasons from its own sense of "now" and flags recent
    data as future-dated. That produced a false positive on ``weekly-growth-covid-deaths``
@@ -15,6 +15,13 @@ The prompt is doing the work here, so the three things it must contain are worth
    to make a judgement rather than hedge.
 4. **A reader-impact field.** A finding that cannot name what a reader would wrongly conclude
    is usually noise, and asking for it up front suppresses more of it than any threshold.
+5. **That our own documentation of the data outranks the model's suspicion.** The bundle carries
+   the indicator's key facts and processing notes, which is where a genuine-but-alarming value is
+   explained; a discontinuity the metadata accounts for is documented, not a finding. This is the
+   route a false positive is closed by — see ``COLUMN_FIELDS`` in ``bundle.py``. Deliberately
+   stated as a rule about the metadata and not as a list of cases: an earlier draft named the
+   Central African Republic here, which suppressed that one chart by name and would have taught
+   nothing about the next one.
 
 What this catches that statistical detection cannot: an error that is stable over time and
 statistically unremarkable, where the only tell is knowing something about the world. The
@@ -26,6 +33,7 @@ tests are ``apps/anomalist``'s job and are deliberately not duplicated here.
 from __future__ import annotations
 
 import datetime as dt
+import re
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -137,6 +145,14 @@ For each issue, set chart_params to the grapher query parameters that put the pr
 screen — the entity and time range you are talking about — so a reviewer sees it immediately
 rather than the chart's default view.
 
+The indicator's key facts and processing notes are our own documentation of the data, written
+for readers. They are where a value that looks impossible is explained — a crisis adjustment
+added on top of a modelled series, a survey redesign, a deliberate aggregation. An extreme value
+or a discontinuity that the metadata accounts for is documented rather than wrong: say nothing
+about it. Judge it against what the metadata actually says, not against whether the number looks
+extreme — an explanation that does not cover the value you are looking at is not a licence to
+dismiss it.
+
 Your knowledge of definitions and thresholds may be out of date, and the chart's own metadata
 is more current than you are. Do not flag a definition, a poverty line, a classification or a
 unit convention merely because it differs from what you remember — flag it only when the chart
@@ -145,6 +161,33 @@ that the International Poverty Line is not $3 per day, when it was revised to ex
 
 Do not invent problems. An ordinary chart has no issues, and returning an empty list is the
 expected outcome for most charts."""
+
+
+# How much of a claim's significant words two findings must share to be the same finding. The
+# model rewords freely — "the subtitle states prices are in constant 2023 US$" and "the chart
+# subtitle states prices are measured in constant 2023 US$" are one claim — so identity has to
+# survive rewording rather than be a hash of the sentence.
+#
+# One definition, used in the two places that have to agree: merging the repeat passes of a
+# single run, and recognising in the digest what has already been posted. They disagreed for a
+# while, and the consequence reached the channel — a finding merged across passes within a run
+# was posted again the next day under its new wording, on a chart that had been fixed in between.
+CLAIM_OVERLAP = 0.4
+
+
+def claim_tokens(claim: str) -> set[str]:
+    """The significant words of a claim, crudely singular-folded.
+
+    Without the folding, "the unit for all three indicators is incorrectly set to 'doses'" and
+    "the indicator unit is incorrectly set to 'doses'" scored below the threshold and were
+    reported as two findings.
+    """
+    return {w.rstrip("s") for w in re.findall(r"[a-z0-9]{4,}", claim.lower())}
+
+
+def same_claim(tokens: set[str], other: set[str]) -> bool:
+    """Whether two claims, reduced to :func:`claim_tokens`, say the same thing."""
+    return len(tokens & other) / max(len(tokens | other), 1) >= CLAIM_OVERLAP
 
 
 def issue_params(target_params: str, issue: dict) -> str:

--- a/apps/chart_critic/digest.py
+++ b/apps/chart_critic/digest.py
@@ -10,8 +10,9 @@ Three things keep the digest worth reading, and all three are about restraint:
 
 - **It deduplicates by indicator, not by chart.** One bad column of one ETL step produced the same
   finding on three separate charts; a dataset refresh would produce it on hundreds.
-- **It remembers what it has posted.** Without state, day two repeats day one and the channel
-  learns to skip it inside a week.
+- **It remembers what it has posted**, and remembers it by what the claim says rather than by how
+  it was worded — the model rewords freely, and a state file keyed on the sentence let day two
+  repeat day one anyway. Without either, the channel learns to skip the digest inside a week.
 - **It says nothing when there is nothing.** No daily heartbeat. A digest that only speaks when it
   has something is one people keep reading.
 """
@@ -27,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 from slack_sdk.errors import SlackClientError
 from structlog import get_logger
 
-from apps.chart_critic.critic import format_views
+from apps.chart_critic.critic import claim_tokens, format_views, same_claim
 from etl.paths import CACHE_DIR
 
 if TYPE_CHECKING:
@@ -244,7 +245,7 @@ def _indicators(facts: dict[str, dict[str, Any]] | None, slug: str) -> list[str]
     return [str(path) for path in got]
 
 
-def _fingerprint_keys(slug: str, issue: dict[str, Any], facts: dict[str, dict[str, Any]] | None = None) -> list[str]:
+def _dedup_keys(slug: str, issue: dict[str, Any], facts: dict[str, dict[str, Any]] | None = None) -> list[str]:
     """Every identity under which this finding should be recognised, across days and charts.
 
     One key per indicator for a data-level finding, rather than one key for the chart's whole
@@ -253,55 +254,102 @@ def _fingerprint_keys(slug: str, issue: dict[str, Any], facts: dict[str, dict[st
     identical finding still takes two of the five digest slots. Matching on *any* shared indicator
     is what "one defective column is one finding" actually requires.
 
-    The claim's own significant words are in every key, so two different problems on charts that
-    happen to share an indicator do not collapse into each other.
-
     Chart-level findings stay keyed by slug: a wrong subtitle really is specific to that chart
     even when the data behind it is shared.
+
+    The key deliberately carries no part of the claim. It used to carry the claim's significant
+    words, which made the key change whenever the model reworded the same finding — and it rewords
+    constantly, so a claim posted yesterday came back as a new key today and was posted again.
+    What the claim *says* is compared separately, with :func:`critic.same_claim`, so two different
+    problems on charts sharing an indicator still do not collapse into each other.
     """
-    words = sorted({w.rstrip("s") for w in re.findall(r"[a-z0-9]{5,}", issue.get("claim", "").lower())})
-    tail = f"{issue.get('kind', '')}:{'-'.join(words[:8])}"
-    indicators = _indicators(facts, slug) if issue.get("kind") == "data" else []
-    return [f"{i}:{tail}" for i in indicators] or [f"{slug}:{tail}"]
+    kind = str(issue.get("kind", ""))
+    indicators = _indicators(facts, slug) if kind == "data" else []
+    return [f"{i}:{kind}" for i in indicators] or [f"{slug}:{kind}"]
 
 
-def load_state() -> dict[str, str]:
+def load_state() -> dict[str, list[dict[str, Any]]]:
+    """What has been posted, as ``{key: [{"words": [...], "date": "YYYY-MM-DD"}, ...]}``.
+
+    The words are :func:`critic.claim_tokens` of the claim, kept rather than a hash of it because
+    recognising the same finding tomorrow means comparing what it says, not whether it was worded
+    identically.
+    """
     if not STATE_PATH.exists():
         return {}
     try:
-        return json.loads(STATE_PATH.read_text())
+        raw = json.loads(STATE_PATH.read_text())
     except json.JSONDecodeError:
         return {}
+    return _upgrade(raw) if isinstance(raw, dict) else {}
 
 
-def save_state(state: dict[str, str]) -> None:
+def _upgrade(raw: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Read the older state format as well as the current one.
+
+    The first format put the claim's words *in* the key —
+    ``<indicator-or-slug>:<kind>:<eight-words>`` mapped to a date — which is the bug this
+    replaced. But the file is the only record of what the channel has already seen, so the old
+    keys are read back into the current shape rather than dropped: their words become the claim
+    they stood for, and yesterday's findings stay suppressed instead of all being posted once more
+    on the day this ships.
+
+    Matching against a migrated entry is weaker than against a current one, because the old key
+    kept only the eight alphabetically-first words of five characters or more: the stored words
+    are a diluted sample of the claim, so a *reworded* repeat of a pre-migration finding can
+    still slip through once. That resolves itself — every finding posted from now on is recorded
+    in full — and it is a better floor than dropping the file and re-posting everything in it.
+    """
+    state: dict[str, list[dict[str, Any]]] = {}
+    for key, value in raw.items():
+        if isinstance(value, list):
+            state.setdefault(key, []).extend(value)
+            continue
+        head, _, words = str(key).rpartition(":")
+        if head:
+            state.setdefault(head, []).append({"words": [w for w in words.split("-") if w], "date": str(value)})
+    return state
+
+
+def save_state(state: dict[str, list[dict[str, Any]]]) -> None:
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(json.dumps(state, indent=1, sort_keys=True))
 
 
 def new_findings(
-    results: list[dict[str, Any]], state: dict[str, str], facts: dict[str, dict[str, Any]] | None = None
+    results: list[dict[str, Any]],
+    state: dict[str, list[dict[str, Any]]],
+    facts: dict[str, dict[str, Any]] | None = None,
 ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
     """Findings not posted before, best first.
 
     Deduplicated by indicator for data-level findings and by chart for chart-level ones — pass
     ``facts`` from :func:`chart_facts` to get the former; without it everything falls back to
     per-chart, which over-reports.
+
+    "Already posted" is a question about what the claim says, not about how it was worded, so a
+    finding is suppressed when its claim overlaps one already recorded under any of its keys —
+    the same test :func:`cli._merge` uses to fold the repeat passes of a single run together.
     """
     out: list[tuple[dict[str, Any], dict[str, Any]]] = []
-    seen: set[str] = set()
+    # What each key has already seen, from the state file and from this run's own findings.
+    seen: dict[str, list[set[str]]] = {
+        key: [set(claim.get("words") or []) for claim in claims] for key, claims in state.items()
+    }
     order = {"high": 0, "medium": 1, "low": 2}
     ranked = sorted(
         ((r, i) for r in results for i in r["issues"]),
         key=lambda ri: (order.get(ri[1].get("severity", "low"), 3), -ri[0].get("views", 0)),
     )
     for result, issue in ranked:
-        keys = _fingerprint_keys(result["slug"], issue, facts)
-        # Any overlap counts as already-known: the same defect on a second chart sharing one
-        # indicator is not news, even though the two charts are not the same chart.
-        if any(k in state or k in seen for k in keys):
+        keys = _dedup_keys(result["slug"], issue, facts)
+        tokens = claim_tokens(issue.get("claim", ""))
+        # A match under any one key counts as already-known: the same defect on a second chart
+        # sharing one indicator is not news, even though the two charts are not the same chart.
+        if any(same_claim(tokens, before) for key in keys for before in seen.get(key, [])):
             continue
-        seen.update(keys)
+        for key in keys:
+            seen.setdefault(key, []).append(tokens)
         out.append((result, issue))
     return out
 
@@ -396,14 +444,20 @@ def format_slack(
 
 def stamp(
     findings: list[tuple[dict[str, Any], dict[str, Any]]],
-    state: dict[str, str],
+    state: dict[str, list[dict[str, Any]]],
     facts: dict[str, dict[str, Any]] | None = None,
-) -> dict[str, str]:
+) -> dict[str, list[dict[str, Any]]]:
     """Record what was posted. ``facts`` must be the same mapping :func:`new_findings` used —
-    a key written per-chart and looked up per-indicator matches nothing, and the digest would
+    a claim written per-chart and looked up per-indicator matches nothing, and the digest would
     re-post every finding every day."""
     today = datetime.now(timezone.utc).date().isoformat()
     for result, issue in findings[:MAX_FINDINGS]:
-        for key in _fingerprint_keys(result["slug"], issue, facts):
-            state[key] = today
+        tokens = claim_tokens(issue.get("claim", ""))
+        for key in _dedup_keys(result["slug"], issue, facts):
+            claims = state.setdefault(key, [])
+            # The same claim can arrive under a key that already holds a reworded version of it,
+            # from an earlier day or from another chart sharing the indicator. Recording it again
+            # would grow the file without changing any answer.
+            if not any(same_claim(tokens, set(claim.get("words") or [])) for claim in claims):
+                claims.append({"words": sorted(tokens), "date": today})
     return state

--- a/apps/chart_critic/fixtures.py
+++ b/apps/chart_critic/fixtures.py
@@ -22,14 +22,19 @@ Two honest caveats:
   worth treating as a regression rather than re-running, and that one case is marked ``flaky``
   and left out of the gate.
 
-Measured on 2026-08-31 with ``google:gemini-3.7-flash``:
+Measured with ``google:gemini-3.7-flash``:
 
-===========  ====================  =================================
-passes       result                cost
-===========  ====================  =================================
-2            6/8 (2/4 errors)      $0.05
-5            **8/8 (4/4 errors)**  $0.22
-===========  ====================  =================================
+===========  ==========  ====================  ======
+date         passes      result                cost
+===========  ==========  ====================  ======
+2026-08-31   2           6/8 (2/4 errors)      $0.05
+2026-08-31   5           **8/8 (4/4 errors)**  $0.22
+2026-09-04   5           **9/9 (3/3 errors)**  $0.24
+===========  ==========  ====================  ======
+
+The last row is with the indicator's ``descriptionKey`` and ``descriptionProcessing`` in the
+bundle, and it is also the first run in which the flaky COVID case landed — one run is not
+evidence that it stopped being flaky.
 
 Both misses at two passes were the subtlest cases — a subtitle typo and a baseline offset —
 and no number of passes made a clean chart fire. So passes buy recall without costing
@@ -66,7 +71,14 @@ CASES: list[Case] = [
         slug="life-expectancy-vs-gdp-per-capita",
         expect_keywords=["central african", "life expectancy"],
         why="CAR's life expectancy oscillates 52.3 → 31.5 → 50.6 → 40.3 → 18.8 → 57.4 (2018-2023). "
-        "Filed as owid/etl#6779. The indicator sits behind 6 charts and ~199k views/yr.",
+        "Filed as owid/etl#6779. The indicator sits behind 6 charts and ~199k views/yr. "
+        "**This one turned out to be a false positive**: the oscillation is the UN's crisis-mortality "
+        "adjustment, corroborated by the surveys it is built from, and owid/etl#6813 documents it in "
+        "the indicator's description_key rather than changing any data. So this case is expected to "
+        "flip to FAIL once that PR is deployed — measured 2026-09-04, splicing its bullet into the "
+        "bundle takes the finding from 5/5 passes to 0/5. When it flips, move it to the clean section "
+        "as a guard case (clear expect_keywords, fill guards_against) rather than deleting it: it then "
+        "guards the mechanism that a documented anomaly is not a finding.",
     ),
     # ---------- fixed since it was filed, kept as a clean case ----------
     Case(

--- a/tests/apps/test_chart_critic_cli.py
+++ b/tests/apps/test_chart_critic_cli.py
@@ -1,0 +1,18 @@
+"""Which bundles a sweep is allowed to replay."""
+
+from apps.chart_critic import cache
+from apps.chart_critic.cli import _resolve_cache_ttl
+
+
+def test_a_changed_since_sweep_refetches_by_default():
+    # The charts are selected because they changed inside the window a cached bundle covers.
+    assert _resolve_cache_ttl(None, 1) == 0.0
+
+
+def test_an_ordinary_sweep_keeps_the_default_ttl():
+    assert _resolve_cache_ttl(None, None) == cache.DEFAULT_TTL_HOURS
+
+
+def test_an_explicit_ttl_always_wins():
+    assert _resolve_cache_ttl(72.0, 1) == 72.0
+    assert _resolve_cache_ttl(-1.0, 1) == -1.0

--- a/tests/apps/test_chart_critic_digest.py
+++ b/tests/apps/test_chart_critic_digest.py
@@ -76,3 +76,55 @@ def test_a_slack_outage_falls_back_to_the_plain_name(monkeypatch):
     digest.attach_mentions(facts, tag_last_editor=True)
     assert facts["a"]["editor_mention"] == "Pablo Rosado"
     digest._slack_member_id.cache_clear()
+
+
+def test_a_reworded_repeat_of_a_posted_finding_is_not_posted_again():
+    """The two wordings below are what the model actually said on consecutive days about
+    `oil-prices-inflation-adjusted`, and the second was posted because the state key carried the
+    claim's words. They are one finding."""
+    yesterday = _result(
+        "oil-prices-inflation-adjusted",
+        "chart",
+        "The subtitle states prices are in constant 2023 US$, while the indicator metadata specifies constant 2025 US$.",
+    )
+    today = _result(
+        "oil-prices-inflation-adjusted",
+        "chart",
+        "The chart subtitle states prices are measured in constant 2023 US$, contradicting the indicator metadata base year of 2025.",
+    )
+    state = digest.stamp(digest.new_findings([yesterday], {}), {})
+    assert digest.new_findings([today], state) == []
+
+
+def test_two_different_findings_on_one_chart_both_get_posted():
+    """Dedup is per claim, not per chart — a second, unrelated problem is still news."""
+    subtitle = _result("a", "chart", "The subtitle says the values are age-standardized but they are not.")
+    empty = _result("a", "chart", "The chart opens with no entity selected, so a reader sees an empty chart.")
+    state = digest.stamp(digest.new_findings([subtitle], {}), {})
+    assert len(digest.new_findings([empty], state)) == 1
+
+
+def test_the_same_data_finding_on_a_chart_sharing_an_indicator_is_not_news():
+    facts = {
+        "a": {"chart_id": 1, "indicators": ["grapher/energy/energy_mix#coal_share"], "editor_mention": None},
+        "b": {"chart_id": 2, "indicators": ["grapher/energy/energy_mix#coal_share"], "editor_mention": None},
+    }
+    claim = "The UK coal share exceeds 100% in 1913, which is impossible for a share."
+    state = digest.stamp(digest.new_findings([_result("a", "data", claim)], {}, facts), {}, facts)
+    reworded = "Coal share for the United Kingdom is above 100% in 1913, an impossible value for a share."
+    assert digest.new_findings([_result("b", "data", reworded)], state, facts) == []
+
+
+def test_the_old_state_format_still_suppresses_what_it_recorded():
+    """The file on the runner is the only record of what the channel has seen, so the previous
+    format — the claim's words baked into the key — is read rather than dropped."""
+    legacy = {
+        "oil-prices-inflation-adjusted:chart:constant-indicator-metadata-price-specifie-state-subtitle-while": "2026-09-03"
+    }
+    state = digest._upgrade(legacy)
+    today = _result(
+        "oil-prices-inflation-adjusted",
+        "chart",
+        "The chart subtitle states prices are measured in constant 2023 US$, contradicting the indicator metadata base year of 2025.",
+    )
+    assert digest.new_findings([today], state) == []


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The digest re-posted a finding to #we-need-to-correct-it the morning after the chart had been fixed, and a separate one that had been investigated and found to be correct. Three independent causes, one per commit-worthy change; no behaviour change to what the critic looks for.

## 1. A `--changed-since` sweep reviewed charts at their pre-edit state

`--changed-since 1` selects charts *because* their configuration changed in the last 24 hours. The bundle cache keeps a chart for 24 hours. With a daily cron the previous run's bundle is always a few minutes inside the TTL, so the selection criterion and the cache guaranteed each other wrong: every finding was a report on yesterday's chart.

That is what reached the channel — the subtitle of `oil-prices-inflation-adjusted` said "constant 2023 US$" against an indicator on 2025; it was corrected during the day, and the correction is what nominated the chart for the next morning's sweep, which then read the pre-correction bundle and raised it again.

A sweep of just-changed charts now re-fetches (`--cache-ttl` still overrides). It is ~17 charts a day, so nothing worth caching is being given up.

## 2. Dedup was keyed on the model's wording

`digest_state.json` is what stops day two repeating day one, but a finding's key carried the claim's own significant words, and the model rewords every pass:

```
Sep 3  The subtitle states prices are in constant 2023 US$, while the indicator
       metadata specifies constant 2025 US$.
Sep 4  The chart subtitle states prices are measured in constant 2023 US$,
       contradicting the indicator metadata base year of 2025.
```

Two keys, so the state file recognised nothing. Meanwhile `_merge` — which folds the repeat passes of a *single* run together — already had a wording-robust test for "the same finding". Those two notions now share one definition (`critic.same_claim`): the key identifies the *subject* (indicator for a data finding, chart for a chart-level one) and the claim is compared separately.

The state file's format changes accordingly, and old entries are read into the new shape rather than dropped, so nothing already posted comes back on deploy day.

## 3. The model was never shown where we document anomalies

The Central African Republic's life expectancy swinging between 14.7 and 57.4 years was filed as an error (#6779). It isn't one — it is the UN's crisis-mortality adjustment, and #6813 documents it in the indicator's `description_key`, for readers, who hit the same spike.

So the bundle now carries `descriptionKey` and `descriptionProcessing`, and the prompt says that a discontinuity our metadata accounts for is documented rather than wrong. This makes the fix for a false positive be *documenting the data* — which we want anyway — rather than a suppression list maintained for the critic alone, which would leave the reader with the unexplained spike.

Measured on `life-expectancy-vs-gdp-per-capita`, 5 passes each on the same bundle:

| | CAR flagged |
|---|---|
| as published today | 5/5 |
| with #6813's bullet spliced in | 0/5 |

An earlier draft of the prompt named CAR as an example. It worked — and it was a suppression list in prose, silencing that one chart while teaching nothing about the next one, so it is stated as a rule about the metadata instead. Cost: ~520 extra input tokens a chart, about $0.0004.

## Checks

- `etl chart-critic --eval` → **9/9** ($0.24), against 8/8 of nine before (the ninth is the flaky COVID case, which landed this time — one run is not evidence it stopped being flaky).
- New unit tests for the dedup: a reworded repeat, two different findings on one chart, the same finding on a chart sharing an indicator, and the old state format.
- Editing `bundle.py`/`critic.py` invalidates the bundle and review caches by design, so the next run re-fetches and re-reviews once.

## Also here, unrelated to the critic

`CLAUDE.md` no longer tells an agent to post `@codex review` on every PR. Asking for a review pass is the author's call, and the `pr-babysitter` skill still covers it when the loop is wanted.

## Still open

- **The fixture for #6779 will go FAIL** once #6813 is deployed, since the critic will correctly stop reporting CAR. The case says so and says what to do (flip it to a guard case). Doing it here would put the gate red until #6813 lands, so it belongs with that PR.
- **Why the review cache missed** while the bundle cache hit — which is what let a reworded claim exist at all on Sep 4 — is inferred, not confirmed: most likely a manual sweep during Sep 3 refreshed the bundle and cached its passes without stamping the digest state. The runner's `.cache/chart_critic` was not inspected. Either cause is fixed by the two changes above.
- Nobody has checked whether other daily owidbot jobs share the same cron-versus-TTL shape.
