### PR TITLE
📜 Document owid-catalog maintenance and backfill the changelog

### DIFF
--- a/docs/libraries/catalog/maintenance.md
+++ b/docs/libraries/catalog/maintenance.md
@@ -18,12 +18,15 @@ pip install owid-catalog
 After working on your changes in the library, publishing to PyPI is automated:
 
 1. **Bump the version** in [:fontawesome-brands-github: `lib/catalog/pyproject.toml`](https://github.com/owid/etl/blob/master/lib/catalog/pyproject.toml)
-2. **Update the changelog** in [:fontawesome-brands-github: `lib/catalog/README.md`](https://github.com/owid/etl/blob/master/lib/catalog/README.md?plain=1#L215)
-3. **Commit and push to `master`** - the package will be automatically published to PyPI via [:fontawesome-brands-github: GitHub Actions](https://github.com/owid/etl/actions/workflows/publish-owid-catalog.yml)
+2. **Update the changelog** in [:fontawesome-brands-github: `lib/catalog/README.md`](https://github.com/owid/etl/blob/master/lib/catalog/README.md#changelog)
+3. **Refresh both lockfiles** — the version is recorded in `lib/catalog/uv.lock` *and* in the repo-root `uv.lock`; run `make .venv` in `lib/catalog/` and at the repo root
+4. **Commit and push to `master`** - the package will be automatically published to PyPI via [:fontawesome-brands-github: GitHub Actions](https://github.com/owid/etl/actions/workflows/publish-owid-packages.yml)
 
 The workflow triggers automatically when `lib/catalog/pyproject.toml` changes on the master branch. It includes a safety check to ensure the version was actually bumped before publishing.
 
-**Manual trigger:** You can still manually trigger the workflow by clicking `Run Workflow` in [:fontawesome-brands-github: GitHub Actions](https://github.com/owid/etl/actions/workflows/publish-owid-catalog.yml) if needed.
+**Manual trigger:** You can still manually trigger the workflow by clicking `Run Workflow` in [:fontawesome-brands-github: GitHub Actions](https://github.com/owid/etl/actions/workflows/publish-owid-packages.yml) if needed.
+
+Nothing bumps the version for you: a PR that only changes library source files publishes nothing, and those changes ship with whoever bumps next. The full maintainer guide — release checklist, versioning practice, dev environment, and which checks actually cover `lib/catalog` — is in [:fontawesome-brands-github: `lib/catalog/DEVELOPMENT.md`](https://github.com/owid/etl/blob/master/lib/catalog/DEVELOPMENT.md).
 
 ### Generate `llms.txt`
 

--- a/lib/catalog/CLAUDE.md
+++ b/lib/catalog/CLAUDE.md
@@ -58,7 +58,7 @@ make format             # Format code with ruff
 make lint               # Lint and auto-fix with ruff
 make check-linting      # Check linting without fixing
 make check-formatting   # Check formatting without fixing
-make check-typing       # Type check with pyright
+make check-typing       # Type check with ty
 make unittest           # Run unit tests only
 make coverage           # Run tests with coverage report
 ```
@@ -87,11 +87,11 @@ The library follows a layered metadata architecture:
 
 ```
 Dataset (folder with index.json)
-├── metadata: DatasetMeta (title, description, sources, licenses)
+├── metadata: DatasetMeta (title, description, origins, licenses)
 └── Tables (feather/parquet/csv files)
     ├── metadata: TableMeta (table-level metadata)
     └── Variables (columns)
-        └── metadata: VariableMeta (unit, description, sources, etc.)
+        └── metadata: VariableMeta (unit, description, origins, etc.)
 ```
 
 ### Package Structure
@@ -122,7 +122,7 @@ owid/catalog/
 - **`tables.py`**: Table class with metadata-aware operations
 - **`indicators.py`**: Variable/Indicator class (pandas.Series with metadata)
 - **`datasets.py`**: Dataset container and serialization logic
-- **`meta.py`**: All metadata dataclasses (DatasetMeta, TableMeta, VariableMeta, Source, Origin, License)
+- **`meta.py`**: All metadata dataclasses (DatasetMeta, TableMeta, VariableMeta, Origin, License)
 - **`processing.py`**: Pandas-like functions that propagate metadata (concat, merge, melt, pivot)
 
 ### API Module (`owid.catalog.api`)
@@ -256,7 +256,7 @@ tb = pr.read_rda("data.rda")
 - Use fixtures from `conftest.py` for common test setup
 - Mock data generation utilities in `tests/mocking.py`
 - Test both functionality and metadata preservation
-- Run type checking with pyright - must pass before committing
+- Run type checking with ty - must pass before committing
 
 ## Dependencies
 
@@ -282,9 +282,11 @@ uv build
 # Package will be in dist/ directory
 ```
 
+Releases are **not** automatic: the version in `pyproject.toml` is bumped by hand, and pushing that bump to `master` is what triggers the PyPI publish. See [`DEVELOPMENT.md`](DEVELOPMENT.md) for the release checklist, versioning practice, and which checks actually cover this directory (the repo-root pre-commit hook does not).
+
 ## Configuration Files
 
-- **pyproject.toml**: Package dependencies, tool configuration (ruff, pyright, hatch)
+- **pyproject.toml**: Package dependencies, tool configuration (ruff, ty, hatch)
 - **Makefile**: Development command shortcuts (includes `../../default.mk`)
 - **.pre-commit-config.yaml**: Pre-commit hooks configuration
 
@@ -294,4 +296,4 @@ uv build
 - This library is experimental - APIs may change
 - Extends ruff configuration from parent `../../pyproject.toml`
 - Always run `make check` before committing changes
-- Type checking is mandatory - must pass pyright checks
+- Type checking is mandatory - must pass ty checks

--- a/lib/catalog/DEVELOPMENT.md
+++ b/lib/catalog/DEVELOPMENT.md
@@ -1,0 +1,168 @@
+# Maintaining `owid-catalog`
+
+How this library is versioned, released and checked. For what the library *is* and how
+to use it, see [`README.md`](README.md); for the architecture and coding patterns, see
+[`CLAUDE.md`](CLAUDE.md).
+
+## Where it lives, and who sees your change
+
+The library lives at `lib/catalog/` inside [owid/etl](https://github.com/owid/etl) and is
+published to PyPI as [`owid-catalog`](https://pypi.org/project/owid-catalog/).
+
+The `etl` repo consumes it as an **editable path dependency** — the repo-root
+`pyproject.toml` declares:
+
+```toml
+owid-catalog = { path = "lib/catalog", editable = true }
+```
+
+So a change is live for everything in this repo (ETL steps, `apps/`, wizard, tests) the
+moment it merges — no version bump, no release, no waiting. A release only matters for
+consumers *outside* the repo: notebooks and other repos that `pip install owid-catalog`.
+
+## Nothing bumps the version for you
+
+`version = "..."` in `lib/catalog/pyproject.toml` is edited by hand. There is no
+auto-increment, no release-please, no version-from-tag. A PR that changes only source
+files publishes nothing and leaves the version where it was.
+
+Publishing is automated *once the version changes*, by
+[`.github/workflows/publish-owid-packages.yml`](../../.github/workflows/publish-owid-packages.yml):
+
+- **Trigger**: push to `master` whose diff touches `lib/catalog/pyproject.toml` (same for
+  `lib/datautils` and `lib/repack`) — the `paths:` filter — or a manual
+  `workflow_dispatch` with `package` = `catalog` | `datautils` | `repack` | `all`.
+- **`detect-changes` job**: diffs the last commit on `master` (`git diff HEAD~1 HEAD`) to
+  decide which of the three packages to build.
+- **`publish` job**: reads the version out of `pyproject.toml`, asks
+  `https://pypi.org/pypi/owid-catalog/<version>/json`, and **fails** with
+  *"Please increment the version before publishing"* if that version already exists.
+  Otherwise `uv build` + `uv publish --trusted-publishing always` — PyPI trusted
+  publishing over OIDC (the job's `id-token: write` permission and the `pypi`
+  environment), so there is no API token to rotate.
+
+Consequences worth knowing:
+
+- **Source changes accumulate.** Everything merged since the last bump ships with
+  whoever bumps next — they are, in effect, releasing other people's work. Write the
+  changelog from the commit range, not from memory (see below).
+- `lib/owl` and `lib/walden` are **not** in this workflow — no release of them happens
+  from here (`lib/walden` has no `pyproject.toml` at all).
+- A published version can never be replaced. If you shipped something broken, bump again.
+
+## Cutting a release
+
+From `lib/catalog/`:
+
+1. **Bump** `version` in `pyproject.toml`.
+2. **Write the changelog** — a new section at the top of the *Changelog* in `README.md`,
+   covering everything since the last release, which you can list with:
+
+   ```bash
+   # <last-bump> = the commit that set the previous version
+   git log --oneline --no-merges <last-bump>..HEAD -- lib/catalog/owid
+   ```
+
+   `lib/catalog/owid` (rather than `lib/catalog`) filters out commits that only touched
+   the lockfile or CI. Group entries the way existing sections do, and name the
+   replacement for anything you removed.
+3. **Refresh both lockfiles.** The version is recorded twice: in `lib/catalog/uv.lock`
+   and in the repo-root `uv.lock` (as `owid-catalog … source = { editable = "lib/catalog" }`).
+   Run `make .venv` in `lib/catalog/` **and** at the repo root — or `uv lock` in both.
+   Every past bump touches all three files; a bump that only edits `pyproject.toml`
+   leaves the repo out of sync.
+4. **Check** (`make check && make test` from `lib/catalog/`) and, because the whole repo
+   uses the working copy, run the root `make unittest` too.
+5. **Merge to `master`.** The workflow publishes within a few minutes; confirm on
+   [PyPI](https://pypi.org/project/owid-catalog/) and in the
+   [Actions run](https://github.com/owid/etl/actions/workflows/publish-owid-packages.yml).
+
+### Choosing the number
+
+There is no written policy; this is what the history does (the package is still
+`Development Status :: 4 - Beta`, and the README calls the API experimental):
+
+| Part | Used for | Examples |
+|------|----------|----------|
+| MAJOR | redesign of the public surface | `1.0.0` — restructure into `core`/`api`, unified `Client` |
+| MINOR | removing or renaming public API | `1.1.0` dropped the processing log; `1.2.0` dropped `Source`/`sources` |
+| PATCH | additive API, bug fixes, dependency bumps, Python-support changes | `1.2.1`–`1.2.4` |
+
+Note that breaking *removals* have not been treated as major: `1.1.0` and `1.2.0` took
+public API away in minor releases, and `1.2.4` dropped `display.yearIsDay` in a patch. So
+pinning `owid-catalog` loosely is not enough to be safe — and when you do remove something,
+say so prominently in the changelog.
+
+### When a bump is worth it
+
+Bump when someone outside this repo needs the change: an external notebook or repo, a
+security fix in a dependency of the published wheel (`1.2.3`), or a rebuild to pick up
+tooling changes (`1.2.2` was a republish and nothing else). Skip it when the change only
+matters to `etl` itself — it is already live — and accept that it will ride along with
+the next bump.
+
+## Development environment
+
+`lib/catalog/` has **its own** venv, `Makefile` and `uv.lock`, separate from the repo root:
+
+```bash
+cd lib/catalog
+make .venv          # uv sync --all-extras --group dev
+.venv/bin/pytest tests/
+```
+
+- **Never run bare `uv sync`** — it prunes optional dependencies. `make .venv` runs the
+  right command.
+- Change dependencies with `uv add` / `uv remove` from inside `lib/catalog/`, then
+  refresh the root lockfile as well (step 3 above).
+- Targets come from [`../../default.mk`](../../default.mk): `make test`
+  (= `check-formatting check-linting check-typing unittest`), `make check` (fix + lint +
+  typecheck), `make watch`, `make unittest`, `make coverage`, `make format`, `make lint`.
+- The typechecker is **`ty`**, pinned in the dev dependencies (`ty==0.0.55` at the time of
+  writing), together with `ruff` for lint and format. `pyright` and `mypy` are long gone.
+- A stale, gitignored `.python-version` in this directory is a common local trap: `uv`
+  honours it and then warns that it *"resolved to Python 3.10.x, which is incompatible
+  with the project's Python requirement"*. Fix it with `uv python pin 3.13` (or delete
+  the file) and rebuild the venv.
+- `make bump` exists in `default.mk` but is dead here — `bump2version` is not a dependency
+  of this package. Edit `pyproject.toml`.
+
+## What actually checks your change
+
+- **The repo-root pre-commit hook does not cover this directory.** It runs the root
+  `make check`, whose `SRC` is `etl snapshots apps api_search tests docs owid_mcp
+  owl_steps lib/owl/owl` — `lib/catalog` is not in it. Committing a library change from
+  the repo root lints and typechecks nothing of it. Run `make check` and `make test`
+  from inside `lib/catalog/`.
+- From the repo root, `make test-all`, `make check-all` and `make format-all` loop over
+  `LIBS` (`lib/catalog lib/datautils lib/owl lib/repack`) after doing the root itself.
+- `lib/catalog/.pre-commit-config.yaml` wires the same three checks for anyone running
+  `pre-commit` inside this directory.
+- `lib/catalog/.github/workflows/python-package.yml` is a leftover from when the library
+  had its own repository. GitHub only reads workflows from the repo root, so **it never
+  runs here**, even though action-pinning PRs keep updating it.
+- Unit tests are run by the Buildkite pipeline behind the badge at the top of
+  `README.md` (`owid-catalog-unit-tests`); that pipeline's configuration lives outside
+  this repo, so its run history is the place to check what it did.
+
+## Backwards compatibility
+
+External code imports from `owid.catalog`, so treat that surface as public:
+
+- Top-level stub modules (`meta.py`, `tables.py`, `utils.py`, `processing.py`) re-export
+  from `owid/catalog/core/`. Keep them importable.
+- `Variable` and `Indicator` are the same class; both names are in use.
+- Metadata dataclasses are serialized into published catalog artifacts (`index.json`,
+  `*.meta.json`) and read back by this library, so renaming or dropping a metadata field
+  affects data that is already out there — check that older artifacts still load.
+- Anything removed belongs in the changelog with its replacement named, the way the
+  `1.1.0` and `1.2.0` entries do.
+
+## Documentation
+
+- Prose docs: `docs/libraries/catalog/{intro,api,structures,maintenance}.md`, with the
+  nav in `zensical.toml`. `maintenance.md` is the reader-facing version of this file.
+- Some pages are generated at build time by `docs/ignore/pre-build/bake_*.py` (run by
+  `make docs.pre` from the repo root), including `bake_catalog_api.py`.
+- `docs/libraries/catalog/llms.txt` is generated from docstrings and docs by
+  `make docs.llms` (repo root). Regenerate it after changing public docstrings.

--- a/lib/catalog/DEVELOPMENT.md
+++ b/lib/catalog/DEVELOPMENT.md
@@ -86,12 +86,12 @@ There is no written policy; this is what the history does (the package is still
 |------|----------|----------|
 | MAJOR | redesign of the public surface | `1.0.0` — restructure into `core`/`api`, unified `Client` |
 | MINOR | removing or renaming public API | `1.1.0` dropped the processing log; `1.2.0` dropped `Source`/`sources` |
-| PATCH | additive API, bug fixes, dependency bumps, Python-support changes | `1.2.1`–`1.2.4` |
+| PATCH | additive API, bug fixes, dependency bumps, Python-support changes | `1.2.1`–`1.2.5` |
 
 Note that breaking *removals* have not been treated as major: `1.1.0` and `1.2.0` took
-public API away in minor releases, and `1.2.4` dropped `display.yearIsDay` in a patch. So
-pinning `owid-catalog` loosely is not enough to be safe — and when you do remove something,
-say so prominently in the changelog.
+public API away in minor releases, while `1.2.4` dropped `display.yearIsDay` and `1.2.5`
+dropped a `CHANNEL` member — both in patches. So pinning `owid-catalog` loosely is not
+enough to be safe, and when you do remove something, say so prominently in the changelog.
 
 ### When a bump is worth it
 

--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://badge.buildkite.com/66cc67fc572120ca97b9ffff288d5d73cb33e019dd70323053.svg)](https://buildkite.com/our-world-in-data/owid-catalog-unit-tests)
 [![PyPI version](https://badge.fury.io/py/owid-catalog.svg)](https://badge.fury.io/py/owid-catalog)
-![](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg)
+![](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)
 
 # owid-catalog
 
@@ -73,7 +73,7 @@ This library is part of OWID's [ETL project](https://github.com/owid/etl), which
 
 ## Development
 
-You need Python 3.10+, `uv` and `make` installed. Clone the repo, then you can simply run:
+You need Python 3.11+, `uv` and `make` installed. Clone the repo, then you can simply run:
 
 ```
 # run all unit tests and CI checks
@@ -83,7 +83,44 @@ make test
 make watch
 ```
 
+Maintainer notes — how the version is bumped, how a release reaches PyPI, and which checks actually cover this directory — are in [`DEVELOPMENT.md`](DEVELOPMENT.md).
+
 ## Changelog
+
+### Unreleased
+Merged to `master` but not published yet — see [`DEVELOPMENT.md`](DEVELOPMENT.md) for how a release is cut.
+- Render metadata Jinja in a `SandboxedEnvironment`, so a producer-supplied value containing `<<` or `<%` cannot walk `__class__`/`__subclasses__` on whatever runs the ETL
+- Fail loudly on a character-exploded `description_key` (a markdown string that was iterated character by character): `Markdown` is now a `str` subclass that raises `TypeError` on iteration, alongside a new `validate_description_key_list()` sanity check
+- New `s3_utils.object_exists()` to check for an object without downloading it
+
+### `v1.2.4`
+- **Python support**
+  - Add Python 3.14, drop Python 3.10 (`requires-python = ">=3.11, <3.15"`)
+  - Drop the `typing_extensions` fallbacks for `Self`, `Required` and `NotRequired`
+- **`description_key` becomes free-form markdown**
+  - `VariableMeta.description_key` is now a markdown string
+  - A list of bullet points is still accepted (items may carry per-item Jinja) and is converted to a markdown list after rendering — the grapher only ever sees a string
+  - New `description_key_to_string()` in `owid.catalog.core.meta`, reproducing how the grapher rendered those lists before
+- **Display metadata**
+  - Add `display.timeInterval` (`day`, `week`, `month`, `quarter`, `year`, `decade`)
+  - Remove the deprecated `display.yearIsDay`
+
+### `v1.2.3`
+- `combine_indicators_processing_level` tolerates unrendered Jinja templates in `processing_level` instead of asserting on an unknown level — when a template is combined with a literal it overstates rather than understates the result, since `processing_level` feeds licensing downstream
+- `s3_utils.upload()` accepts `content_type` and `cache_control`
+- Catalog JSON-LD (`schema_org`): license and keyword fixes, `citation` dropped
+- Dependency bumps for security advisories
+
+### `v1.2.2`
+- Add `owners` to `DatasetMeta`
+- New `Dataset.update_metadata_from_dict()` and `yaml_metadata.update_metadata_from_dict()`, for callers that already hold parsed metadata rather than a YAML path (used by the Owl runner)
+- New `schema_org` module emitting schema.org JSON-LD for catalog datasets and tables, with follow-ups: stable short landing-page URLs, table descriptions filled from existing metadata, an explicit dataset description requirement, and unrendered Jinja templates kept out of the output
+- YAML variable checks accept a long-format base name as a match for pivoted `{base}__{dim}_{value}` columns, so a `long_to_wide` override block is no longer flagged as a typo
+- Republished to PyPI after the `ty` upgrade, with no functional change of its own
+
+### `v1.2.1`
+- Send `User-Agent: owid-catalog/<version> (python <x.y.z>)` on every outbound HTTP call, via a shared `requests.Session` in `owid.catalog.api.utils` (plus `STORAGE_OPTIONS` for the pandas reads that cannot take a session)
+- `prune_dict()` keeps explicitly-empty values for keys listed in `KEEP_IF_EMPTY`: `chartTypes: []` is a meaningful "render no chart-type toggles" override, not the same as an absent key
 
 ### `v1.2.0`
 - **Remove legacy `Source` metadata (origins only)**

--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -87,8 +87,8 @@ Maintainer notes — how the version is bumped, how a release reaches PyPI, and 
 
 ## Changelog
 
-### Unreleased
-Merged to `master` but not published yet — see [`DEVELOPMENT.md`](DEVELOPMENT.md) for how a release is cut.
+### `v1.2.5`
+- Remove the leftover `multidim` channel from `CHANNEL` in `core.datasets` and `core.paths`. MDIM configs were written as datasets under `data/multidim/` for a short while in 2025; they have lived outside the data catalog since, so the channel only made the publish job look for an empty folder and write an empty index file on every deploy
 - Render metadata Jinja in a `SandboxedEnvironment`, so a producer-supplied value containing `<<` or `<%` cannot walk `__class__`/`__subclasses__` on whatever runs the ETL
 - Fail loudly on a character-exploded `description_key` (a markdown string that was iterated character by character): `Markdown` is now a `str` subclass that raises `TypeError` on iteration, alongside a new `validate_description_key_list()` sanity check
 - New `s3_utils.object_exists()` to check for an object without downloading it


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

`lib/catalog` had no maintainer guide, and the changelog stopped at `v1.2.0`.

| What | Where |
|------|-------|
| New maintainer guide | [`lib/catalog/DEVELOPMENT.md`](https://github.com/owid/etl/blob/docs-catalogmaintenance-changelogbackfill/lib/catalog/DEVELOPMENT.md) |
| Changelog `v1.2.1`–`v1.2.5` | [`lib/catalog/README.md`](https://github.com/owid/etl/blob/docs-catalogmaintenance-changelogbackfill/lib/catalog/README.md#changelog) |
| Staff docs page refreshed | [`docs/libraries/catalog/maintenance.md`](https://github.com/owid/etl/blob/docs-catalogmaintenance-changelogbackfill/docs/libraries/catalog/maintenance.md) |

Notes on the non-obvious bits:

- The changelog entries were reconstructed from `git log --oneline <bump>..<bump> -- lib/catalog/owid` between the commits that set each version, so each section covers everything that shipped in that release — not only the change that carried the bump (`v1.2.2` in particular is mostly other people's work plus a republish).
- `v1.2.5` (#6844) covers the `multidim` channel removal plus the three fixes that had been sitting unreleased on `master`: the Jinja sandbox (#6775), the character-exploded `description_key` guard (#6649) and `s3_utils.object_exists` (#6575).
- Drive-by fixes: the Python badge and "Python 3.10+" line in the README (stale since `v1.2.4`), `pyright` → `ty` and the removed `Source` class in `lib/catalog/CLAUDE.md`, and the `publish-owid-catalog.yml` → `publish-owid-packages.yml` links in the staff docs page (the old filename 404s).

Left open, deliberately:

- `lib/catalog/.github/workflows/python-package.yml` is inert here (GitHub only reads root workflows) but still gets updated by action-pinning PRs. DEVELOPMENT.md says so; deleting it is a separate call.
- No version bump in this PR — docs only, so nothing publishes.
- The Buildkite pipeline behind the README badge is configured outside this repo, so the guide points at its run history rather than describing it.
