### PR TITLE
📊 Refresh AHDI snapshot metadata (new source URLs and citation)

### DIFF
--- a/snapshots/ahdi/2023-09-08/augmented_hdi.xlsx.dvc
+++ b/snapshots/ahdi/2023-09-08/augmented_hdi.xlsx.dvc
@@ -29,20 +29,16 @@ meta:
 
       By how much did human development improve over the long run? Given the way in which the index has been computed, the conventional logarithmic rate of variation (as in the case of GDP per head) can be used.
     producer: Leandro Prados de la Escosura
-    citation_full: Prados de la Escosura, L. (2021), Augmented Human Development
-      in the Age of Globalisation, Economic History Review.
-    url_main:
-      https://frdelpino.es/investigacion/en/category/01_social-sciences/02_world-economy/03_human-development-world-economy/
-    url_download:
-      https://frdelpino.es/investigacion/wp-content/uploads/2023/02/AHDI_countries_1870-2020.xlsx
-    date_published: 2021
-    date_accessed: 2023-09-08
+    citation_full: 'Leandro Prados de la Escosura (2022), Human Development and the Path to Freedom: 1870 to the Present, Cambridge: Cambridge University Press. https://doi.org/10.1017/9781108769655'
+    url_main: https://frdelpino.es/investigacion/en_gb/world-economy/human-development-world-economy/
+    url_download: https://frdelpino.es/investigacion/wp-content/uploads/2025/11/AHDI_countries_1870-2020_dataset.xlsx
+    date_published: 2022
+    date_accessed: 2026-09-04
     license:
-      url:
-        https://frdelpino.es/investigacion/en/category/01_social-sciences/02_world-economy/03_human-development-world-economy/
+      url: https://frdelpino.es/investigacion/en_gb/world-economy/human-development-world-economy/
       name: Creative Commons BY 4.0
 wdir: ../../../data/snapshots/ahdi/2023-09-08
 outs:
-- md5: d187329001384e104e019a3e08d533c6
-  size: 478574
-  path: augmented_hdi.xlsx
+  - md5: 62715a5870cdfe87b431de244460bc91
+    size: 476940
+    path: augmented_hdi.xlsx

--- a/snapshots/ahdi/2023-09-08/augmented_hdi_region.xlsx.dvc
+++ b/snapshots/ahdi/2023-09-08/augmented_hdi_region.xlsx.dvc
@@ -30,20 +30,16 @@ meta:
 
       By how much did human development improve over the long run? Given the way in which the index has been computed, the conventional logarithmic rate of variation (as in the case of GDP per head) can be used.
 
-    citation_full: Prados de la Escosura, L. (2021), Augmented Human Development
-      in the Age of Globalisation, Economic History Review.
-    url_main:
-      https://frdelpino.es/investigacion/en/category/01_social-sciences/02_world-economy/03_human-development-world-economy/
-    url_download:
-      https://frdelpino.es/investigacion/wp-content/uploads/2023/03/AHDI_regions_1870-2020_rev.xlsx
-    date_published: 2021
-    date_accessed: 2023-09-08
+    citation_full: 'Leandro Prados de la Escosura (2022), Human Development and the Path to Freedom: 1870 to the Present, Cambridge: Cambridge University Press. https://doi.org/10.1017/9781108769655'
+    url_main: https://frdelpino.es/investigacion/en_gb/world-economy/human-development-world-economy/
+    url_download: https://frdelpino.es/investigacion/wp-content/uploads/2025/11/AHDI_regions_1870-2020_dataset.xlsx
+    date_published: 2022
+    date_accessed: 2026-09-04
     license:
-      url:
-        https://frdelpino.es/investigacion/en/category/01_social-sciences/02_world-economy/03_human-development-world-economy/
+      url: https://frdelpino.es/investigacion/en_gb/world-economy/human-development-world-economy/
       name: Creative Commons BY 4.0
 wdir: ../../../data/snapshots/ahdi/2023-09-08
 outs:
-- md5: 38a54c74b72cd97ae30bce518cc07588
-  size: 102308
-  path: augmented_hdi_region.xlsx
+  - md5: d0d9c2fbbc26e4e32e541540cf752f0b
+    size: 102601
+    path: augmented_hdi_region.xlsx


### PR DESCRIPTION
> _Written by Claude Opus 5 — @edomt at the wheel._

Metadata-only refresh of the two AHDI snapshots (`ahdi/2023-09-08`). **No data change.**

## Why

The producer's page moved, so our `url_main` and `license.url` were 404ing, and the two `url_download` links pointed at 2023 uploads. The current page ([here](https://frdelpino.es/investigacion/en_gb/world-economy/human-development-world-economy/)) links to files re-uploaded in November 2025, and now asks that the data be cited as the 2022 Cambridge University Press book rather than the 2021 *Economic History Review* article.

## The data is unchanged

I diffed the new workbooks against our snapshots cell by cell before touching anything:

| Sheet | Country file | Region file |
|---|---|---|
| All 10 data tables (+ `Regional_Composition`) | 0 differing cells | 0 differing cells |
| `Content` | +1 row (the new citation line) | +1 row (the new citation line) |

Still 1870–2020, same countries, same shapes. The series hasn't been extended past 2020 — it is tied to the 2021 article / 2022 book, not an annually updated product.

## Changes

Both `augmented_hdi.xlsx.dvc` and `augmented_hdi_region.xlsx.dvc`:

- `citation_full` → `Leandro Prados de la Escosura (2022), Human Development and the Path to Freedom: 1870 to the Present, Cambridge: Cambridge University Press. https://doi.org/10.1017/9781108769655` (the producer's own requested wording)
- `date_published` `2021` → `2022`, to stay consistent with the citation year. This changes the automatic grapher attribution to "Leandro Prados de la Escosura (2022)".
- `url_main` and `license.url` → the current page, which is also where the producer states the CC BY 4.0 terms ("Augmented Human Development, 1870-2020 by Leandro Prados de la Escosura is licensed under CC BY 4.0")
- `url_download` → the November 2025 files
- `date_accessed` → 2026-09-04
- `outs` md5/size updated: the re-run pulls the new files, which differ in bytes (the extra `Content` row) but not in data

## Verification

`etl diff REMOTE data/ --include ahdi` reports `~ Table augmented_hdi (changed metadata)` for meadow, garden and grapher — metadata only, no value differences.

## Left open

- The grapher DB upsert (`grapher://grapher/ahdi/2023-09-08/augmented_hdi`) hasn't been run against production; that happens on merge. Staging rebuilds from this branch.
- Nobody has re-read the AHDI indicator descriptions in `augmented_hdi.meta.yml` against the current style guide — out of scope here, and untouched by this PR.
- Charts using this dataset will show the new "(2022)" attribution once merged. No chart configs were changed and no indicator IDs move (same version folder), so no remapping is needed.
