### PR TITLE
🔨 Explain missing etlr flags, and detect them under --modified even after global changes

### DIFF
--- a/.claude/skills/create-multidim/SKILL.md
+++ b/.claude/skills/create-multidim/SKILL.md
@@ -282,7 +282,7 @@ Key fields for `config` in views or `common_views`:
 
 ## Troubleshooting
 
-**"No steps matched"**: Chart steps need the `--grapher` flag. Without it, they're skipped.
+**"No steps matched"**: Chart steps need the `--grapher` flag. Without it, they're skipped (etlr says which flag to pass).
 
 **Step not found in DAG**: Check that the entry is under the `steps:` key in the correct `dag/*.yml` file, and that the file is included from `dag/main.yml`.
 

--- a/.claude/skills/create-static-viz/SKILL.md
+++ b/.claude/skills/create-static-viz/SKILL.md
@@ -300,7 +300,7 @@ Everything about authoring the step: the Figma handoff contract the emitted file
 ```
 
 `--grapher` is the flag for every `viz://` step. A static step only writes the PNG and SVG next to
-the recipe, but without the flag it is skipped ("No steps matched").
+the recipe, but without the flag it is skipped, and `etlr` says so.
 
 **From a fresh worktree, give it its own `.venv` before rendering.** A worktree starts without one,
 and borrowing the main checkout's is a trap: `etl` is installed there editable via a `.pth` holding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Internal terms that recur across this guide, the skills, and the codebase:
 .venv/bin/etlr namespace/version/dataset --force --only # Force re-run
 ```
 
-Key flags: `--grapher/-g` runs `grapher://` upserts and every `viz://` step (chart, explorer, static, bespoke); `--export` runs the `export://` steps, which write to shared external destinations (R2, GitHub); `data://` steps need no flag. A step whose flag is missing is skipped (if it was the only step you asked for, `etlr` reports "No steps matched" and lists it among the "closest matches"). Other flags: `--dry-run` (preview), `--force/-f` (re-run), `--only/-o` (no deps), `--private` (always use)
+Key flags: `--grapher/-g` runs `grapher://` upserts and every `viz://` step (chart, explorer, static, bespoke); `--export` runs the `export://` steps, which write to shared external destinations (R2, GitHub); `data://` steps need no flag. A step whose flag is missing is skipped; if it was the only step you asked for, `etlr` says which flag to pass and then lists the "closest matches". Other flags: `--dry-run` (preview), `--force/-f` (re-run), `--only/-o` (no deps), `--private` (always use)
 
 **"The step completed" is not "the data is right".** After running a step for
 someone, report what came out of it: row count, year range, entities, and a few

