### PR TITLE
🔨 Use create_snapshot(data=...) instead of df_to_file in snapshot scripts

### DIFF
--- a/apps/wizard/app_pages/fasttrack/fast_import.py
+++ b/apps/wizard/app_pages/fasttrack/fast_import.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pandas as pd
 from git.repo import Repo
 from owid.catalog import Dataset, DatasetMeta, Origin, Table
-from owid.datautils import io
 from rich.console import Console
 from sqlalchemy.orm import Session
 from structlog import get_logger
@@ -147,8 +146,7 @@ class FasttrackImport:
 
         # upload snapshot
         snap = self.snapshot
-        io.df_to_file(self.data, file_path=snap.path)
-        snap.dvc_add(upload=True)
+        snap.create_snapshot(data=self.data, upload=True)
 
         # save metadata
         self.__snapshot_path = snap.metadata_path

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import re
 import tempfile
 import time
@@ -22,8 +23,7 @@ from owid.catalog.core.meta import (
     TableMeta,
     pruned_json,
 )
-from owid.datautils import dataframes
-from owid.datautils.io import decompress_file
+from owid.datautils.io import decompress_file, df_to_file
 from owid.repack import to_safe_types
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
 
@@ -401,7 +401,7 @@ class Snapshot:
             self.path.write_bytes(Path(filename).read_bytes())
         elif data is not None:
             # Copy dataframe to snapshots data folder.
-            dataframes.to_file(data, file_path=self.path)
+            df_to_file(data, file_path=self.path)
         elif self.metadata.origin and self.metadata.origin.url_download:
             # Create snapshot by downloading data from a URL with retry logic.
             for attempt in range(1, download_retries + 1):
@@ -689,6 +689,22 @@ class Snapshot:
             return tb
 
 
+def _dates_as_strings(value: Any) -> Any:
+    """Recursively coerce dates to strings, the way the metadata classes store them.
+
+    `yaml.safe_load` parses an unquoted `date_accessed: 2026-03-20` into a `datetime.date`, while
+    `Origin` keeps its date fields as ISO strings. Comparing a freshly loaded .dvc against
+    `SnapshotMeta._meta_to_dict()` without this would always differ on those fields.
+    """
+    if isinstance(value, dict):
+        return {k: _dates_as_strings(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_dates_as_strings(v) for v in value]
+    if isinstance(value, dt.date):
+        return str(value)
+    return value
+
+
 @pruned_json
 @dataclass
 class SnapshotMeta(MetaBase):
@@ -817,8 +833,9 @@ class SnapshotMeta(MetaBase):
             # NOTE: meta does not have `outs` field, it's reset when saving
             meta = self._meta_to_dict()
 
-            # No change, keep the file as is
-            if yaml["meta"] == meta:
+            # No change, keep the file as is. Rewriting would reformat the whole file (re-wrapping
+            # long lines, re-indenting `outs`) for no reason.
+            if _dates_as_strings(yaml["meta"]) == _dates_as_strings(meta):
                 return
 
             # Otherwise update the file

--- a/snapshots/aviation_safety_network/2022-10-12/aviation_statistics.py
+++ b/snapshots/aviation_safety_network/2022-10-12/aviation_statistics.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -69,11 +68,8 @@ def main(upload: bool) -> None:
     period_df = get_aviation_data(url=snap_by_period.metadata.source.url)  # ty: ignore
     nature_df = get_aviation_data(url=snap_by_nature.metadata.source.url)  # ty: ignore
 
-    df_to_file(period_df, file_path=snap_by_period.path)
-    df_to_file(nature_df, file_path=snap_by_nature.path)
-
-    snap_by_period.dvc_add(upload=upload)
-    snap_by_nature.dvc_add(upload=upload)
+    snap_by_period.create_snapshot(data=period_df, upload=upload)
+    snap_by_nature.create_snapshot(data=nature_df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/bls/2026-03-20/us_consumer_prices.py
+++ b/snapshots/bls/2026-03-20/us_consumer_prices.py
@@ -9,7 +9,6 @@ import click
 import pandas as pd
 import requests
 from dotenv import load_dotenv
-from owid.datautils.io import df_to_file
 from structlog import get_logger
 
 from etl.snapshot import Snapshot
@@ -168,9 +167,7 @@ def main(upload: bool) -> None:
     # Convert to DataFrame and save
     df = pd.DataFrame(flattened)
 
-    df_to_file(df, file_path=snap.path)
-
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/bls/2026-08-18/us_ppi_construction.py
+++ b/snapshots/bls/2026-08-18/us_ppi_construction.py
@@ -9,7 +9,6 @@ import click
 import pandas as pd
 import requests
 from dotenv import load_dotenv
-from owid.datautils.io import df_to_file
 from structlog import get_logger
 
 from etl.snapshot import Snapshot
@@ -108,6 +107,4 @@ def main(upload: bool) -> None:
     # Convert to DataFrame and save
     df = pd.DataFrame(flattened)
 
-    df_to_file(df, file_path=snap.path)
-
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df, upload=upload)

--- a/snapshots/cancer/2024-09-06/gco_infections.py
+++ b/snapshots/cancer/2024-09-06/gco_infections.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pandas as pd
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -45,5 +44,4 @@ def run(upload: bool = True) -> None:
     df_all = pd.concat(dataframes, ignore_index=True)
 
     # Write the combined file, add it to DVC and upload it to R2.
-    df_to_file(df_all, file_path=snap.path)
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df_all, upload=upload)

