### PR TITLE
🐝 Remove the leftover multidim data channel from the catalog

### DIFF
--- a/lib/catalog/owid/catalog/core/datasets.py
+++ b/lib/catalog/owid/catalog/core/datasets.py
@@ -52,7 +52,6 @@ CHANNEL = Literal[
     "examples",
     "explorers",
     "external",
-    "multidim",
 ]
 
 # all pandas nullable dtypes

--- a/lib/catalog/owid/catalog/core/paths.py
+++ b/lib/catalog/owid/catalog/core/paths.py
@@ -16,7 +16,6 @@ CHANNEL = Literal[
     "examples",
     "explorers",
     "external",
-    "multidim",
 ]
 
 # Set of valid channels for runtime validation

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-catalog"
-version = "1.2.4"
+version = "1.2.5"
 description = "Core data types used by OWID for managing data."
 readme = "README.md"
 authors = [{ name = "Our World in Data", email = "tech@ourworldindata.org" }]

--- a/lib/catalog/tests/test_catalog_path.py
+++ b/lib/catalog/tests/test_catalog_path.py
@@ -443,7 +443,6 @@ class TestAdditionalCoverage:
             "examples",
             "explorers",
             "external",
-            "multidim",
         ]
         for channel in channels:
             p = CatalogPath.from_str(f"{channel}/ns/2024/ds")

--- a/lib/catalog/uv.lock
+++ b/lib/catalog/uv.lock
@@ -1306,7 +1306,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },

--- a/uv.lock
+++ b/uv.lock
@@ -4482,7 +4482,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "lib/catalog" }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
## Human summary

Remove some references to the old multidim channel, which is no longer needed.

---
> _Written by Claude Fable 5.1 — @pabloarosado at the wheel._

The data catalog's channel list still contains `multidim`, added in [#4292 "🎉 save and load MDIMs, combine MDIMs"](https://github.com/owid/etl/pull/4292) when MDIM configs were briefly saved as datasets under `data/multidim/`. MDIMs have been chart configs upserted to the grapher DB ever since (today via `viz://chart` steps, see [#6836](https://github.com/owid/etl/pull/6836)), so no build has had a `data/multidim/` folder for a long time. The only effect of the entry was the "Publish data-catalog" job looking for that folder and writing an empty `catalog-multidim.feather` on every deploy.

This removes the channel from the `CHANNEL` literal in `owid.catalog.core.paths` and `owid.catalog.core.datasets`, and from the test that enumerates channels. Three deletions, no other change. The `multidim` strings in `apps/inspector` refer to collection types, not catalog channels, and stay.

After merging, the stale `catalog-multidim.feather` on R2 is simply no longer referenced; nothing reads it.