### PR TITLE
📜🤖 Warn that the step and the template disagree about line counts

### DIFF
--- a/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
+++ b/.claude/skills/create-static-viz/reference/WRITING-THE-STEP.md
@@ -378,6 +378,25 @@ with its labels (`Note:`, `Data source:` — singular — the exact tagline and 
 - A caveat about **what the chart claims** cannot go. Move it into the subtitle, which mobile does
   have. Dropping it silently reintroduces an over-claim.
 
+**The step and the template will not agree on how many lines a string takes, and the step is the one
+that reserves the space.** The step measures its own type — 10.5pt here — while the template renders
+the same string at the slot's size, 16px for a subtitle on the 850- and 540-wide templates. Those wrap
+differently, so the line counts can differ, and the step is reserving the chart area against the wrong
+one. It cannot be fixed from the step: it deliberately sets no fonts, so it cannot measure Lato.
+
+What this costs is a surprise on the *next copy edit*, not on the first build. Adding a single
+character — an Oxford comma, in the case that found this — tipped a mobile subtitle from three lines
+to four in the template while the step still reserved three, and the chart's topmost label then sat
+above the header's last line. So after **any** change to a title, subtitle or note, re-read the
+template slot's height in Figma rather than trusting the step's own wrap, and check the header
+clearance on the frame.
+
+Two things make that cheap. The step should reserve the *larger* of the two counts where they differ,
+so the failure mode is a generous gap rather than an overlap. And an orphan — a last line holding a
+word or two — is worth removing at the same time, because it is both a copy defect in its own right
+and the state one character away from adding a line: measure it by cloning the slot, setting
+`textAutoResize = "WIDTH_AND_HEIGHT"` to get the unwrapped width, and comparing against the slot's.
+
 ### Derive every string from the data
 
 Crossover ages, discontinuity positions, the source citation built from `col.metadata.origins` —


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

One lesson from the growth-curves refresh (#6711) that #6818 did not cover.

## The trap

An `export://static_viz` step reserves its chart area by measuring **its own** type — 10.5pt for a subtitle here. The Figma template renders the same string at **the slot's** size, 16px on the 850- and 540-wide templates. Those two wrap differently, so they can disagree about how many lines a title, subtitle or note takes — and it is the step that reserves the space.

It cannot be reconciled from the step, which deliberately sets no fonts (the machine building it may have neither Lato nor Playfair) and so cannot measure what the template will do.

## Why it bites later rather than at build time

The first build looks right, because whoever placed the frame checked it. The surprise arrives on the **next copy edit**. Adding a single character — an Oxford comma, in the case that found this — tipped a mobile subtitle from three lines to four in the template while the step still reserved three, and the chart's topmost label then sat above the header's last line.

## What the section says to do

- After **any** change to a title, subtitle or note, re-read the slot's height in Figma rather than trusting the step's own wrap, and check the header clearance on the frame.
- Reserve the **larger** of the two counts where they differ, so the failure mode is a generous gap rather than an overlap.
- Clear any orphan line at the same time — it is both a copy defect in its own right and the state one character away from adding a line. Measure it by cloning the slot, setting `textAutoResize = "WIDTH_AND_HEIGHT"` for the unwrapped width, and comparing against the slot's.

## Scope

One section added to `create-static-viz/reference/WRITING-THE-STEP.md`, beside the existing text-slot guidance. No script or behaviour changes.

`verify_docs.py --structure --against origin/master` passes on both `create-static-viz` (1,145 substantive lines, 5 files) and `create-figma-chart` (4,604 lines, 25 files); codespell and `make check` clean.

## Not included, because they are already in master

Checked rather than assumed, since two PRs touched these files in the same week:

- The dash-per-segment rendering trap, the `lines.scale_dashes` multiplier, and the resampling recipe — landed in #6711 and survived #6818.
- Stripping `patch_1` whether or not it paints, and inserting the chart at index 0 so the template's text stays double-clickable — landed in #6818, which is exactly this fix. A scan of the 25 most recent dated pages found **1 of 21** static-viz frames still carrying the old structure: `long-run-history-child-mortality`, which belongs to the in-flight #6701 and will correct itself on that branch's next import.
- The footer's growth direction — already documented in `TEXTS.md`, and more precisely than my own notes had it (`constraints.vertical` measured per template: `MIN` on almost all, `MAX` on static mobile 1 alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