--- a/snapshots/climate/2024-02-22/weekly_wildfires_2003_2023.py
+++ b/snapshots/climate/2024-02-22/weekly_wildfires_2003_2023.py
@@ -7,7 +7,6 @@ import click
 import pandas as pd
 import requests
 from owid.catalog import fetch
-from owid.datautils.io import df_to_file
 from structlog import get_logger
 from tqdm import tqdm
 
@@ -163,11 +162,8 @@ def main(upload: bool) -> None:
 
     # Combine both fires and emissions data into a final DataFrame.
     df_final = pd.concat([dfs_fires, dfs_emissions])
-    # Save the final DataFrame to the specified file path in the snapshot.
-    df_to_file(df_final, file_path=snap.path)  # ty: ignore[invalid-argument-type]
-
-    # Add the file to DVC and optionally upload it to S3, based on the `upload` parameter.
-    snap.dvc_add(upload=upload)
+    # Save the final DataFrame, add it to DVC and optionally upload it to S3, based on the `upload` parameter.
+    snap.create_snapshot(data=df_final, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/climate/2025-02-12/sst.py
+++ b/snapshots/climate/2025-02-12/sst.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import click
 import pandas as pd
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -83,8 +82,7 @@ def main(upload: bool) -> None:
 
         dfs.append(df)
     df = pd.merge(dfs[0], dfs[1], on=["year", "month"], how="outer")
-    df_to_file(df, file_path=snap.path)
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/climate/2025-03-07/sst.py
+++ b/snapshots/climate/2025-03-07/sst.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import click
 import pandas as pd
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -83,8 +82,7 @@ def main(upload: bool) -> None:
 
         dfs.append(df)
     df = pd.merge(dfs[0], dfs[1], on=["year", "month"], how="outer")
-    df_to_file(df, file_path=snap.path)
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/climate/2026-08-21/sst.py
+++ b/snapshots/climate/2026-08-21/sst.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import click
 import pandas as pd
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -83,8 +82,7 @@ def main(upload: bool) -> None:
 
         dfs.append(df)
     df = pd.merge(dfs[0], dfs[1], on=["year", "month"], how="outer")
-    df_to_file(df, file_path=snap.path)
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/climate/2026-08-28/weekly_wildfires.py
+++ b/snapshots/climate/2026-08-28/weekly_wildfires.py
@@ -16,7 +16,6 @@ import click
 import pandas as pd
 import requests
 from owid.catalog import Dataset
-from owid.datautils.io import df_to_file
 from structlog import get_logger
 from tqdm import tqdm
 
@@ -330,14 +329,11 @@ def main(upload: bool) -> None:
             f"New snapshot has fewer rows ({len(df_final)}) than the previous snapshot ({len(orig_snapshot_df)}). API could be down or data is missing."
         )
 
