### PR TITLE
🔨🤖 Validate indicator grapher_config against the patch schema

### DIFF
--- a/.claude/skills/sync-grapher-schema/SKILL.md
+++ b/.claude/skills/sync-grapher-schema/SKILL.md
@@ -15,16 +15,17 @@ metadata:
 
 # Sync Grapher Schema
 
-The grapher chart-config schema is owned by the web team in [`owid-grapher`](https://github.com/owid/owid-grapher/tree/master/packages/%40ourworldindata/grapher/src/schema) and published at `https://files.ourworldindata.org/schemas/grapher-schema.NNN.json`. **It is mutated in place without version bumps** (e.g. dumbbell plots landed in `.010` directly), so when it changes upstream, four things in this repo need to follow:
+The grapher chart-config schema is owned by the web team in [`owid-grapher`](https://github.com/owid/owid-grapher/tree/master/packages/%40ourworldindata/grapher/src/schema) and published at `https://files.ourworldindata.org/schemas/grapher-schema.NNN.json`. **It is mutated in place without version bumps** (e.g. dumbbell plots landed in `.010` directly), so when it changes upstream, five things in this repo need to follow:
 
 | File | Role | Sync mechanism |
 |---|---|---|
 | `schemas/grapher-schema.NNN.json` | Vendored copy of upstream | automatic (`--refresh`) |
+| `schemas/grapher-schema.NNN.patch.json` | Vendored copy of upstream's patch variant (same schema, `required: ["$schema"]`) — what `_validate_grapher_config` validates indicator `grapher_config` patches against | automatic (same `--refresh`); never hand-edited |
 | `schemas/multidim-schema.json` + `schemas/explorer-schema.json` | View config `$ref`s into the grapher schema | manual: add `$ref` for **new** properties |
 | `schemas/dataset-schema.json` | Embedded `grapher_config` block (validates garden `.meta.yml`) | manual: mirror changes, preserve deviations |
 | `etl/collection/model/schema_types.py` | Generated Python TypedDicts | automatic (regenerate) |
 
-Unit tests enforce consistency between all of these (`tests/test_schema_types_generation.py`, `test_grapher_config_schema_sync` in `tests/test_metadata_schemas.py`), so partial syncs fail CI. Full background: `docs/guides/grapher-schema-sync.md`.
+Unit tests enforce consistency between all of these (`tests/test_schema_types_generation.py`, `test_grapher_config_schema_sync` and `test_vendored_patch_schema_matches_full_schema` in `tests/test_metadata_schemas.py`), so partial syncs fail CI. The last of those also catches a half-done refresh, i.e. the full file updated but not the patch one. Full background: `docs/guides/grapher-schema-sync.md`.
 
 ## Entry points
 
@@ -118,7 +119,9 @@ Rarer case — when the web team publishes a new schema version instead of mutat
 
 1. Bump `DEFAULT_GRAPHER_SCHEMA` in `etl/config.py`. (Keep it a concrete version, never `latest` — it is written into chart configs as `$schema`, and grapher's config migrations are keyed on the version.)
 2. Update every `$ref` in `schemas/multidim-schema.json` and `schemas/explorer-schema.json`: `sed -i 's/grapher-schema.NNN.json/grapher-schema.MMM.json/g' schemas/multidim-schema.json schemas/explorer-schema.json`.
-3. `.venv/bin/python scripts/generate_schema_types.py --refresh` (vendors the new version — the filename follows `DEFAULT_GRAPHER_SCHEMA`), then `git rm` the old vendored file.
+3. `.venv/bin/python scripts/generate_schema_types.py --refresh` (vendors the new version — both filenames follow `DEFAULT_GRAPHER_SCHEMA`), then `git rm` **both** old vendored files (`grapher-schema.NNN.json` and `grapher-schema.NNN.patch.json`).
+
+   ⚠️ **The new version needs its patch variant published too.** `_validate_grapher_config` derives `grapher-schema.MMM.patch.json` from each config's `$schema` and fetches it with no fallback, so if upstream published `MMM` without the patch variant, every grapher step carrying a `presentation.grapher_config` hard-fails on a 404. Check it before bumping (`curl -fsSI https://files.ourworldindata.org/schemas/grapher-schema.MMM.patch.json`) and flag it to the web team as part of the bump rather than discovering it afterwards.
 4. Continue from step 1's diff review above (diff old vendored vs new: `git diff --no-index schemas/grapher-schema.NNN.json schemas/grapher-schema.MMM.json`).
 
 ### Don't bump the `grapher_schema` pins in MDIM configs

--- a/.github/workflows/sync-grapher-schema.yml
+++ b/.github/workflows/sync-grapher-schema.yml
@@ -42,7 +42,11 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          VENDORED=$(ls schemas/grapher-schema.*.json)
+          # Exclude the patch variant: the glob must resolve to exactly one file, or basename,
+          # curl -o and the json.load below all break on a two-line $VENDORED. Detection stays
+          # keyed off the full schema only — upstream publishes the two together, so a change to
+          # one implies a change to the other, and --refresh then pulls both.
+          VENDORED=$(ls schemas/grapher-schema.*.json | grep -v '\.patch\.json$')
           NAME=$(basename "$VENDORED")
 
           # Cloudflare fronts files.ourworldindata.org with s-maxage=300, so for up to five

--- a/docs/guides/grapher-schema-sync.md
+++ b/docs/guides/grapher-schema-sync.md
@@ -8,13 +8,26 @@ ETL keeps a **vendored pin** of the upstream schema — a committed snapshot, sa
 owid-grapher (web team)
     │  publishes / mutates grapher-schema.010.json
     ▼
-schemas/grapher-schema.010.json              ← vendored pin (the only upstream copy in ETL)
+schemas/grapher-schema.010.json              ← vendored pin (the only full upstream copy in ETL)
     ├─→ etl/collection/model/schema_types.py    generated from it    ← unit test (offline)
     ├─→ multidim/explorer-schema $refs           resolved against it  ← at runtime (offline)
-    └─→ dataset-schema.json embedded block       checked against it   ← unit test (offline, enum-deep)
+    ├─→ dataset-schema.json embedded block       checked against it   ← unit test (offline, enum-deep)
+    └─→ schemas/grapher-schema.010.patch.json    same file, `required: ["$schema"]`
+                                                                     ← unit test (offline)
 
 vendored ↔ live upstream                      ← scheduled workflow + integration tests
 ```
+
+Upstream publishes a **patch variant** alongside every version, identical except that it requires
+only `$schema` instead of `$schema` + `dimensions`. It is the schema for a *partial* config, so
+`etl.grapher.helpers._validate_grapher_config` validates each indicator's
+`presentation.grapher_config` against it — that config is a patch applied on top of a chart's own
+config, never a complete chart. The URL is derived from the config's own `$schema` at validation
+time (`etl.files.patch_schema_url`), so validation follows whatever version a config pins;
+`DEFAULT_GRAPHER_SCHEMA` stays the non-patch URL, since that is the value written into configs.
+
+The patch file is vendored too, purely so the "differs in `required` and `$id` only" invariant can
+be asserted offline. Nothing reads the vendored copy at runtime.
 
 Everything inside the repo is machine-checked against the pin on every PR; only the pin itself can lag upstream, and that is what the scheduled workflow watches.
 
@@ -72,4 +85,5 @@ It can also be run ad-hoc — e.g. when the web team announces a change and you 
 | `schemas/*.json` edited without regenerating types, or generated file hand-edited | `tests/test_schema_types_generation.py` (unit, offline) |
 | Embedded `grapher_config` in `dataset-schema.json` out of sync with the vendored pin | `test_grapher_config_schema_sync` in `tests/test_metadata_schemas.py` (unit, offline, enum-deep) |
 | Vendored pin stale vs live upstream (in-place mutation) | scheduled workflow → draft PR; `test_vendored_grapher_schema_is_current` (integration) |
+| Patch variant diverges from the full schema beyond `required`/`$id`, or a refresh updated only one of the two | `test_vendored_patch_schema_matches_full_schema` in `tests/test_metadata_schemas.py` (unit, offline) |
 | Upstream publishes a new schema version | scheduled workflow → issue; `test_no_newer_grapher_schema_version` (integration) |

--- a/etl/files.py
+++ b/etl/files.py
@@ -425,6 +425,20 @@ def read_json_schema(path: Path | str) -> dict[str, Any]:
         return cast(dict[str, Any], dix)
 
 
+def patch_schema_url(schema_url: str) -> str:
+    """`.../grapher-schema.011.json` -> `.../grapher-schema.011.patch.json`.
+
+    The patch variant of a grapher schema requires only `$schema`, so it is the one to
+    validate a *partial* config against -- an indicator's `grapher_config`, which is applied
+    on top of a chart's own config and is never a complete chart. Upstream publishes one
+    alongside every full schema, back to 001.
+    """
+    suffix = ".json"
+    if schema_url.endswith(".patch.json") or not schema_url.endswith(suffix):
+        raise ValueError(f"Not a full grapher schema URL: {schema_url!r}")
+    return schema_url[: -len(suffix)] + ".patch.json"
+
+
 @cache
 def get_schema_from_url(schema_url: str) -> dict:
     """Get the schema of a chart configuration. Schema URL is saved in config["$schema"] and looks like:
@@ -439,4 +453,8 @@ def get_schema_from_url(schema_url: str) -> dict:
     Dict[str, Any]
         Schema of a chart configuration.
     """
-    return http_session.get(schema_url, timeout=20, verify=TLS_VERIFY).json()
+    resp = http_session.get(schema_url, timeout=20, verify=TLS_VERIFY)
+    # Without this, a missing object (404 text/plain "Object Not Found") surfaces as a
+    # JSONDecodeError pointing at column 1, instead of naming the URL that is missing.
+    resp.raise_for_status()
+    return resp.json()

--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from etl.config import DEFAULT_GRAPHER_SCHEMA
 from etl.db import get_engine, read_sql
-from etl.files import get_schema_from_url, yaml_dump
+from etl.files import get_schema_from_url, patch_schema_url, yaml_dump
 from etl.grapher.io import add_entity_code_and_name, trim_long_variable_name
 
 log = structlog.get_logger()
@@ -777,15 +777,16 @@ def _validate_time_interval(tab: Table, col: str) -> None:
 
 
 def _validate_grapher_config(tab: Table, col: str) -> None:
-    """Validate grapher config against given schema or against the default schema."""
+    """Validate grapher config against the patch schema for its version.
+
+    An indicator's `grapher_config` is a patch applied on top of a chart's own config, so it
+    is validated against the `.patch.json` variant (which requires only `$schema`) rather than
+    the full schema (which also requires `dimensions`).
+    """
     grapher_config = getattr(tab[col].m.presentation, "grapher_config", None)
     if grapher_config:
         grapher_config.setdefault("$schema", DEFAULT_GRAPHER_SCHEMA)
-
-        # Load schema and remove properties that are not relevant for the validation
-        schema = get_schema_from_url(grapher_config["$schema"])
-        # schema["required"] = [f for f in schema["required"] if f not in ("dimensions", "version", "title")]
-        schema["required"] = []
+        schema = get_schema_from_url(patch_schema_url(grapher_config["$schema"]))
 
         from jsonschema import ValidationError, validate
 

--- a/schemas/grapher-schema.011.patch.json
+++ b/schemas/grapher-schema.011.patch.json
@@ -1,0 +1,1079 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://files.ourworldindata.org/schemas/grapher-schema.011.patch.json",
+  "required": [
+    "$schema"
+  ],
+  "type": "object",
+  "description": "Our World In Data grapher configuration. Most of the fields can be left empty\nand will be filled with reasonable default values.\n",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Url of the concrete schema version to use to validate this document",
+      "format": "uri",
+      "default": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
+      "const": "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
+    },
+    "id": {
+      "type": "integer",
+      "description": "Internal database id",
+      "minimum": 0
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Chart config version"
+    },
+    "slug": {
+      "type": "string",
+      "description": "Slug of the chart on Our World In Data"
+    },
+    "title": {
+      "type": "string",
+      "description": "Big title text of the chart"
+    },
+    "subtitle": {
+      "type": "string",
+      "description": "The longer subtitle text to show beneath the title"
+    },
+    "isPublished": {
+      "type": "boolean",
+      "description": "Indicates if the chart is published on Our World In Data or still in draft"
+    },
+    "originUrl": {
+      "type": "string",
+      "description": "The page containing this chart where more context can be found"
+    },
+    "license": {
+      "type": "string",
+      "description": "The license the chart is published under, linked in the chart footer",
+      "default": "cc-by",
+      "enum": [
+        "cc-by",
+        "cc-by-sa",
+        "cc-by-nc",
+        "cc-by-nc-sa",
+        "cc-by-nd",
+        "cc-by-nc-nd"
+      ]
+    },
+    "sourceDesc": {
+      "type": "string",
+      "description": "Short comma-separated list of source names"
+    },
+    "note": {
+      "type": "string",
+      "description": "Note displayed in the footer of the chart"
+    },
+    "internalNotes": {
+      "type": "string",
+      "description": "Additional text used internally to differentiate charts with the same title"
+    },
+    "variantName": {
+      "type": "string",
+      "description": "Optional internal variant name for distinguishing charts with the same title"
+    },
+    "dimensions": {
+      "type": "array",
+      "description": "List of dimensions and their mapping to variables",
+      "items": {
+        "type": "object",
+        "required": [
+          "property",
+          "variableId"
+        ],
+        "properties": {
+          "targetYear": {
+            "type": "integer",
+            "description": "Charts that can display more than one primary dimensions (i.e. scatter and marimekko)\nsometimes need to \"hardcode\" one dimension to a specific year. This happens e.g. when\nmixing a daily X variable in a scatter plot with a yearly one, e.g. population.\n"
+          },
+          "property": {
+            "type": "string",
+            "description": "Which dimension this property maps to",
+            "enum": [
+              "y",
+              "x",
+              "size",
+              "color",
+              "table"
+            ]
+          },
+          "display": {
+            "type": "object",
+            "properties": {
+              "isProjection": {
+                "type": "boolean",
+                "default": false,
+                "description": "Indicates if this time series is a forward projection (if yes then this is rendered\ndifferently in e.g. line charts)\n"
+              },
+              "plotMarkersOnlyInLineChart": {
+                "type": "boolean",
+                "default": false,
+                "description": "Indicates if data points should be connected with a line in a line chart\n"
+              },
+              "name": {
+                "type": "string",
+                "description": "The display string for this variable"
+              },
+              "description": {
+                "type": "string",
+                "description": "Variable description",
+                "$comment": "This is a new field that did not exist prior to November 2021 in the DB. It overrides the description on the variable DB table."
+              },
+              "tableDisplay": {
+                "type": "object",
+                "description": "Configuration for the table sheet for this variable",
+                "properties": {
+                  "hideAbsoluteChange": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "hideRelativeChange": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "tolerance": {
+                "type": "integer",
+                "default": 0,
+                "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, either years or days.\n",
+                "minimum": 0
+              },
+              "entityAnnotationsMap": {
+                "type": "string",
+                "description": "Entity annotations"
+              },
+              "timeInterval": {
+                "type": "string",
+                "default": "year",
+                "description": "Resolution at which the time values should be interpreted and formatted.",
+                "enum": [
+                  "day",
+                  "week",
+                  "month",
+                  "quarter",
+                  "year",
+                  "decade"
+                ]
+              },
+              "color": {
+                "type": "string",
+                "description": "Default color for this time series"
+              },
+              "includeInTable": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether to render this time series in the table sheet"
+              },
+              "shortUnit": {
+                "type": "string",
+                "description": "Short unit symbol - This is used in tight UI spaces when the value is shown"
+              },
+              "conversionFactor": {
+                "type": "number",
+                "description": "Conversion factor to apply before showing values"
+              },
+              "unit": {
+                "type": "string",
+                "description": "Long unit text - This is shown in the UI when there is more space (e.g. tooltips) after values"
+              },
+              "roundingMode": {
+                "type": "string",
+                "description": "Rounding strategy to use. Supported are rounding to a fixed number of decimals and rounding to significant figures.\nIf 'decimalPlaces' is selected, then 'numDecimalPlaces' is used. If 'significantFigures' is selected, then 'numSignificantFigures' is used.\n",
+                "default": "decimalPlaces",
+                "enum": [
+                  "decimalPlaces",
+                  "significantFigures"
+                ]
+              },
+              "numDecimalPlaces": {
+                "type": "integer",
+                "description": "Number of decimal places to show",
+                "minimum": 0,
+                "default": 2
+              },
+              "numSignificantFigures": {
+                "type": "integer",
+                "description": "Number of significant figures to show",
+                "minimum": 1,
+                "default": 3
+              },
+              "zeroDay": {
+                "type": "string",
+                "description": "Iso date day string used as the reference date for day-encoded values",
+                "default": "2020-01-21"
+              }
+            },
+            "additionalProperties": false
+          },
+          "variableId": {
+            "type": "integer",
+            "description": "The variable id to get the values for this time series",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "selectedEntityNames": {
+      "type": "array",
+      "description": "The initial selection of entities",
+      "default": [],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "focusedSeriesNames": {
+      "type": "array",
+      "description": "The initially focused chart elements. Is either a list of entity or variable names.\nOnly works for line and slope charts for now.\n",
+      "default": [],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "excludedEntityNames": {
+      "type": "array",
+      "description": "Entities that should be excluded (opposite of includedEntityNames)",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "includedEntityNames": {
+      "type": "array",
+      "description": "Entities that should be included (opposite of excludedEntityNames).\nIf empty, all available entities are used. If set, all entities not specified here are excluded.\nexcludedEntityNames are evaluated afterwards and can still remove entities even if they were included before.\n",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "inapplicableEntityNames": {
+      "type": "array",
+      "description": "Entities the indicator's data can't apply to by construction, e.g. Mexico for\n\"Where do Mexican emigrants live?\". On the map, they are excluded from the\ncolor scale and rendered in a dedicated pattern.\n",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "selectedEntityColors": {
+      "type": "object",
+      "description": "Colors for selected entities",
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      }
+    },
+    "addCountryMode": {
+      "type": "string",
+      "description": "Whether the user can change countries, add additional ones or neither",
+      "default": "add-country",
+      "enum": [
+        "add-country",
+        "change-country",
+        "disabled"
+      ]
+    },
+    "peerCountryStrategy": {
+      "type": "string",
+      "description": "Strategy for selecting peer countries for comparison\n- \"defaultSelection\": Use the chart's default selection as peers\n- \"parentRegions\": Use the containing continent, income group, and World as peers\n- \"gdpPerCapita\": Use countries with similar GDP per capita as peers\n- \"population\": Use countries with similar population as peers\n- \"dataRange\": Use countries that represent the data range as peers\n- \"neighbors\": Use neighboring countries as peers\n- \"none\": Don't automatically add peer countries (useful in search)\n",
+      "enum": [
+        "defaultSelection",
+        "parentRegions",
+        "gdpPerCapita",
+        "population",
+        "dataRange",
+        "neighbors",
+        "none"
+      ]
+    },
+    "entityType": {
+      "type": "string",
+      "default": "country or region",
+      "description": "Display string for naming the primary entities of the data. The default is 'country or region', but you can specify a different one such as 'state' or 'region'"
+    },
+    "entityTypePlural": {
+      "description": "Plural of the entity type (i.e. when entityType is 'country' this would be 'countries')",
+      "default": "countries and regions",
+      "type": "string"
+    },
+    "facettingLabelByYVariables": {
+      "type": "string",
+      "default": "metric",
+      "description": "Display string that replaces 'metric' in the 'Split by metric' label in facet controls (e.g. 'product' displays 'Split by product')"
+    },
+    "chartTypes": {
+      "type": "array",
+      "description": "Which chart types should be shown",
+      "default": [
+        "LineChart",
+        "DiscreteBar"
+      ],
+      "items": {
+        "type": "string",
+        "enum": [
+          "LineChart",
+          "ScatterPlot",
+          "StackedArea",
+          "DiscreteBar",
+          "StackedDiscreteBar",
+          "SlopeChart",
+          "StackedBar",
+          "Marimekko",
+          "Dumbbell"
+        ]
+      }
+    },
+    "hasMapTab": {
+      "type": "boolean",
+      "default": false,
+      "description": "Indicates if the map tab should be shown"
+    },
+    "tab": {
+      "type": "string",
+      "description": "The tab that is shown initially",
+      "default": "chart",
+      "enum": [
+        "chart",
+        "map",
+        "table",
+        "line",
+        "slope",
+        "discrete-bar",
+        "marimekko",
+        "scatter",
+        "stacked-area",
+        "stacked-bar",
+        "stacked-discrete-bar",
+        "dumbbell"
+      ]
+    },
+    "xAxis": {
+      "$ref": "#/$defs/axis"
+    },
+    "yAxis": {
+      "$ref": "#/$defs/axis"
+    },
+    "colorScale": {
+      "$ref": "#/$defs/colorScale"
+    },
+    "map": {
+      "type": "object",
+      "description": "Configuration of the world map chart",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Which region to focus on",
+          "enum": [
+            "World",
+            "Europe",
+            "Africa",
+            "Asia",
+            "NorthAmerica",
+            "SouthAmerica",
+            "Oceania"
+          ],
+          "default": "World"
+        },
+        "hideTimeline": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the timeline should be hidden in the map view and thus the user not be able to change the year"
+        },
+        "colorScale": {
+          "$ref": "#/$defs/colorScale"
+        },
+        "timeTolerance": {
+          "type": "integer",
+          "description": "Tolerance to use. If data points are missing for a time point, a match is accepted if it lies\nwithin the specified time period. The unit is the dominating time unit, usually years but can be days for\ndaily time series. If not provided, the tolerance specified in the metadata of the indicator is used.\nIf that's not specified, 0 is used.\n",
+          "minimum": 0
+        },
+        "toleranceStrategy": {
+          "type": "string",
+          "description": "Tolerance strategy to use. Options include accepting matches that are \"closest\" to the time point in question\n(going forwards and backwards in time), and accepting matches that lie in the past (\"backwards\") or\nthe future (\"forwards\").\n",
+          "enum": [
+            "closest",
+            "forwards",
+            "backwards"
+          ],
+          "default": "closest"
+        },
+        "tooltipUseCustomLabels": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the label from colorSchemeLabels in the tooltip instead of the numeric value"
+        },
+        "time": {
+          "description": "Select a specific time to be displayed. If startTime is given, this acts as the end time.",
+          "default": "latest",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "latest",
+                "earliest"
+              ]
+            }
+          ]
+        },
+        "startTime": {
+          "description": "Select a specific start time to be displayed. If given, two maps are shown next to each other.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "latest",
+                "earliest"
+              ]
+            }
+          ]
+        },
+        "columnSlug": {
+          "description": "Column to show in the map tab. Can be a column slug (e.g. in explorers) or a variable ID (as string).\nIf not provided, the first y dimension is used.\n",
+          "type": "string"
+        },
+        "selectedEntityNames": {
+          "type": "array",
+          "description": "The initial selection of entities to show on the map",
+          "default": [],
+          "items": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "globe": {
+          "type": "object",
+          "description": "Configuration of the globe",
+          "properties": {
+            "isActive": {
+              "type": "boolean",
+              "description": "Whether the globe is initially shown"
+            },
+            "rotation": {
+              "type": "array",
+              "description": "Latitude and Longitude of the globe rotation",
+              "items": {
+                "type": [
+                  "number"
+                ]
+              }
+            },
+            "zoom": {
+              "type": "number",
+              "description": "Zoom level of the globe"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "dumbbell": {
+      "type": "object",
+      "description": "Configuration of the dumbbell chart",
+      "properties": {
+        "connectorStyle": {
+          "type": "string",
+          "default": "arrow",
+          "description": "How the connector between dumbbell heads is drawn.\n- arrow: draw an arrow pointing from start to end\n- line: draw a simple line (only respected when two indicators are plotted)\n",
+          "enum": [
+            "arrow",
+            "line"
+          ]
+        },
+        "valueLabelMode": {
+          "type": "string",
+          "default": "absolute",
+          "description": "What to display as value labels next to each dumbbell.\n- absolute: show the raw values at the start and end\n- change: show the absolute change (e.g. +50)\n- percentChange: show the percentage change (e.g. +33%)\n- none: hide value labels\n",
+          "enum": [
+            "absolute",
+            "change",
+            "percentChange",
+            "none"
+          ]
+        },
+        "trendColorMap": {
+          "type": "object",
+          "description": "Custom colors for the time-range encoding",
+          "properties": {
+            "increase": {
+              "type": "string",
+              "description": "Color for dumbbells whose value increased over time"
+            },
+            "decrease": {
+              "type": "string",
+              "description": "Color for dumbbells whose value decreased over time"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "baseColorScheme": {
+      "$ref": "#/$defs/colorScheme"
+    },
+    "invertColorScheme": {
+      "type": "boolean",
+      "default": false,
+      "description": "Reverse the order of colors in the color scheme"
+    },
+    "logo": {
+      "type": "string",
+      "description": "Which logo to show on the upper right side",
+      "default": "owid",
+      "enum": [
+        "owid",
+        "core+owid",
+        "gv+owid"
+      ]
+    },
+    "hideSeriesLabels": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to hide the inline series labels drawn at the end\nof each series. Applies to line, slope, and stacked area charts\n"
+    },
+    "hideLogo": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to hide the logo"
+    },
+    "hideRelativeToggle": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to hide the relative mode UI toggle"
+    },
+    "hideConnectedScatterLines": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to hide connecting lines on scatter plots when a time range is selected"
+    },
+    "hideScatterLabels": {
+      "type": "boolean",
+      "default": false,
+      "description": "Hide entity names in Scatter plots"
+    },
+    "hideTotalValueLabel": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to hide the total value label (used on stacked discrete bar charts)"
+    },
+    "hideFacetControl": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to hide the faceting control"
+    },
+    "hideAnnotationFieldsInTitle": {
+      "type": "object",
+      "description": "Whether to hide any automatically added title annotations like the selected year",
+      "properties": {
+        "entity": {
+          "type": "boolean",
+          "description": "Whether to hide the entity annotation",
+          "default": false
+        },
+        "time": {
+          "type": "boolean",
+          "description": "Whether to hide the time annotation",
+          "default": false
+        },
+        "changeInPrefix": {
+          "type": "boolean",
+          "description": "Whether to hide \"Change in\" in relative line charts",
+          "default": false
+        }
+      }
+    },
+    "minTime": {
+      "description": "Start point of the initially selected time span.",
+      "default": "earliest",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "latest",
+            "earliest"
+          ]
+        }
+      ]
+    },
+    "maxTime": {
+      "description": "End point of the initially selected time span.",
+      "default": "latest",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "latest",
+            "earliest"
+          ]
+        }
+      ]
+    },
+    "timelineMinTime": {
+      "description": "The lowest year to show in the timeline. If this is set then the user is not able to see\nany data before this year. If set to \"earliest\", then the earliest year in the data is used.\n",
+      "default": "earliest",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "earliest"
+          ]
+        }
+      ]
+    },
+    "timelineMaxTime": {
+      "description": "The highest year to show in the timeline. If this is set then the user is not able to see\nany data after this year. If set to \"latest\", then the latest year in the data is used.\n",
+      "default": "latest",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "latest"
+          ]
+        }
+      ]
+    },
+    "hideTimeline": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to hide the timeline from the user. If it is hidden then the user can't change the time"
+    },
+    "stackMode": {
+      "type": "string",
+      "description": "Stack mode. Only absolute and relative are actively used.",
+      "default": "absolute",
+      "enum": [
+        "absolute",
+        "relative"
+      ]
+    },
+    "zoomToSelection": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to zoom to the selected data points"
+    },
+    "showYearLabels": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to show year labels in bar charts"
+    },
+    "showNoDataArea": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to show an area for entities that have no data (used in marimekko charts)"
+    },
+    "compareEndPointsOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Drops in between points in scatter plots"
+    },
+    "matchingEntitiesOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Exclude entities that do not belong in any color group"
+    },
+    "missingDataStrategy": {
+      "type": "string",
+      "default": "auto",
+      "description": "The desired strategy for handling entities with missing data",
+      "enum": [
+        "auto",
+        "hide",
+        "show"
+      ]
+    },
+    "scatterPointLabelStrategy": {
+      "type": "string",
+      "default": "year",
+      "description": "When a user hovers over a connected series line in a ScatterPlot we show\na label for each point. By default that value will be from the \"year\" column\nbut by changing this option the column used for the x or y axis could be used instead.\n",
+      "enum": [
+        "x",
+        "y",
+        "year"
+      ]
+    },
+    "selectedFacetStrategy": {
+      "type": "string",
+      "default": "none",
+      "description": "The desired facetting strategy (none for no facetting)",
+      "enum": [
+        "none",
+        "entity",
+        "metric"
+      ]
+    },
+    "sortBy": {
+      "type": "string",
+      "description": "Sort criterion (used by discrete bar, stacked discrete bar, and dumbbell charts).\n- column: sort by the value of a specific column, identified by sortColumnSlug\n- total: sort by the total across all columns\n- entityName: sort alphabetically by entity name\n- custom: preserve the specified entity order\n- change: sort by the change between the start and end values (dumbbell charts only)\n- startValue: sort by the start value (dumbbell charts only)\n- endValue: sort by the end value (dumbbell charts only)\n",
+      "default": "total",
+      "enum": [
+        "column",
+        "total",
+        "entityName",
+        "custom",
+        "change",
+        "startValue",
+        "endValue"
+      ]
+    },
+    "sortOrder": {
+      "type": "string",
+      "description": "Sort order",
+      "default": "desc",
+      "enum": [
+        "desc",
+        "asc"
+      ]
+    },
+    "sortColumnSlug": {
+      "description": "Sort column if sortBy is column",
+      "type": "string"
+    },
+    "comparisonLines": {
+      "description": "List of comparison lines to draw",
+      "type": "array",
+      "default": [],
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "description": "Comparison line of arbitrary shape defined by a formula. Defaults to `yEquals = x` if not specified",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "yEquals": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Vertical comparison line drawn at a specific x-value",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "xEquals": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "xEquals"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "relatedQuestions": {
+      "type": "array",
+      "description": "Links to related questions",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "axis": {
+      "type": "object",
+      "properties": {
+        "removePointsOutsideDomain": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to remove data points that fall outside the axis domain"
+        },
+        "label": {
+          "type": "string",
+          "description": "Axis label"
+        },
+        "min": {
+          "description": "Minimum domain value of the axis. Inferred from data if set to \"auto\".\nUsually defaults to \"auto\", but defaults to 0 for line and slope charts on the y-axis.\n",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "auto"
+              ]
+            }
+          ]
+        },
+        "scaleType": {
+          "type": "string",
+          "description": "Toggle linear/logarithmic",
+          "default": "linear",
+          "enum": [
+            "linear",
+            "log"
+          ]
+        },
+        "max": {
+          "description": "Maximum domain value of the axis. Inferred from data if set to \"auto\".",
+          "default": "auto",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "auto"
+              ]
+            }
+          ]
+        },
+        "canChangeScaleType": {
+          "type": "boolean",
+          "description": "Allow user to change lin/log",
+          "default": false
+        },
+        "facetDomain": {
+          "type": "string",
+          "description": "Whether the axis domain should be the same across faceted charts (if possible)",
+          "default": "shared",
+          "enum": [
+            "independent",
+            "shared"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "colorScheme": {
+      "type": "string",
+      "description": "One of the predefined base color schemes.\nIf not provided, a default is automatically chosen based on the chart type.\n",
+      "enum": [
+        "YlGn",
+        "YlGnBu",
+        "GnBu",
+        "BuGn",
+        "PuBuGn",
+        "BuPu",
+        "RdPu",
+        "PuRd",
+        "OrRd",
+        "YlOrRd",
+        "YlOrBr",
+        "Purples",
+        "Blues",
+        "Greens",
+        "Oranges",
+        "Reds",
+        "Greys",
+        "PuOr",
+        "BrBG",
+        "PRGn",
+        "PiYG",
+        "RdBu",
+        "RdGy",
+        "RdYlBu",
+        "Spectral",
+        "RdYlGn",
+        "Accent",
+        "Dark2",
+        "Paired",
+        "Pastel1",
+        "Pastel2",
+        "Set1",
+        "Set2",
+        "Set3",
+        "PuBu",
+        "Magma",
+        "Inferno",
+        "Plasma",
+        "Viridis",
+        "continents",
+        "stackedAreaDefault",
+        "owid-distinct",
+        "SingleColorDenim",
+        "SingleColorTeal",
+        "SingleColorPurple",
+        "SingleColorDustyCoral",
+        "SingleColorDarkCopper",
+        "OwidCategoricalA",
+        "OwidCategoricalB",
+        "OwidCategoricalC",
+        "OwidCategoricalD",
+        "OwidCategoricalE",
+        "OwidCategoricalMap",
+        "OwidEnergy",
+        "OwidEnergyLines",
+        "OwidDistinctLines",
+        "BinaryMapPaletteA",
+        "BinaryMapPaletteB",
+        "BinaryMapPaletteC",
+        "BinaryMapPaletteD",
+        "BinaryMapPaletteE",
+        "SingleColorGradientDenim",
+        "SingleColorGradientTeal",
+        "SingleColorGradientPurple",
+        "SingleColorGradientDustyCoral",
+        "SingleColorGradientDarkCopper"
+      ]
+    },
+    "colorScale": {
+      "type": "object",
+      "description": "Color scale definition",
+      "properties": {
+        "customNumericLabels": {
+          "type": "array",
+          "description": "Custom labels for each numeric bin. Only applied when strategy is `manual`.\n`null` falls back to default label.\n",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "customCategoryColors": {
+          "type": "object",
+          "description": "Map of categorical values to colors. Colors are CSS colors, usually in the form `#aa9944`",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          }
+        },
+        "baseColorScheme": {
+          "$ref": "#/$defs/colorScheme"
+        },
+        "customHiddenCategories": {
+          "type": "object",
+          "description": "Allow hiding categories from the legend",
+          "patternProperties": {
+            ".*": {
+              "type": "boolean"
+            }
+          }
+        },
+        "binningStrategy": {
+          "type": "string",
+          "description": "The strategy for generating the bin boundaries",
+          "default": "auto",
+          "enum": [
+            "manual",
+            "auto",
+            "log-auto",
+            "log-1-2-5",
+            "log-1-3",
+            "log-10",
+            "equalSizeBins-few-bins",
+            "equalSizeBins-normal",
+            "equalSizeBins-many-bins",
+            "equalSizeBins-percent"
+          ]
+        },
+        "minValue": {
+          "type": "number",
+          "description": "Minimum value of the color scale, for automated binning."
+        },
+        "maxValue": {
+          "type": "number",
+          "description": "Maximum value of the color scale, for automated binning."
+        },
+        "midpoint": {
+          "type": "number",
+          "default": 0,
+          "description": "Midpoint value for the color scale, for automated binning around the midpoint."
+        },
+        "midpointMode": {
+          "type": "string",
+          "description": "How to handle the midpoint when generating bins. Undefined means automatically choosing between 'none' and 'symmetric'.",
+          "enum": [
+            "none",
+            "symmetric",
+            "same-num-bins",
+            "asymmetric"
+          ]
+        },
+        "createBinForMidpoint": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to create a separate bin that only contains the midpoint value."
+        },
+        "legendDescription": {
+          "type": "string",
+          "description": "A custom legend description. Only used in ScatterPlot legend titles for now."
+        },
+        "customNumericColors": {
+          "type": "array",
+          "description": "Override some or all colors for the numerical color legend.\nColors are CSS colors, usually in the form `#aa9944`\n`null` falls back the color scheme color.\n",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "customNumericValues": {
+          "type": "array",
+          "description": "Custom maximum brackets for each numeric bin. Only applied when strategy is `manual`",
+          "items": {
+            "type": "number"
+          }
+        },
+        "customNumericColorsActive": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether `customNumericColors` are used to override the color scheme"
+        },
+        "colorSchemeInvert": {
+          "type": "boolean",
+          "default": false,
+          "description": "Reverse the order of colors in the color scheme"
+        },
+        "customCategoryLabels": {
+          "type": "object",
+          "description": "Map of category values to color legend labels.",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/generate_schema_types.py
+++ b/scripts/generate_schema_types.py
@@ -33,12 +33,20 @@ from pathlib import Path
 from typing import Any
 
 from etl.config import DEFAULT_GRAPHER_SCHEMA
+from etl.files import patch_schema_url
 from etl.paths import SCHEMAS_DIR
 
 OUTPUT_PATH = Path(__file__).parent.parent / "etl" / "collection" / "model" / "schema_types.py"
 
 # Vendored copy of the grapher schema (DEFAULT_GRAPHER_SCHEMA), refreshed with --refresh.
 VENDORED_GRAPHER_SCHEMA_PATH = SCHEMAS_DIR / DEFAULT_GRAPHER_SCHEMA.rsplit("/", 1)[-1]
+
+# Upstream publishes a patch variant of every schema, identical except that it requires only
+# `$schema` (no `dimensions`). `etl.grapher.helpers._validate_grapher_config` validates
+# indicator `grapher_config` patches against it. Vendored so the invariant test can run offline;
+# the two files always move together upstream, so `--refresh` fetches both.
+DEFAULT_GRAPHER_PATCH_SCHEMA = patch_schema_url(DEFAULT_GRAPHER_SCHEMA)
+VENDORED_PATCH_SCHEMA_PATH = SCHEMAS_DIR / DEFAULT_GRAPHER_PATCH_SCHEMA.rsplit("/", 1)[-1]
 
 # Extra fields injected into ViewConfig that are not part of the multidim schema.
 # TODO: remove once we are done with explorers
@@ -482,15 +490,19 @@ class TypedDictGenerator:
 
 
 def refresh_vendored_schema() -> None:
-    """Re-download the vendored grapher schema from the upstream URL."""
+    """Re-download the vendored grapher schemas (full + patch) from the upstream URLs."""
     from etl.http import session
 
-    resp = session.get(DEFAULT_GRAPHER_SCHEMA, timeout=30)
-    resp.raise_for_status()
-    with open(VENDORED_GRAPHER_SCHEMA_PATH, "w") as f:
-        json.dump(resp.json(), f, indent=2)
-        f.write("\n")
-    print(f"Refreshed {VENDORED_GRAPHER_SCHEMA_PATH} from {DEFAULT_GRAPHER_SCHEMA}")
+    for url, path in (
+        (DEFAULT_GRAPHER_SCHEMA, VENDORED_GRAPHER_SCHEMA_PATH),
+        (DEFAULT_GRAPHER_PATCH_SCHEMA, VENDORED_PATCH_SCHEMA_PATH),
+    ):
+        resp = session.get(url, timeout=30)
+        resp.raise_for_status()
+        with open(path, "w") as f:
+            json.dump(resp.json(), f, indent=2)
+            f.write("\n")
+        print(f"Refreshed {path} from {url}")
 
 
 def format_content(content: str) -> str:
@@ -523,7 +535,7 @@ def main():
     parser.add_argument(
         "--refresh",
         action="store_true",
-        help=f"Re-download the vendored grapher schema from {DEFAULT_GRAPHER_SCHEMA} before generating.",
+        help="Re-download the vendored grapher schemas (full + patch variant) before generating.",
     )
     args = parser.parse_args()
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from etl import files
 
@@ -84,3 +85,16 @@ def test_checksum_dict():
 def test_checksum_df():
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "x", "y"]})
     assert files.checksum_df(df) == "34c7a3a435e4a0703b37904f09f967f1"
+
+
+def test_patch_schema_url():
+    assert (
+        files.patch_schema_url("https://files.ourworldindata.org/schemas/grapher-schema.011.json")
+        == "https://files.ourworldindata.org/schemas/grapher-schema.011.patch.json"
+    )
+    # Already patched — deriving again would give `.patch.patch.json`.
+    with pytest.raises(ValueError):
+        files.patch_schema_url("https://files.ourworldindata.org/schemas/grapher-schema.011.patch.json")
+    # Not a .json URL at all.
+    with pytest.raises(ValueError):
+        files.patch_schema_url("https://files.ourworldindata.org/schemas/grapher-schema.011")

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -1,15 +1,23 @@
+import copy
+import json
 from unittest import mock
 
 import numpy as np
 import pandas as pd
+import pytest
 from owid.catalog import (
     DatasetMeta,
     Table,
     TableMeta,
     VariableMeta,
+    VariablePresentationMeta,
 )
 
+from etl import files
+from etl.config import DEFAULT_GRAPHER_SCHEMA
+from etl.files import patch_schema_url
 from etl.grapher import helpers as gh
+from etl.paths import SCHEMAS_DIR
 
 
 def test_yield_wide_table():
@@ -224,3 +232,80 @@ def test_adapt_table_with_dates_preserves_declared_interval():
     tb["value"].metadata.display = {"timeInterval": "month"}
     tb = gh.adapt_table_with_dates_to_grapher(tb)
     assert tb["value"].m.display["timeInterval"] == "month"
+
+
+def _tab_with_grapher_config(grapher_config: dict) -> Table:
+    tb = Table(pd.DataFrame({"value": [1.0]}))
+    tb.value.metadata.presentation = VariablePresentationMeta(grapher_config=grapher_config)
+    return tb
+
+
+def _fake_schema_session(monkeypatch) -> list[str]:
+    """Serve the vendored schemas from disk instead of the network; return requested URLs."""
+    requested = []
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            # A fresh copy per call, so a mutating caller can't poison the fixture itself and
+            # hide the very bug case 1 guards against.
+            return copy.deepcopy(self._payload)
+
+    def fake_get(url, *args, **kwargs):
+        requested.append(url)
+        path = SCHEMAS_DIR / url.rsplit("/", 1)[-1]
+        if not path.exists():
+            raise AssertionError(f"Test asked for a schema that is not vendored: {url}")
+        with open(path) as f:
+            return _Resp(json.load(f))
+
+    files.get_schema_from_url.cache_clear()
+    monkeypatch.setattr(files.http_session, "get", fake_get)
+    return requested
+
+
+def test_validate_grapher_config_accepts_partial_config(monkeypatch):
+    """A `grapher_config` is a patch, so it validates without `dimensions`."""
+    requested = _fake_schema_session(monkeypatch)
+    tab = _tab_with_grapher_config({"$schema": DEFAULT_GRAPHER_SCHEMA, "hasMapTab": True})
+
+    gh._validate_grapher_config(tab, "value")
+
+    assert requested == [patch_schema_url(DEFAULT_GRAPHER_SCHEMA)]
+    # The full schema's cached dict must come back untouched — validation used to empty
+    # `required` in place on a @cache'd dict, poisoning it for every other caller.
+    assert files.get_schema_from_url(DEFAULT_GRAPHER_SCHEMA)["required"] == ["$schema", "dimensions"]
+
+
+def test_validate_grapher_config_rejects_unknown_property(monkeypatch):
+    """`additionalProperties: false` must survive the switch to the patch schema."""
+    _fake_schema_session(monkeypatch)
+    tab = _tab_with_grapher_config({"$schema": DEFAULT_GRAPHER_SCHEMA, "hasMapTabb": True})
+
+    with pytest.raises(ValueError, match="Invalid grapher_config for column `value`"):
+        gh._validate_grapher_config(tab, "value")
+
+
+def test_validate_grapher_config_rejects_wrong_type(monkeypatch):
+    _fake_schema_session(monkeypatch)
+    tab = _tab_with_grapher_config({"$schema": DEFAULT_GRAPHER_SCHEMA, "hasMapTab": "yes"})
+
+    with pytest.raises(ValueError, match="Invalid grapher_config for column `value`"):
+        gh._validate_grapher_config(tab, "value")
+
+
+def test_validate_grapher_config_defaults_missing_schema(monkeypatch):
+    """No `$schema` is filled in, not rejected — the patch schema requires it."""
+    requested = _fake_schema_session(monkeypatch)
+    config = {"hasMapTab": True}
+    tab = _tab_with_grapher_config(config)
+
+    gh._validate_grapher_config(tab, "value")
+
+    assert config["$schema"] == DEFAULT_GRAPHER_SCHEMA
+    assert requested == [patch_schema_url(DEFAULT_GRAPHER_SCHEMA)]

--- a/tests/test_metadata_schemas.py
+++ b/tests/test_metadata_schemas.py
@@ -14,7 +14,7 @@ from yaml.loader import SafeLoader
 
 from etl.config import DEFAULT_GRAPHER_SCHEMA
 from etl.dag_helpers import get_active_snapshots, get_active_steps
-from etl.files import read_json_schema
+from etl.files import patch_schema_url, read_json_schema
 from etl.paths import BASE_DIR, SCHEMAS_DIR, SNAPSHOTS_DIR, STEP_DIR, STEPS_DATA_DIR
 
 log = structlog.get_logger()
@@ -385,6 +385,9 @@ LOCAL_ONLY_PROPERTIES = {"data", "includedEntities"}
 # Vendored copy of the upstream grapher schema (see scripts/generate_schema_types.py --refresh).
 VENDORED_GRAPHER_SCHEMA = SCHEMAS_DIR / DEFAULT_GRAPHER_SCHEMA.rsplit("/", 1)[-1]
 
+# Vendored copy of its patch variant, refreshed by the same `--refresh`.
+VENDORED_PATCH_SCHEMA = SCHEMAS_DIR / patch_schema_url(DEFAULT_GRAPHER_SCHEMA).rsplit("/", 1)[-1]
+
 
 def _local_enum_values(node) -> set | None:
     """Return the set of enum values a local schema node accepts, or None if unconstrained.
@@ -509,6 +512,40 @@ def test_grapher_config_schema_sync():
             "Local grapher_config has properties not in upstream schema (may be deprecated)",
             properties=sorted(removed),
         )
+
+
+def test_vendored_patch_schema_matches_full_schema():
+    """The patch schema must differ from the full one in `required` and `$id` only.
+
+    `etl.grapher.helpers._validate_grapher_config` validates indicator `grapher_config`
+    patches against the `.patch.json` variant, on the assumption that it is the full schema
+    with `required` narrowed to `["$schema"]` — so every other constraint
+    (`additionalProperties: false`, types, enums) still applies. This asserts that, offline.
+
+    It also catches a half-done refresh: `test_vendored_grapher_schema_is_current` detects a
+    stale *full* copy, and if `--refresh` updated the full file but not the patch one, the two
+    vendored files stop matching here.
+    """
+    with open(VENDORED_GRAPHER_SCHEMA) as f:
+        full = json.load(f)
+    with open(VENDORED_PATCH_SCHEMA) as f:
+        patch = json.load(f)
+
+    assert patch.pop("required", None) == ["$schema"], (
+        f"{VENDORED_PATCH_SCHEMA.name} must require only `$schema` — that is the whole point of "
+        "the patch variant. If upstream changed this, `_validate_grapher_config` needs revisiting."
+    )
+    assert full.pop("required", None) is not None
+    assert patch.pop("$id", None) == patch_schema_url(DEFAULT_GRAPHER_SCHEMA)
+    assert full.pop("$id", None) == DEFAULT_GRAPHER_SCHEMA
+
+    # Popping both keys means any *third* divergence fails here.
+    assert full == patch, (
+        f"{VENDORED_PATCH_SCHEMA.name} diverges from {VENDORED_GRAPHER_SCHEMA.name} beyond "
+        "`required` and `$id`. Validating partial configs against it is no longer equivalent to "
+        "validating against the full schema — review the diff before touching "
+        "`_validate_grapher_config`."
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

An indicator's `presentation.grapher_config` is a patch applied on top of a chart's own config, never a complete chart, but `_validate_grapher_config` validated it against the full grapher schema and worked around the `dimensions` requirement by emptying `required` in place on a `@cache`d dict. Upstream publishes a `.patch.json` variant of every schema that requires only `$schema`, so validate against that instead. The URL is derived from each config's own `$schema`, so validation follows whatever version a config pins; `DEFAULT_GRAPHER_SCHEMA` stays the non-patch URL, since that is the value written into configs and what grapher's config migrations key on.

This is behaviour-preserving. The patch schema requires `$schema`, which the `setdefault` a line above already guarantees, and every other constraint is byte-identical. I validated all 1,424 `grapher_config` blocks in the repo both ways and none of them disagree.

- **Fix.** Emptying `required` in place poisoned the shared cached dict for every other caller of that URL, including `etl/indicator_upgrade/schema.py`, which reads the real `required` in three places. Not reachable today, since those run in separate processes.
- **Fix.** `get_schema_from_url` had no `raise_for_status`, so a missing schema surfaced as `JSONDecodeError` at line 1 column 1 rather than a 404 naming the URL. That matters more now there is no fallback path.
- **Fix.** The sync workflow's `ls schemas/grapher-schema.*.json` matches the new patch file too, and a two-line `$VENDORED` breaks `basename` and `curl -o`. Schema-change detection would have stopped working silently the moment the vendored patch file landed, so the glob now excludes it. Detection stays keyed off the full file, which is fine because the two move together upstream and `--refresh` pulls both.
- The multidim and explorer `$ref`s stay on the full schema. They reference individual properties rather than the root, so top-level `required` never applies to them, and one of them is `#/properties/$schema`, whose `const` is correctly the non-patch URL.
- The patch schema is vendored so a unit test can assert it differs from the full one in `required` and `$id` only. Nothing reads the vendored copy at runtime.

Left open:

- `compute_inheritance_patch` borrows the full schema's `required` into the indicator baseline so a bare `{}` patch validates. It can now validate against the patch schema instead and shrink that borrow to `$schema`.
