### PR TITLE
📜 Update docs leftovers for the viz:// step rename

### DIFF
--- a/docs/data/faostat.md
+++ b/docs/data/faostat.md
@@ -313,7 +313,7 @@ which there is new data (let us call the new dataset version to be created `YYYY
 10. Run the explorers step, to update the global food explorer.
 
     ```bash
-    etl run explorers/faostat/latest/global_food --export
+    etl run viz://explorer/faostat/latest/global_food --grapher
     ```
 
 11. Update titles and descriptions of snapshot origins (to use the custom dataset titles and descriptions defined in garden). Also, attributions will be added to origins.

--- a/docs/getting-started/project-content.md
+++ b/docs/getting-started/project-content.md
@@ -20,6 +20,7 @@ You don't need to understand all of them to get started, but as you work more wi
 | `docs/`, `.readthedocs.yaml`    | Project documentation config files and directory. |
 | `etl/`       | This is home to our ETL library. This is where all the recipes to generate our datasets live. |
 | `export/`    | Similar to `data/` but for `export` steps. |
+| `viz/`    | Similar to `data/` but for `viz` steps (charts, explorers, static images, bespoke visualizations). |
 | `lib/`    | Other OWID sub-packages. |
 | `owid_mcp/`    | OWID's MCP server code. |
 | `schemas/`    | Metadata schemas for ETL datasets. |

--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -71,9 +71,9 @@ views:
 
 ```
 
-The `dimensions` field specifies selectors, and the `views` field defines views for the selection. Since there are numerous possible configurations, `views` are usually generated programmatically (using function `etl.collection.multidim.expand_config`).
+The `dimensions` field specifies selectors, and the `views` field defines views for the selection. Since there are numerous possible configurations, `views` are usually generated programmatically (using function `etl.collection.expand_config`).
 
-You can also combine manually defined views with generated ones. See the `etl.collection.multidim` module for available helper functions or refer to examples from `etl/steps/viz/chart/`. Feel free to add or modify the helper functions as needed.
+You can also combine manually defined views with generated ones. See the `etl.collection` module for available helper functions or refer to examples from `etl/steps/viz/chart/`. Feel free to add or modify the helper functions as needed.
 
 The chart step loads the data dependencies and the config YAML file, adds `views` to the config, and then pushes the configuration to the database.
 
@@ -96,7 +96,7 @@ def run() -> None:
     config = paths.load_collection_config()
 
     # Create views.
-    config["views"] = multidim.expand_config(
+    config["views"] = expand_config(
         tb_annual,
         dimensions=["frequency", "source", "unit"],
         additional_config={"chartTypes": ["LineChart", "DiscreteBar"], "hasMapTab": True, "tab": "map"},

--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -8,12 +8,14 @@ icon: lucide/forward
 
 Viz steps (`viz://`) produce visualizations and export steps (`export://`) ship files to external destinations. They are defined in the `etl/steps/viz` and `etl/steps/export` directories and have a similar structure to regular steps. Viz steps are run with `--grapher`; export steps write to R2 or GitHub and are run with `--export`.
 
-The channel of a viz step says what it produces, and its output goes to the gitignored `viz/<channel>/...` folder:
+The channel of a viz step says what it produces:
 
 - `viz://chart/`: a chart or an MDIM (a chart is just an MDIM with no dimensions), upserted to the grapher DB. A chart step can be a bare `<name>.config.yml` with no Python file.
 - `viz://explorer/`: an explorer, upserted to the grapher DB.
 - `viz://static/`: a static image (PNG/SVG) rendered with matplotlib next to the recipe and committed.
 - `viz://bespoke/`: the data feed of a bespoke interactive visualization, uploaded to R2.
+
+Chart and explorer steps also write their expanded config to the gitignored `viz/<channel>/...` folder, like `data/` for data steps.
 
 ```bash
 etlr viz://explorer/minerals/latest/minerals --grapher

--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -8,28 +8,22 @@ icon: lucide/forward
 
 Viz steps (`viz://`) produce visualizations and export steps (`export://`) ship files to external destinations. They are defined in the `etl/steps/viz` and `etl/steps/export` directories and have a similar structure to regular steps. Viz steps are run with `--grapher`; export steps write to R2 or GitHub and are run with `--export`.
 
+The channel of a viz step says what it produces, and its output goes to the gitignored `viz/<channel>/...` folder:
+
+- `viz://chart/`: a chart or an MDIM (a chart is just an MDIM with no dimensions), upserted to the grapher DB. A chart step can be a bare `<name>.config.yml` with no Python file.
+- `viz://explorer/`: an explorer, upserted to the grapher DB.
+- `viz://static/`: a static image (PNG/SVG) rendered with matplotlib next to the recipe and committed.
+- `viz://bespoke/`: the data feed of a bespoke interactive visualization, uploaded to R2.
+
 ```bash
 etlr viz://explorer/minerals/latest/minerals --grapher
 ```
 
-The `def run():` function doesn't save a dataset, but calls a method that performs the action. For instance `create_explorer(...)` or `gh.commit_file_to_github(...)`. Once the step is executed successfully, it won't be run again unless its code or dependencies change (it won't be "dirty").
+The `def run():` function doesn't save a dataset, but calls a method that performs the action. For instance `paths.create_collection(...)` or `gh.commit_file_to_github(...)`. Once the step is executed successfully, it won't be run again unless its code or dependencies change (it won't be "dirty").
 
 ## Creating explorers
 
-TSV files for explorers are created using the `create_explorer` function, usually from a configuration YAML file
-
-```py
-# Create a new explorers dataset and tsv file.
-ds_explorer = paths.create_explorer(config=config, df_graphers=df_graphers)
-ds_explorer.save()
-```
-
-!!! info "Creating explorers on staging servers"
-
-    TODO: how do we push explorers to production?
-
-    Explorers can be created or edited on staging servers and then manually migrated to production. Each staging server creates a branch in the `owid-content` repository. Editing explorers in Admin or running the `create_explorer` function pushes changes to that branch. Once the PR is merged, the branch gets pushed to the `owid-content` repository (not to the `master` branch, but its own branch). You then need to manually create a PR from that branch and merge it into `master`.
-
+Explorers are created with `paths.create_collection(config=..., explorer=True)` from a configuration YAML file, and upserted to the grapher DB by `.save()`. They follow the same structure as MDIMs, see [MDIMs and Explorers](mdims.md).
 
 ## Creating multi-dimensional indicators
 
@@ -97,7 +91,7 @@ def run() -> None:
     # Process data.
     #
     # Load configuration from adjacent yaml file.
-    config = paths.load_mdim_config()
+    config = paths.load_collection_config()
 
     # Create views.
     config["views"] = multidim.expand_config(
@@ -109,7 +103,7 @@ def run() -> None:
     #
     # Save outputs.
     #
-    mdim = paths.create_mdim(config=config)
+    mdim = paths.create_collection(config=config)
     mdim.save()
 
 ```

--- a/docs/guides/data-work/index.md
+++ b/docs/guides/data-work/index.md
@@ -57,7 +57,7 @@ The first question you have to ask yourself is whether you want to add a new dat
 ## Update charts
 Once you have the data ready in the database, you can now [**update any chart**](update-charts) (or create new ones).
 
-Here, you can also decide whether you want to create or update an Explorer or an MDIM with the new data. This is done with [**export steps**](export-data.md).
+Here, you can also decide whether you want to create or update an Explorer or an MDIM with the new data. This is done with [**viz steps**](export-data.md).
 
 ## Migrate changes
 

--- a/docs/guides/data-work/mdims.md
+++ b/docs/guides/data-work/mdims.md
@@ -88,7 +88,7 @@ views:
 This example is fairly simple, and is entirely manual. The corresponding step script could simply look like:
 
 ```python
-from etl.collection import multidim
+from etl.collection import expand_config
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
@@ -145,7 +145,7 @@ In this example, we note that we can group together indicators from any dataset.
     Proper documentation of all available options will be available soon.
 
 ### Automated MDIMs
-MDIMs are very suitable for those datasets that have a lot of dimensions in them. For these, one can leverage functions like `etl.collection.multidim.expand_config`, which programmatically generates all possible views from an indicator (or multiple ones) in a table.
+MDIMs are very suitable for those datasets that have a lot of dimensions in them. For these, one can leverage functions like `etl.collection.expand_config`, which programmatically generates all possible views from an indicator (or multiple ones) in a table.
 
 !!! question "What does it mean for a dataset to have dimensions?"
     Datasets with dimensions are those that have additional index (e.g. `age`) in Garden, beyond the standard ones (`year` or `date`, and `country`).
@@ -215,7 +215,7 @@ def run() -> None:
     config = paths.load_collection_config()
 
     # Create views.
-    config["views"] = multidim.expand_config(
+    config["views"] = expand_config(
         tb_annual,
         dimensions=["frequency", "source", "unit"],
         additional_config={"chartTypes": ["LineChart", "DiscreteBar"], "hasMapTab": True, "tab": "map"},
@@ -229,7 +229,7 @@ def run() -> None:
 
 ```
 
-You can also combine manually defined views with generated ones. See the `etl.collection.multidim` module for available helper functions or refer to examples from `etl/steps/viz/chart/`.
+You can also combine manually defined views with generated ones. See the `etl.collection` module for available helper functions or refer to examples from `etl/steps/viz/chart/`.
 
 
 ### Defining view configurations
@@ -309,7 +309,7 @@ Some key differences are:
 - **View config has different fields:** MDIMs rely on our standard grapher configs. Instead, Explorers rely on a custom configuration. Fields available are equivalent to the columns that are available in the `grapher` table of a legacy explorer config in admin.
 - **Indicator display config**: Explorers also rely on a custom configuration. Fields available are equivalent to the columns that are available in the `columns` table of a legacy explorer config in admin.
 
-Also, instead of relying on `etl.collection.multidim`, you should instead use the functions from `etl.collection.explorer`.
+The same helpers work for explorers: pass `explorer=True` to `paths.create_collection`.
 
 !!! note "There is no schema for explorers"
 

--- a/docs/guides/data-work/mdims.md
+++ b/docs/guides/data-work/mdims.md
@@ -96,9 +96,9 @@ paths = PathFinder(__file__)
 
 def run() -> None:
     # Load configuration from adjacent yaml file.
-    config = paths.load_mdim_config(fname)
+    config = paths.load_collection_config(fname)
     # Create MDIM object
-    mdim = paths.create_mdim(config)
+    mdim = paths.create_collection(config)
     # Save to DB
     mdim.save()
 ```
@@ -212,7 +212,7 @@ def run() -> None:
     # Process data.
     #
     # Load configuration from adjacent yaml file.
-    config = paths.load_mdim_config()
+    config = paths.load_collection_config()
 
     # Create views.
     config["views"] = multidim.expand_config(
@@ -224,7 +224,7 @@ def run() -> None:
     #
     # Save outputs.
     #
-    mdim = paths.create_mdim(config=config)
+    mdim = paths.create_collection(config=config)
     mdim.save()
 
 ```
@@ -321,11 +321,7 @@ Also, instead of relying on `etl.collection.multidim`, you should instead use th
 - [:fontawesome-brands-github:  Climate change](https://github.com/owid/etl/blob/master/etl/steps/viz/explorer/climate/latest/climate_change.config.yml): Manually crafted.
 
 ### How are explorers saved in admin?
-While MDIMs are pushed to our database, explorers need to go through the old legacy channel of `owid-content` repository. Hence, when calling `Explorer.save`, the configuration is re-shaped and stored as a TSV file in `owid-content`.
-
-
-!!! info "Creating explorers on staging servers"
-    Explorers can be created or edited on staging servers and then manually migrated to production. Each staging server creates a branch in the `owid-content` repository. Editing explorers in Admin or running the `create_explorer` function pushes changes to that branch. Once the PR is merged, the branch gets pushed to the `owid-content` repository (not to the `master` branch, but its own branch). You then need to manually create a PR from that branch and merge it into `master`.
+Like MDIMs, explorers are upserted to the grapher DB when calling `.save()`. Staging servers write to their own DB, and production is updated when the PR is merged.
 
 ## MDIM pending features
 For better reference, read [:fontawesome-brands-github: this issue](https://github.com/owid/etl/issues/3992), or follow the latest news in `#proj-explorers-mdims-convergence`.

--- a/docs/guides/vscode-extensions.md
+++ b/docs/guides/vscode-extensions.md
@@ -65,7 +65,7 @@ Turn DAG entries into clickable links with visual status feedback:
 
 !!! note "How it works"
 
-    - Click any DAG entry to open its `.py` file (data/export steps) or `.dvc` file (snapshots)
+    - Click any DAG entry to open its `.py` file (data/viz/export steps) or `.dvc` file (snapshots)
     - Status emoji appears based on step version and health
     - Works across all DAG files in the project
 
@@ -166,7 +166,7 @@ The panel **auto-rebuilds** when you save the step file (uses `etlr --watch` in 
 
 #### Chart preview
 
-Embeds the staging admin chart viewer for `.chart.yml` and multidim export steps.
+Embeds the staging admin chart viewer for `.chart.yml` files and `viz://chart` steps (charts and MDIMs).
 
 !!! note "How it works"
 

--- a/docs/guides/vscode-extensions.md
+++ b/docs/guides/vscode-extensions.md
@@ -65,7 +65,7 @@ Turn DAG entries into clickable links with visual status feedback:
 
 !!! note "How it works"
 
-    - Click any DAG entry to open its `.py` file (data/viz/export steps) or `.dvc` file (snapshots)
+    - Click any DAG entry to open its recipe (`.py`, or `.config.yml` for YAML-only chart steps) or `.dvc` file (snapshots)
     - Status emoji appears based on step version and health
     - Works across all DAG files in the project
 

--- a/etl/steps/data/garden/food/2026-05-06/clark_et_al_2022.meta.yml
+++ b/etl/steps/data/garden/food/2026-05-06/clark_et_al_2022.meta.yml
@@ -6,7 +6,7 @@ definitions:
       grapher_config:
         # Per-bar colors on the explorer's single-y `specific_food_product` views.
         # Explicitly cleared for `all_impacts` (facet) and `compare_units` group views
-        # in `etl/steps/export/explorers/food/latest/food_footprints.py`.
+        # in `etl/steps/viz/explorer/food/latest/food_footprints.py`.
         baseColorScheme: owid-distinct
 
 tables:


### PR DESCRIPTION
## Human summary

Update the etl docs to mention the new `viz` channel (which will come with https://github.com/owid/etl/pull/6836), and update some stale bits in the guides.

---
> _Written by Claude Fable 5.1 — @pabloarosado at the wheel._

Docs leftovers from [#6836 "🔨 Rename export steps to viz://chart, viz://explorer, viz://static and viz://bespoke"](https://github.com/owid/etl/pull/6836). Stacked on that branch; merge after it. Seven files, about 60 changed lines.

**Name stragglers the rename missed**

- `docs/data/faostat.md`: the global food explorer command now uses `viz://explorer/...` and `--grapher` (the old `explorers/... --export` form matches nothing).
- `docs/getting-started/project-content.md`: add the `viz/` output folder.
- `docs/guides/data-work/index.md`: explorers and MDIMs are viz steps, not export steps.
- `docs/guides/vscode-extensions.md`: clickable DAG and chart preview descriptions use the new step names.
- `etl/steps/data/garden/food/2026-05-06/clark_et_al_2022.meta.yml`: comment points at the moved food footprints explorer recipe. Comment-only, but it changes the step checksum, so staging rebuilds that garden step and its downstream steps once.

**Stale explanations in the two viz guides** (`docs/guides/data-work/export-data.md`, `docs/guides/data-work/mdims.md`)

- `paths.load_mdim_config` and `paths.create_mdim` no longer exist; the examples now use `load_collection_config` and `create_collection`.
- The explorer sections described the old owid-content TSV flow (with a "TODO: how do we push explorers to production?"). Explorers are upserted to the grapher DB like MDIMs, so both sections are replaced by two sentences saying so.
- The viz guide gets a short list of the four channels and what each produces.
- Both guides pointed at `etl.collection.multidim`, a module that no longer exists; `expand_config` is imported from `etl.collection` now, and explorers use the same helpers with `explorer=True`.

Left alone on purpose: the one-off migration notebooks under `etl/steps/viz/explorer/*/migrate_*.ipynb` and `scripts/execution_times.ipynb`, which are historical records.