-    # Save the final DataFrame to the specified file path in the snapshot.
-    df_to_file(df_final, file_path=snap.path)  # ty: ignore[invalid-argument-type]
-
     # Add date_accessed
     snap = modify_metadata(snap)
 
-    # Add the file to DVC and optionally upload it to S3, based on the `upload` parameter.
-    snap.dvc_add(upload=upload)
+    # Save the final DataFrame, add it to DVC and optionally upload it to S3, based on the `upload` parameter.
+    snap.create_snapshot(data=df_final, upload=upload)
 
 
 def modify_metadata(snap: Snapshot) -> Snapshot:

--- a/snapshots/demography/2025-01-23/us_state_population.py
+++ b/snapshots/demography/2025-01-23/us_state_population.py
@@ -11,7 +11,6 @@ import click
 import pandas as pd
 import requests
 from dotenv import load_dotenv
-from owid.datautils.io import df_to_file
 
 from etl.paths import BASE_DIR
 from etl.snapshot import Snapshot
@@ -101,9 +100,8 @@ def main(upload: bool) -> None:
 
     snap = Snapshot(f"demography/{SNAPSHOT_VERSION}/us_state_population.csv")
     pop_data = download_state_level_population_data()
-    df_to_file(pop_data, file_path=snap.path)
-    # Download data from source, add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save data, add file to DVC and upload to S3.
+    snap.create_snapshot(data=pop_data, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/education/2023-07-17/education_barro_lee_projections.py
+++ b/snapshots/education/2023-07-17/education_barro_lee_projections.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -23,9 +22,8 @@ def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"education/{SNAPSHOT_VERSION}/education_barro_lee_projections.csv")
     all_dfs = get_data()
-    df_to_file(all_dfs, file_path=snap.path)
-    # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save data, add file to DVC and upload to S3.
+    snap.create_snapshot(data=all_dfs, upload=upload)
 
 
 def get_data() -> pd.DataFrame:

--- a/snapshots/education/2023-07-17/education_lee_lee.py
+++ b/snapshots/education/2023-07-17/education_lee_lee.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -23,9 +22,8 @@ def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"education/{SNAPSHOT_VERSION}/education_lee_lee.xlsx")
     all_dfs = get_data()
-    df_to_file(all_dfs, file_path=snap.path)
-    # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save data, add file to DVC and upload to S3.
+    snap.create_snapshot(data=all_dfs, upload=upload)
 
 
 def get_data() -> pd.DataFrame:

--- a/snapshots/education/2023-08-14/oecd_education.py
+++ b/snapshots/education/2023-08-14/oecd_education.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -87,11 +86,8 @@ def main(upload: bool) -> None:
         all_dfs, df_ed_years, on=["year", "country_or_region", "average_years_of_education"], how="outer"
     )
 
-    # Save the merged dataset to the snapshot path
-    df_to_file(all_dfs, file_path=snap.path)
-
-    # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save the merged dataset, add file to DVC and upload to S3.
+    snap.create_snapshot(data=all_dfs, upload=upload)
 
 
 def read_excel_data(filepath, format_type):

--- a/snapshots/media_cloud/2025-05-19/media_deaths.py
+++ b/snapshots/media_cloud/2025-05-19/media_deaths.py
@@ -10,7 +10,6 @@ import pandas as pd
 import structlog
 from dotenv import load_dotenv
 from media_deaths_queries import create_full_queries, create_queries
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -136,10 +135,8 @@ def run(upload: bool) -> None:
     # Initialize a new snapshot.
     snap = Snapshot(f"media_cloud/{SNAPSHOT_VERSION}/media_deaths.csv")
 
-    df_to_file(df=mentions_df, file_path=snap.path)  # ty: ignore
-
     # Save snapshot.