--- a/etl/command.py
+++ b/etl/command.py
@@ -259,6 +259,21 @@ def main_cli(
             # We only need file names/statuses to pick steps, not the (slow) per-file diff contents.
             files_changed = get_changed_files(include_diff=False)
             global_changes = _global_checksum_inputs_changed(files_changed)
+            modified_steps = _modified_steps(includes=steps, exact_match=exact_match, files_changed=files_changed)
+
+            # `--modified` surfaces modified viz/export steps (chart, explorer, bespoke, export recipes) by
+            # design, but they're only buildable when their flag is passed (see construct_subdag).
+            # When a branch edits only such a recipe (e.g. a single `<explorer>.<key>.config.yml`),
+            # without this we would exclude it downstream and crash with "No steps matched".
+            # Enable the flag the modified steps need, so they actually rebuild. This applies whether
+            # or not the run is filtered below.
+            if not grapher and any(s.startswith(GRAPHER_FLAG_PREFIXES) for s in modified_steps):
+                grapher = True
+                click.echo("Detected modified viz:// step(s); enabling --grapher for this run.")
+            if not export and any(s.startswith(EXPORT_FLAG_PREFIXES) for s in modified_steps):
+                export = True
+                click.echo("Detected modified export:// step(s); enabling --export for this run.")
+
             if global_changes:
                 # These files aren't under etl/steps/ or snapshots/, so _modified_steps would see
                 # nothing changed - but DataStep.checksum_input() bakes pd.__version__ and
@@ -270,19 +285,10 @@ def main_cli(
                     "(no diff filter)."
                 )
             else:
-                steps = _modified_steps(includes=steps, exact_match=exact_match, files_changed=files_changed)
+                steps = modified_steps
                 if not steps:
                     click.echo("No steps modified relative to origin/master.")
                     return
-                # `--modified` surfaces modified viz steps (chart/explorer recipes) by design, but
-                # they're only buildable with --grapher. When a branch edits only such a recipe
-                # (e.g. a single `<explorer>.<key>.config.yml`), the modified set is viz-only;
-                # without this we would exclude it downstream and crash with "No steps matched".
-                # Enable --grapher (which also un-excludes the grapher deps the viz step needs) so
-                # the chart/explorer actually rebuilds.
-                if not grapher and any(s.startswith("viz://") for s in steps):
-                    grapher = True
-                    click.echo("Detected modified viz step(s); enabling --grapher for this run.")
                 click.echo(f"Restricting to {len(steps)} step(s) modified vs origin/master.")
                 # We matched modified catalog paths as substrings, so disable exact matching downstream.
                 exact_match = False
@@ -538,13 +544,12 @@ def construct_subdag(
     if not excludes:
         excludes = []
 
-    # Grapher steps and viz steps (charts, explorers, static, bespoke) write to the grapher DB
+    # Steps that write to the grapher DB (grapher:// upserts and viz:// steps) run only with --grapher;
+    # steps that write to external destinations (export://, i.e. R2 and GitHub) only with --export.
     if not grapher:
-        excludes.append("^(grapher|viz)://.*")
-
-    # Export steps (R2, GitHub)
+        excludes.append(_prefix_pattern(GRAPHER_FLAG_PREFIXES))
     if not export:
-        excludes.append("^export://.*")
+        excludes.append(_prefix_pattern(EXPORT_FLAG_PREFIXES))
 
     # Exclude private steps
     if not private:
@@ -554,12 +559,45 @@ def construct_subdag(
     subdag = filter_to_subgraph(dag, includes=includes, excludes=excludes, only=only, exact_match=exact_match)
 
     if not subdag:
-        # If no steps are found, the most likely case is that the step passed as argument was misspelled.
-        # Print a short error message, show a list of the closest matches, and exit.
+        # No steps found. Either the requested step exists but was skipped because its flag is
+        # missing, or (most likely) the argument was misspelled. Say which.
+        _explain_missing_flags(dag, includes, exact_match, grapher=grapher, export=export)
         _find_closest_matches(" ".join(orig_includes or []), dag)
         sys.exit(1)
 
     return subdag
+
+
+# Step types gated by each flag. grapher:// upserts and viz:// steps write to the grapher DB of the
+# targeted environment; export:// steps write to shared destinations (R2, GitHub).
+GRAPHER_FLAG_PREFIXES = ("grapher://", "viz://")
+EXPORT_FLAG_PREFIXES = ("export://",)
+
+
+def _prefix_pattern(prefixes: tuple[str, ...]) -> str:
+    return "^(?:" + "|".join(re.escape(p) for p in prefixes) + ")"
+
+
+def _explain_missing_flags(dag: DAG, includes: list[str], exact_match: bool, grapher: bool, export: bool) -> None:
+    """Tell the user which requested steps were skipped for lack of a flag, and which flag to pass."""
+    from etl.steps import graph_nodes
+
+    gated = []
+    if not grapher:
+        gated.append((GRAPHER_FLAG_PREFIXES, "writes to the grapher DB; pass --grapher to run it."))
+    if not export:
+        gated.append((EXPORT_FLAG_PREFIXES, "writes to an external destination (R2, GitHub); pass --export to run it."))
+    if exact_match:
+        requested = [step for step in includes if step in dag]
+    else:
+        patterns = [re.compile(p) for p in includes]
+        requested = sorted(step for step in graph_nodes(dag) if any(p.search(step) for p in patterns))
+    shown = 0
+    for step in requested:
+        for prefixes, explanation in gated:
+            if step.startswith(prefixes) and shown < 10:
+                print(f"`{step}` {explanation}")
+                shown += 1
 
 
 def run_steps(

--- a/etl/command.py
+++ b/etl/command.py
@@ -261,18 +261,15 @@ def main_cli(
             global_changes = _global_checksum_inputs_changed(files_changed)
             modified_steps = _modified_steps(includes=steps, exact_match=exact_match, files_changed=files_changed)
 
-            # `--modified` surfaces modified viz/export steps (chart, explorer, bespoke, export recipes) by
-            # design, but they're only buildable when their flag is passed (see construct_subdag).
-            # When a branch edits only such a recipe (e.g. a single `<explorer>.<key>.config.yml`),
-            # without this we would exclude it downstream and crash with "No steps matched".
-            # Enable the flag the modified steps need, so they actually rebuild. This applies whether
-            # or not the run is filtered below.
-            if not grapher and any(s.startswith(GRAPHER_FLAG_PREFIXES) for s in modified_steps):
+            # `--modified` surfaces modified viz steps (chart/explorer recipes) by design, but they're
+            # only buildable with --grapher (see construct_subdag). When a branch edits only such a
+            # recipe (e.g. a single `<explorer>.<key>.config.yml`), without this we would exclude it
+            # downstream and crash with "No steps matched". Enable --grapher so it actually rebuilds,
+            # whether or not the run is filtered below. --export is never inferred: it gates uploads
+            # to shared destinations (R2, GitHub) and must stay an explicit choice.
+            if not grapher and any(s.startswith("viz://") for s in modified_steps):
                 grapher = True
                 click.echo("Detected modified viz:// step(s); enabling --grapher for this run.")
-            if not export and any(s.startswith(EXPORT_FLAG_PREFIXES) for s in modified_steps):
-                export = True
-                click.echo("Detected modified export:// step(s); enabling --export for this run.")
 
             if global_changes:
                 # These files aren't under etl/steps/ or snapshots/, so _modified_steps would see
@@ -584,9 +581,9 @@ def _explain_missing_flags(dag: DAG, includes: list[str], exact_match: bool, gra
 
     gated = []
     if not grapher:
-        gated.append((GRAPHER_FLAG_PREFIXES, "writes to the grapher DB; pass --grapher to run it."))
+        gated.append((GRAPHER_FLAG_PREFIXES, "is skipped without --grapher; pass it to run this step."))
     if not export:
-        gated.append((EXPORT_FLAG_PREFIXES, "writes to an external destination (R2, GitHub); pass --export to run it."))
+        gated.append((EXPORT_FLAG_PREFIXES, "is skipped without --export; pass it to run this step."))
     if exact_match:
         requested = [step for step in includes if step in dag]
     else:

--- a/etl/config.py
+++ b/etl/config.py
@@ -398,6 +398,7 @@ class OWIDEnv:
     _env_local: OWIDEnvType | None
     conf: Config
     _engine: Engine | None
+    _engine_pid: int | None
 
     def __init__(
         self,
@@ -408,8 +409,9 @@ class OWIDEnv:
         self._env_remote = None
         # Local environment: environment where the code is running
         self._env_local = None  # "production", "staging", "dev"
-        # Engine (cached)
+        # Engine (cached per process, see `engine`)
         self._engine = None
+        self._engine_pid = None
 
     @property
     def env(self) -> OWIDEnvType:
@@ -493,11 +495,19 @@ class OWIDEnv:
 
     @property
     def engine(self) -> Engine:
-        """Get engine for env."""
+        """Get engine for env.
+
+        Cached per process: a step forked by `etlr` inherits this object from its parent, but not
+        usable DB sockets (the child closes every inherited file descriptor), so an engine created
+        in the parent must not be reused in the child. `etl.db.get_engine` memoizes by pid for the
+        same reason.
+        """
         from etl.db import get_engine
 
-        if self._engine is None:
+        pid = os.getpid()
+        if self._engine is None or self._engine_pid != pid:
             self._engine = get_engine(self.conf.__dict__)
+            self._engine_pid = pid
         return self._engine
 
     @property

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -290,3 +290,27 @@ def test_construct_subdag_no_matches():
     with pytest.raises(SystemExit) as exc_info:
         cmd.construct_subdag(dag, includes=["nonexistent"])
     assert exc_info.value.code == 1
+
+
+def test_construct_subdag_explains_steps_skipped_for_missing_flag(capsys):
+    """Requesting a step whose flag is missing says which flag to pass, then exits."""
+    full_dag = {
+        "data://grapher/happiness/2023-01-01/happiness": set(),
+        "viz://chart/happiness/latest/happiness": {"data://grapher/happiness/2023-01-01/happiness"},
+        "export://s3/happiness/latest/happiness": {"data://grapher/happiness/2023-01-01/happiness"},
+    }
+
+    with pytest.raises(SystemExit):
+        cmd.construct_subdag(full_dag, includes=["viz://chart/happiness"])
+    captured = capsys.readouterr()
+    assert (
+        "`viz://chart/happiness/latest/happiness` writes to the grapher DB; pass --grapher to run it." in captured.out
+    )
+
+    with pytest.raises(SystemExit):
+        cmd.construct_subdag(full_dag, includes=["export://s3/happiness/latest/happiness"], exact_match=True)
+    captured = capsys.readouterr()
+    assert (
+        "`export://s3/happiness/latest/happiness` writes to an external destination (R2, GitHub); pass --export to run it."
+        in captured.out
+    )

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -304,13 +304,14 @@ def test_construct_subdag_explains_steps_skipped_for_missing_flag(capsys):
         cmd.construct_subdag(full_dag, includes=["viz://chart/happiness"])
     captured = capsys.readouterr()
     assert (
-        "`viz://chart/happiness/latest/happiness` writes to the grapher DB; pass --grapher to run it." in captured.out
+        "`viz://chart/happiness/latest/happiness` is skipped without --grapher; pass it to run this step."
+        in captured.out
     )
 
     with pytest.raises(SystemExit):
         cmd.construct_subdag(full_dag, includes=["export://s3/happiness/latest/happiness"], exact_match=True)
     captured = capsys.readouterr()
     assert (
-        "`export://s3/happiness/latest/happiness` writes to an external destination (R2, GitHub); pass --export to run it."
+        "`export://s3/happiness/latest/happiness` is skipped without --export; pass it to run this step."
         in captured.out
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,3 +67,18 @@ def test_OWIDEnv_dev():
 
     env._env_local = "dev"
     assert env.wizard_url == "http://localhost:8053/"
+
+
+def test_OWIDEnv_engine_is_not_shared_across_processes(monkeypatch):
+    """A forked step must not reuse the parent's engine: its pooled DB sockets are closed in the child."""
+    env = OWIDEnv.from_staging("branch")
+    first = env.engine
+    assert env.engine is first
+
+    # Simulate the fork: same object, different pid.
+    import os
+
+    monkeypatch.setattr(os, "getpid", lambda: -1)
+    second = env.engine
+    assert second is not first
+    assert env.engine is second


### PR DESCRIPTION
## Human summary

This PR adds a fix that emerged while running https://github.com/owid/etl/pull/6836 and some small related improvements.

---
> _Written by Claude Fable 5.1 — @pabloarosado at the wheel._

Follow-up to [#6836 "🔨 Rename export steps to viz://chart, viz://explorer, viz://static and viz://bespoke"](https://github.com/owid/etl/pull/6836), stacked on its branch; merge after it. These are the optional `etl/command.py` changes that were split out of the rename so that PR stays minimal.

- **Say which flag a skipped step needs.** Asking for a step without its flag, e.g. `etlr viz://chart/energy/latest/energy_prices`, used to print only "No steps matched" and a list of similar names, which is confusing when the name was right. It now prints `` `viz://chart/energy/latest/energy_prices` is skipped without --grapher; pass it to run this step. `` first (same for `export://` and `--export`). The hint names the flag rule only, since static viz steps write local files rather than to the DB.
- **Name the gated prefixes once** (`GRAPHER_FLAG_PREFIXES`, `EXPORT_FLAG_PREFIXES`) and build the skip patterns from them, so the rule and the hint can't drift apart.
- **`--modified` flag detection after global changes.** The rule that switches on `--grapher` when a modified step is a `viz://` step lived only in the branch that filters steps; when a global checksum file (`etl/config.py`, `pyproject.toml`) changed, that branch is skipped and the flag was never enabled. It now applies in both cases. `--export` is never inferred: it gates uploads to shared destinations (R2, GitHub) and stays an explicit choice, also under `--modified`.

- **Recreate `OWIDEnv.engine` after a fork.** The engine was cached on the `OWIDEnv` object for the whole process tree. `etlr` runs each step in a forked child that closes every inherited file descriptor, so once a grapher upsert had used the engine in the same worker process, the next forked viz step reused a pool of dead sockets and failed with `OSError: Bad file descriptor` (about thirty MDIMs in the rename's first staging build). The engine is now cached per process id, as `etl.db.get_engine` already was.

Tests: the hint (pattern and exact-match includes) in `tests/test_command.py`; the existing `construct_subdag` tests cover the prefix constants; the per-process engine in `tests/test_config.py`.