### PR TITLE
🔨 Bump the Gemini flash default to gemini-3.8-flash

### DIFF
--- a/apps/chart_critic/critic.py
+++ b/apps/chart_critic/critic.py
@@ -43,14 +43,14 @@ from apps.chart_critic.bundle import Bundle
 
 # Tested defaults. The flash tier is enough: on the SDG 16.2.2 case both flash and flash-lite
 # identified the swap from the render alone, and flash-lite did it for ~$0.0002 a call.
-DEFAULT_MODEL = "google:gemini-3.7-flash"
+DEFAULT_MODEL = "google:gemini-3.8-flash"
 CHEAP_MODEL = "google:gemini-3.1-flash-lite"
 
 # Fallback prices in $ per million tokens (input, output), from Google's published rates.
 # `genai_prices` (used by apps.utils.llms.costs) does not carry these models yet; drop an entry
-# here once it does, and note that gemini-3.7-flash doubles to 1.50/7.50 on 2027-01-01.
+# here once it does, and note that gemini-3.8-flash doubles to 1.50/7.50 on 2027-01-01.
 FALLBACK_PRICES = {
-    "google:gemini-3.7-flash": (0.75, 3.75),
+    "google:gemini-3.8-flash": (0.75, 3.75),
     "google:gemini-3.1-flash-lite": (0.10, 0.40),
 }
 

--- a/scripts/vocabulary/README.md
+++ b/scripts/vocabulary/README.md
@@ -58,7 +58,7 @@ staging server.
 
 ### Choose model
 ```bash
-# Use faster/cheaper model (default: gemini-3-flash-preview)
+# Use faster/cheaper model (default: gemini-3.8-flash)
 .venv/bin/python scripts/vocabulary/vocabulary.py --topic energy --no-upload --model gemini-2.5-flash-lite
 ```
 
@@ -66,7 +66,7 @@ staging server.
 
 - `--topic SLUG` - Topic slug(s) to extract (can be specified multiple times). If not provided, extracts for all topics.
 - `--output PATH` - Output JSON file path (optional, prints to console if not provided)
-- `--model MODEL` - Gemini model to use (default: `gemini-3.7-flash`). Any model id the API accepts works; models missing from `PRICING` just report their cost as unknown.
+- `--model MODEL` - Gemini model to use (default: `gemini-3.8-flash`). Any model id the API accepts works; models missing from `PRICING` just report their cost as unknown.
 - `--upload-path KEY` - Key to write inside the `owid-public` bucket (default: `topic_vocabulary.json`)
 - `--no-upload` - Generate without writing to R2
 - `--report PATH` - Write an HTML coverage report: per term, what it reveals and what it adds, plus the most-viewed charts nothing covers

--- a/scripts/vocabulary/vocabulary.py
+++ b/scripts/vocabulary/vocabulary.py
@@ -64,7 +64,7 @@ from etl.config import OWID_ENV  # ty: ignore
 S3_BUCKET_NAME = "owid-public"
 DEFAULT_S3_VOCABULARY_PATH = "topic_vocabulary.json"
 
-DEFAULT_MODEL = "gemini-3.7-flash"
+DEFAULT_MODEL = "gemini-3.8-flash"
 
 # Ask for the same candidates every time. Left at the model's defaults, two runs
 # of identical code disagreed on almost every topic — Gender Ratio came back


### PR DESCRIPTION
Moves the two places that pin a Gemini flash default from `gemini-3.7-flash` to `gemini-3.8-flash`:

- `apps/chart_critic/critic.py` — `DEFAULT_MODEL` (the daily digest on `etl-deploy` runs on this) and its `FALLBACK_PRICES` key.
- `scripts/vocabulary/vocabulary.py` — `DEFAULT_MODEL`.

**Pricing is unchanged.** 3.8 flash ships at the same $0.75 / $3.75 per 1M introductory rate, in force through 2026-12-31 and doubling to 1.50/7.50 on 2027-01-01 — so `FALLBACK_PRICES` keeps its numbers and only the key moves, and the comment next to it stays true.

Two notes on things adjacent to the bump:

- The vocabulary `README.md` stated two different defaults (`gemini-3-flash-preview` in the example, `gemini-3.7-flash` in the CLI options). Both now say `gemini-3.8-flash`.
- `scripts/vocabulary/vocabulary.py`'s `PRICING` dict has no entry for its own default, so the cost estimate the CLI prints has been "unknown" by default for a while. Left alone here — happy to add `gemini-3.8-flash: 0.75/3.75` if that estimate is worth having.

The critic's known-answer fixtures — whose measurement table was taken on 3.7 — were removed in #6834, so nothing in the diff restates numbers that were measured on the old model.