-    snap.create_snapshot(upload=upload)
+    snap.create_snapshot(data=mentions_df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/statins/2023-10-05/bmj_2022.py
+++ b/snapshots/statins/2023-10-05/bmj_2022.py
@@ -7,7 +7,6 @@ import click
 import pandas as pd
 import pdfplumber
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -51,8 +50,7 @@ def main(upload: bool) -> None:
             df = pd.merge(df_statins, df_econ_health, on="country")
 
             # Saving the merged dataframe to a file and updating the DVC.
-            df_to_file(df, file_path=snap.path)
-            snap.dvc_add(upload=upload)
+            snap.create_snapshot(data=df, upload=upload)
 
 
 def extract_statin_use_table(response):

--- a/snapshots/statins/2023-10-05/lancet_2022.py
+++ b/snapshots/statins/2023-10-05/lancet_2022.py
@@ -7,7 +7,6 @@ import click
 import pandas as pd
 import pdfplumber
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -46,8 +45,7 @@ def main(upload: bool) -> None:
             # Merging extracted tables based on the 'country' column.
 
             # Saving the merged dataframe to a file and updating the DVC.
-            df_to_file(df_statins, file_path=snap.path)
-            snap.dvc_add(upload=upload)
+            snap.create_snapshot(data=df_statins, upload=upload)
 
 
 def extract_statin_use_table(response):

--- a/snapshots/wb/2024-11-04/edstats.py
+++ b/snapshots/wb/2024-11-04/edstats.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 import requests
 import world_bank_data as wb
-from owid.datautils.io import df_to_file
 from tqdm import tqdm
 
 from etl.db import get_engine
@@ -43,9 +42,8 @@ def main(upload: bool) -> None:
 
     # Merge the results back into the original DataFrame
     df = pd.merge(temp_df, wb_education_df, on="wb_seriescode", how="right")
-    df_to_file(df, file_path=snap.path)
-    # Download data from source, add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save data, add file to DVC and upload to S3.
+    snap.create_snapshot(data=df, upload=upload)
 
 
 def fetch_indicator_metadata(indicator):

--- a/snapshots/who/2022-09-01/autopsy.py
+++ b/snapshots/who/2022-09-01/autopsy.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import click
 import pandas as pd
 import requests
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -31,10 +30,8 @@ def main(upload: bool) -> None:
     df = pd.read_csv(url, skiprows=25)
     # assert column names are as expected
     assert df.columns.to_list() == ["COUNTRY", "COUNTRY_GRP", "SEX", "YEAR", "VALUE"]
-    # Download data from source.
-    df_to_file(df, file_path=snap.path)
-    # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save data, add file to DVC and upload to S3.
+    snap.create_snapshot(data=df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/who/2023-07-14/standard_age_distribution.py
+++ b/snapshots/who/2023-07-14/standard_age_distribution.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -52,10 +51,8 @@ def main(upload: bool) -> None:
             ],
         }
     )
-    df_to_file(df, file_path=snap.path)
-
-    # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Save data, add file to DVC and upload to S3.
+    snap.create_snapshot(data=df, upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/who/2025-08-01/guinea_worm.py
+++ b/snapshots/who/2025-08-01/guinea_worm.py
@@ -7,7 +7,6 @@ import click
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
-from owid.datautils.io import df_to_file
 
 from etl.snapshot import Snapshot
 
@@ -26,9 +25,8 @@ def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"who/{SNAPSHOT_VERSION}/guinea_worm.csv")
     df = get_certification_table()
-    df_to_file(df, file_path=snap.path)
     # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    snap.create_snapshot(data=df, upload=upload)
 
 
 def get_certification_table() -> pd.DataFrame:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,6 +1,7 @@
 import tempfile
 import zipfile
 from pathlib import Path
+from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -306,3 +307,43 @@ def test_snapshot_to_yaml():
         "version": "2023-04-18",
         "origin": {"title": "Aviation Statistics by Period", "producer": "Producer"},
     }
+
+
+def test_metadata_save_leaves_a_dvc_with_unquoted_dates_untouched(tmp_path, monkeypatch):
+    """An unchanged .dvc must survive `save()` byte for byte, unquoted dates included.
+
+    `yaml.safe_load` parses `date_accessed: 2023-10-05` into a `datetime.date` while `Origin` keeps
+    it as a string, so the "nothing changed" check used to always miss and rewrite the file —
+    reflowing long lines and re-indenting `outs` for no reason. `create_snapshot` calls `save()` on
+    every run, so those diffs surfaced in whichever dataset update happened to come next.
+    """
+    monkeypatch.setattr(paths, "SNAPSHOTS_DIR", tmp_path)
+    dvc_path = tmp_path / "namespace" / "2023-10-05" / "dataset.csv.dvc"
+    dvc_path.parent.mkdir(parents=True)
+    original = dedent("""\
+        meta:
+          origin:
+            title: A title long enough that a rewrite would wrap it onto a second line of its own
+            producer: Producer
+            citation_full: Producer (2023)
+            url_main: https://example.org/data
+            date_published: 2023-10-01
+            date_accessed: 2023-10-05
+            license:
+              name: CC BY 4.0
+        outs:
+        - md5: a9bae94a60b04dea8b889d16f23c0ca9
+          size: 1632
+          path: dataset.csv
+        """)
+    dvc_path.write_text(original)
+
+    snap = Snapshot("namespace/2023-10-05/dataset.csv")
+    snap.metadata.save()
+    assert dvc_path.read_text() == original
+
+    # A genuine change is still written out.
+    snap.metadata.origin.date_accessed = "2023-11-20"  # ty: ignore
+    snap.metadata.save()
+    assert "date_accessed: '2023-11-20'" in dvc_path.read_text()
+    assert "md5: a9bae94a60b04dea8b889d16f23c0ca9" in dvc_path.read_text()


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

`Snapshot.create_snapshot(data=df, upload=upload)` already writes the dataframe to `snap.path` and calls `dvc_add`, so the `df_to_file(df, file_path=snap.path)` + `snap.dvc_add(upload=upload)` pair was a hand-rolled copy of it. 125 snapshot scripts and the wizard cookiecutter already use `create_snapshot`; these 22 call sites were the stragglers.

Two things in `etl/snapshot.py` that this exposed:

- `create_snapshot` wrote the dataframe via `owid.datautils.dataframes.to_file` — the deprecated shim that warns on every call — instead of `owid.datautils.io.df_to_file`.
- **`SnapshotMeta.save()` rewrote a `.dvc` even when nothing had changed.** `yaml.safe_load` parses an unquoted `date_accessed: 2026-03-20` into a `datetime.date` while `Origin` keeps it as a string, so the "no change" check always missed and the file was reserialized: dates re-quoted, long lines reflowed, `outs` re-indented. 851 of the repo's 8253 `.dvc` files carry an unquoted date, and `create_snapshot` calls `save()` on every run — so those diffs surfaced in whichever dataset update happened to come next. Without this fix, 13 of the 19 `.dvc` files behind the migrated scripts would have been reformatted on their next run. Regression test added, verified to fail without the fix.

## Verification

`make check` and 875 unit tests pass. `who/2023-07-14/standard_age_distribution.py` (the one migrated script that runs fully offline) was run end to end with `--skip-upload`: output md5 `5c6bc0b649c343483f4c8d07fbb540c5`, 333 bytes — an exact match for what its `.dvc` records, with the `.dvc` left untouched.

## Open items

- **The other 20 migrated scripts were not executed** — they need network, API keys (BLS, FRED, Media Cloud), or PDF parsing. The edit is mechanical and identical across all of them, and none of their `.dvc` files change under `save()`, but nobody ran them.
- **482 legacy backport scripts left alone.** They hand-roll the same thing as `df.reset_index().to_feather(snap.path)` + `dvc_add`, all in 2014–2023 version folders. Same collapse would apply; deliberately out of scope to keep this diff reviewable.
- **`snapshots/aviation_safety_network/2022-10-12/aviation_statistics.py` is an orphan** — pre-existing, not caused by this PR. Its two `.dvc` files were removed when the step was archived (`dag/archive/main.yml:145`), so the script can only raise `FileNotFoundError`. Migrated for consistency; deleting the leftover `.py` is a separate call.
