### PR TITLE
✨ Require a pinned grapher_schema, and stop hand-maintaining the version

### DIFF
--- a/.claude/skills/chart-editing/SKILL.md
+++ b/.claude/skills/chart-editing/SKILL.md
@@ -26,6 +26,7 @@ The chart's public slug is auto-derived from the short name with underscores rep
 ## Minimum viable config
 
 ```yaml
+grapher_schema: "011"  # QUOTED — a bare 011 is YAML octal
 chart_config_id: "0191b6c7-5595-70b2-8d30-fa03fccd7add"
 topic_tags:
   - "Animal Welfare"
@@ -51,10 +52,11 @@ views:
 
 Key fields:
 
+- `grapher_schema` — **required**, and there is no fallback: the grapher chart-config schema version this config is written against, which becomes the chart's `$schema` and is what lets grapher migrate the config after a breaking schema change. Use the version in `DEFAULT_GRAPHER_SCHEMA` (`etl/config.py`) when authoring, then leave it alone. Quote it — an unquoted `011` is YAML octal.
 - `chart_config_id` — **required**, the chart's identity in grapher (`charts.configId`). See "The chart's identity" below.
 - `dimensions: []` and exactly one view → this YAML pushes as a single chart, not an mdim page.
 - `views[0].indicators.y` — list of indicator catalog paths. For multi-series, list more than one.
-- `views[0].config` — the grapher config that becomes the chart's `etlConfig` in `chart_configs`. Same shape as a chart-admin export. Omit `$schema` — the current default (`DEFAULT_GRAPHER_SCHEMA` in `etl/config.py`) is applied automatically, so pinning a version only ages badly.
+- `views[0].config` — the grapher config that becomes the chart's `etlConfig` in `chart_configs`. Same shape as a chart-admin export. Never put `$schema` in here: it would override the top-level `grapher_schema` while being far less visible (ETL warns when it does).
 - No top-level `title:` or `default_selection:` block — those exist only for multidim data pages and are ignored for single charts.
 
 ## The chart's identity (`chart_config_id`)

--- a/.claude/skills/create-multidim/SKILL.md
+++ b/.claude/skills/create-multidim/SKILL.md
@@ -118,10 +118,10 @@ The ETL has built-in change detection — if you modify the config, it will auto
 ## Config YAML Structure
 
 ```yaml
-# Grapher chart-config schema the view configs below are written against. Always pin it, as a
-# QUOTED string — a bare `011` is YAML octal. Use the current DEFAULT_GRAPHER_SCHEMA version
-# (etl/config.py) when authoring a new MDIM, then leave it alone: Grapher migrates outdated
-# configs forward, but skips migration entirely when no version is given.
+# REQUIRED — grapher chart-config schema the view configs below are written against, as a
+# QUOTED string (a bare `011` is YAML octal). There is no fallback: ETL fails without it. Use the
+# current DEFAULT_GRAPHER_SCHEMA version (etl/config.py) when authoring a new MDIM, then leave it
+# alone: it is what lets Grapher migrate the config forward after a breaking schema change.
 grapher_schema: "011"
 # Never put `$schema` inside a view's `config` block: Grapher lets the view value override this
 # collection-level pin, so the two silently disagree. ETL warns when that happens.

--- a/.claude/skills/sync-grapher-schema/SKILL.md
+++ b/.claude/skills/sync-grapher-schema/SKILL.md
@@ -19,7 +19,7 @@ The grapher chart-config schema is owned by the web team in [`owid-grapher`](htt
 
 | File | Role | Sync mechanism |
 |---|---|---|
-| `schemas/grapher-schema.NNN.json` | Vendored copy of upstream | automatic (`--refresh`) |
+| `schemas/grapher-schema.NNN.json` | Vendored copy of upstream, and the single source of truth for the version (`DEFAULT_GRAPHER_SCHEMA` is derived from its `$id`) | automatic (`--refresh`; `--bump-version` for a new version) |
 | `schemas/multidim-schema.json` + `schemas/explorer-schema.json` | View config `$ref`s into the grapher schema | manual: add `$ref` for **new** properties |
 | `schemas/dataset-schema.json` | Embedded `grapher_config` block (validates garden `.meta.yml`) | manual: mirror changes, preserve deviations |
 | `etl/collection/model/schema_types.py` | Generated Python TypedDicts | automatic (regenerate) |
@@ -116,16 +116,25 @@ Commit with `✨🤖`. In the PR body, list the upstream changes synced (link th
 
 Rarer case — when the web team publishes a new schema version instead of mutating in place. Detected by the integration test `test_no_newer_grapher_schema_version` (compares the `$id` of upstream `grapher-schema.latest.json` against `DEFAULT_GRAPHER_SCHEMA`).
 
-1. Bump `DEFAULT_GRAPHER_SCHEMA` in `etl/config.py`. (Keep it a concrete version, never `latest` — it is written into chart configs as `$schema`, and grapher's config migrations are keyed on the version.)
-2. Update every `$ref` in `schemas/multidim-schema.json` and `schemas/explorer-schema.json`: `sed -i 's/grapher-schema.NNN.json/grapher-schema.MMM.json/g' schemas/multidim-schema.json schemas/explorer-schema.json`.
-3. `.venv/bin/python scripts/generate_schema_types.py --refresh` (vendors the new version — the filename follows `DEFAULT_GRAPHER_SCHEMA`), then `git rm` the old vendored file.
-4. Continue from step 1's diff review above (diff old vendored vs new: `git diff --no-index schemas/grapher-schema.NNN.json schemas/grapher-schema.MMM.json`).
+```bash
+.venv/bin/python scripts/generate_schema_types.py --bump-version
+```
+
+That one command reads the new version from `grapher-schema.latest.json`'s `$id`, vendors it as `schemas/grapher-schema.MMM.json`, deletes the old copy, repoints every `$ref` in `schemas/multidim-schema.json` + `schemas/explorer-schema.json`, and regenerates `schema_types.py`. **Nothing in `etl/config.py` is hand-edited**: `DEFAULT_GRAPHER_SCHEMA` is derived from whichever schema is vendored (`vendored_grapher_schema_id()`), so it follows automatically — and it always resolves to a concrete version, never `latest`, since grapher's config migrations are keyed on the version.
+
+Then, by hand:
+
+1. Review the upstream diff: `git show HEAD:schemas/grapher-schema.NNN.json | diff -u - schemas/grapher-schema.MMM.json`.
+2. Continue from step 3 above — mirror new/changed properties into the embedded `grapher_config` block in `schemas/dataset-schema.json`, preserving the deliberate ETL-side deviations. `test_grapher_config_schema_sync` fails until this is done.
+3. Check whether the command reported leftover mentions of the old filename outside `$ref`s (the `grapher_schema` `examples` in `multidim-schema.json`, which show what a *new* config should pin).
+
+`--bump-version` is idempotent — it prints "already vendoring the newest published schema" and changes nothing when there is no new version, so it is safe to run blind.
 
 ### Don't bump the `grapher_schema` pins in MDIM configs
 
-Every multidim config pins `grapher_schema: "NNN"` (enforced by `test_multidim_configs_pin_grapher_schema`). **Leave those pins at their old version.** They record what each config was authored against, which is what lets grapher migrate them to `MMM` on upsert. Bumping them would tell grapher the configs are already current and skip the migration — the exact failure the pins exist to prevent.
+Every multidim and single-chart config pins `grapher_schema: "NNN"` — required, with no fallback (`required` in `schemas/multidim-schema.json`, re-checked by `Collection.validate_grapher_schema_pinned()`, and swept offline by `test_multidim_configs_pin_grapher_schema`). **Leave those pins at their old version.** They record what each config was authored against, which is what lets grapher migrate them to `MMM` on upsert. Bumping them would tell grapher the configs are already current and skip the migration — the exact failure the pins exist to prevent.
 
-The one thing to check: step 2 repoints multidim view-config validation at the new version, so a config that is no longer valid under `MMM` will now fail `Collection.validate_schema()`. Fix the config *and* bump only that config's pin, since at that point it genuinely was re-authored against `MMM`.
+The one thing to check: `--bump-version` repoints multidim view-config validation at the new version, so a config that is no longer valid under `MMM` will now fail `Collection.validate_schema()`. Fix the config *and* bump only that config's pin, since at that point it genuinely was re-authored against `MMM`.
 
 Views can also carry their own `$schema` inside a `config` block, which **overrides** the collection-level pin (grapher spreads the view config last). As of #6705 follow-up no step does this any more, and ETL warns if one reappears — so treat a hit from `grep -rn '\$schema' etl/steps/viz/chart` as something to remove rather than to bump.
 

--- a/.github/workflows/sync-grapher-schema.yml
+++ b/.github/workflows/sync-grapher-schema.yml
@@ -91,7 +91,7 @@ jobs:
           TITLE="New grapher schema version published upstream"
           EXISTING=$(gh issue list --search "\"$TITLE\" in:title" --state open --json number --jq '.[0].number // empty')
           if [ -z "$EXISTING" ]; then
-            gh issue create --title "$TITLE" --body "$(printf 'Upstream now publishes **%s** while we pin **%s**.\n\nFollow the "Version bump" section of the \`/sync-grapher-schema\` skill to upgrade (bump \`DEFAULT_GRAPHER_SCHEMA\` in \`etl/config.py\`, sed the \`$ref\`s, re-vendor, regenerate).\n\n_Opened automatically by the sync-grapher-schema workflow._' "$LATEST_ID" "$PINNED_URL")"
+            gh issue create --title "$TITLE" --body "$(printf 'Upstream now publishes **%s** while we vendor **%s**.\n\nRun `python scripts/generate_schema_types.py --bump-version` — it vendors the new version, drops the old copy, repoints the `$ref`s and regenerates the types (`DEFAULT_GRAPHER_SCHEMA` is derived from the vendored file, so nothing there is hand-edited). It then prints what still needs judgment: the upstream diff review, and mirroring new properties into the embedded `grapher_config` block in `schemas/dataset-schema.json`.\n\nSee the "Version bump" section of the `/sync-grapher-schema` skill. Do **not** bump the `grapher_schema` pins in existing collection configs.\n\n_Opened automatically by the sync-grapher-schema workflow._' "$LATEST_ID" "$PINNED_URL")"
           else
             echo "Issue #$EXISTING already open, skipping."
           fi

--- a/apps/wizard/etl_steps/cookiecutter/collection/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.config.yml
+++ b/apps/wizard/etl_steps/cookiecutter/collection/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.config.yml
@@ -1,3 +1,7 @@
+# Grapher chart-config schema version these view configs are written against. Required, and
+# QUOTED — a bare `011` is YAML octal. Leave it as it is once the config exists: it lets Grapher
+# migrate the config forward after a breaking schema change.
+grapher_schema: "{{cookiecutter.grapher_schema}}"
 title:
   title: TODO
   title_variant: TODO

--- a/apps/wizard/etl_steps/forms.py
+++ b/apps/wizard/etl_steps/forms.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 from apps.utils.files import generate_step, generate_step_to_channel
 from apps.wizard.etl_steps.utils import ADD_DAG_OPTIONS, COOKIE_STEPS, SNAPSHOT_SCHEMA, remove_playground_notebook
 from apps.wizard.utils import clean_empty_dict
+from etl.collection.utils import default_grapher_schema_version
 from etl.dag_helpers import write_to_dag_file
 from etl.files import ruamel_dump
 from etl.owners import resolve_owner
@@ -647,6 +648,10 @@ class CollectionForm(StepForm):
 
 def generate_export_step_to_channel(cookiecutter_path: Path, data: dict[str, Any]) -> Path:
     assert {"namespace", "version"} <= data.keys()
+
+    # Collection configs must pin `grapher_schema`; scaffold it at the version we vendor today so
+    # the generated config runs as-is instead of failing on the missing pin.
+    data = {**data, "grapher_schema": default_grapher_schema_version()}
 
     target_dir = STEP_DIR / "viz" / "chart"
     generate_step(cookiecutter_path, data, target_dir)

--- a/docs/guides/data-work/mdims.md
+++ b/docs/guides/data-work/mdims.md
@@ -107,7 +107,7 @@ As you can see, there are top-level fields (`title`, `default_selection`, `topic
 
 In this example, we note that we can group together indicators from any dataset. While we may present them as "dimensional", the underlying data structure may not be.
 
-!!! important "Always pin `grapher_schema`"
+!!! important "`grapher_schema` is required"
     `grapher_schema` records the version of the [Grapher chart-config schema](https://github.com/owid/owid-grapher/tree/master/packages/%40ourworldindata/grapher/src/schema) that this MDIM's view configs were written against. Grapher uses it as the `$schema` of every view config, and migrates outdated configs forward to the current version when it upserts the MDIM.
 
     Two forms are accepted — the short version, or the full URL:
@@ -119,7 +119,7 @@ In this example, we note that we can group together indicators from any dataset.
 
     **Quote the short form.** YAML parses a bare `011` as an octal number, so it would silently resolve to a different version (ETL rejects it rather than guessing).
 
-    Omitting the field falls back to `DEFAULT_GRAPHER_SCHEMA` (`etl/config.py`), which tells Grapher the configs are already current — so the next breaking schema change would skip the migration for those views. Once set, leave the pin alone: it is a record of what the config was authored against, which is exactly what lets Grapher migrate it later.
+    **There is no default.** Omitting the field fails the step — schema validation rejects it when `create_collection` builds the config, and `Collection.save()` re-checks. That is deliberate: a fallback would resolve an unpinned config to whatever version the repo vendors *on the day the step runs*, which both tells Grapher the config is already current (so the next breaking schema change skips the migration for those views) and silently resolves to a different version the next time the step runs. Once set, leave the pin alone: it is a record of what the config was authored against, which is exactly what lets Grapher migrate it later.
 
     The one exception is a pin that **contradicts the config body** — e.g. pinned `005` while the config uses `chartTypes`, a field that only exists from `006` onwards (the 005→006 migration is what creates it). That is a stale pin rather than a record, and leaving it means Grapher runs migrations over a config they were never meant to touch. Correct such a pin to the version the config is actually written against.
 
@@ -131,13 +131,14 @@ In this example, we note that we can group together indicators from any dataset.
     |---|---|---|
     | config YAML | `grapher_schema` | `"011"` |
     | `viz/chart/…/<name>.config.json` | `grapher_schema` | `"011"` |
-    | Grapher DB / admin API payload | `grapherConfigSchema` | `https://…/grapher-schema.011.json` |
+    | Grapher DB / admin API payload (mdim) | `grapherConfigSchema` | `https://…/grapher-schema.011.json` |
+    | Grapher DB (single chart, `chart_configs.etlConfig`) | `$schema` | `https://…/grapher-schema.011.json` |
 
     The generated JSON keeps the authored short form because `CollectionSet.read()` loads it back through `Collection.from_dict`; only the upsert payload is camelized and resolved to a full URL. So grepping the generated JSON for `grapherConfigSchema` finds nothing even when the pin is working perfectly.
 
-    Note also that while `DEFAULT_GRAPHER_SCHEMA` equals the version everything pins, a working pin and a dropped one look identical in the database. ETL logs a warning when a collection falls back to the default, which is the signal to trust.
+    A single chart (`dimensions: []`) has no `grapherConfigSchema` indirection — its config carries `$schema` directly — so for charts the pin *is* the stored `$schema`.
 
-    This field is MDIM-only. Explorers reach Grapher through the legacy TSV path, which has no equivalent.
+    This field is MDIM-and-chart-only. Explorers reach Grapher through the legacy TSV path, which has no equivalent, and they reject the field outright.
 
 !!! tip "Learn more about the structure of MDIMs in [:fontawesome-brands-github: their schema](https://github.com/owid/etl/blob/master/schemas/multidim-schema.json)"
     There are more options available in the schema that are not covered here. E.g. you can set chart configurations for each view (`.config`), or indicator-level display settings (`.display`). You can even tweak the presentation fields like `description_key` for a specific view (`.metadata`).

--- a/docs/guides/grapher-schema-sync.md
+++ b/docs/guides/grapher-schema-sync.md
@@ -41,7 +41,7 @@ The automatic part of a sync (vendored refresh + type regeneration) is committed
 
 - mirroring the upstream diff into the `grapher_config` block embedded in `schemas/dataset-schema.json`, **preserving the deliberate ETL-side deviations** (Jinja `oneOf` escape hatches, the extra `WorldMap` chart type, the ETL-only `data`/`includedEntities` properties);
 - adding `$ref`s for genuinely new properties to `schemas/multidim-schema.json` / `schemas/explorer-schema.json`;
-- handling the rarer **version bump** (new `grapher-schema.NNN`): bumping `DEFAULT_GRAPHER_SCHEMA` in `etl/config.py`, updating `$ref`s, re-vendoring.
+- handling the rarer **version bump** (new `grapher-schema.NNN`): run `python scripts/generate_schema_types.py --bump-version`, which reads the new version from `grapher-schema.latest.json`, vendors it, drops the old copy, repoints the `$ref`s and regenerates the types. `DEFAULT_GRAPHER_SCHEMA` follows on its own — `etl/config.py` derives it from whichever schema is vendored — so nothing there is hand-edited. What's left after the command is judgment: reviewing the upstream diff and mirroring new properties into the embedded `grapher_config` block.
 
 !!! warning "A version bump does *not* touch the `grapher_schema` pins in MDIM configs"
 
@@ -73,3 +73,4 @@ It can also be run ad-hoc — e.g. when the web team announces a change and you 
 | Embedded `grapher_config` in `dataset-schema.json` out of sync with the vendored pin | `test_grapher_config_schema_sync` in `tests/test_metadata_schemas.py` (unit, offline, enum-deep) |
 | Vendored pin stale vs live upstream (in-place mutation) | scheduled workflow → draft PR; `test_vendored_grapher_schema_is_current` (integration) |
 | Upstream publishes a new schema version | scheduled workflow → issue; `test_no_newer_grapher_schema_version` (integration) |
+| A collection config with no `grapher_schema` pin, whose meaning would then change under the next bump | `grapher_schema` in multidim-schema.json's `required` + `Collection.validate_grapher_schema_pinned()`; `test_multidim_configs_pin_grapher_schema` (unit, offline) |

--- a/docs/guides/schema-management.md
+++ b/docs/guides/schema-management.md
@@ -11,17 +11,39 @@ This guide covers how to manage schema updates in the ETL system, particularly f
 
 ## Update grapher schema version
 
-When the grapher API changes and requires a new schema version, you need to update references throughout the ETL codebase to maintain compatibility.
+The grapher chart-config schema version lives in exactly one place: the vendored copy under `schemas/grapher-schema.NNN.json`. `DEFAULT_GRAPHER_SCHEMA` in `etl/config.py` is *derived* from that file's own `$id` (`vendored_grapher_schema_id()`), so there is no constant to keep in sync — and the constant can never name a version we don't have on disk.
+
+### What touches the network, and when
+
+Nothing about the schema version is resolved while ETL runs. Steps, `etlr`, `import etl.config` — all read the vendored file on disk, offline and deterministic. The two commands below are the *only* things that fetch from `files.ourworldindata.org`, and a person or the scheduled workflow runs them deliberately.
+
+| When | What runs | Network? | Who runs it |
+|---|---|---|---|
+| Any ETL step, any import | reads `schemas/grapher-schema.NNN.json` | no | — |
+| Upstream edited the current version in place (the common case) | `--refresh` | yes | the scheduled workflow, which commits it to a draft PR; or you, ad-hoc |
+| Upstream published a *new* version (rare: `011` in ~2 years) | `--bump-version` | yes | you, prompted by the issue the workflow opens |
 
 ### Update process
 
-1. **Update the default schema version** in `etl/config.py`:
-   ```python
-   DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
-   ```
+Upstream publishes a new version rarely; most changes are made in place to the current one.
 
-2. **Update schema references** in these files:
-   - `schemas/multidim-schema.json` - Multiple `$ref` references
-   - `schemas/explorer-schema.json` - Multiple `$ref` references
-   - `apps/wizard/utils/chart_config.py` - Default schema reference
+```bash
+# In-place upstream change to the version we already vendor
+python scripts/generate_schema_types.py --refresh
+
+# Upstream published a new version (NNN → MMM)
+python scripts/generate_schema_types.py --bump-version
+```
+
+`--bump-version` reads the new version from `grapher-schema.latest.json`, vendors it, deletes the old copy, repoints the `$ref`s in `schemas/multidim-schema.json` and `schemas/explorer-schema.json`, and regenerates `etl/collection/model/schema_types.py`. It prints what still needs a human: reviewing the upstream diff, and mirroring genuinely new properties into the `grapher_config` block embedded in `schemas/dataset-schema.json` while preserving the deliberate ETL-side deviations.
+
+!!! warning "Don't touch the `grapher_schema` pins in collection configs"
+
+    A bump repoints *validation* at the new version; it must not rewrite the pins in `etl/steps/viz/chart/**` configs. Those record what each config was authored against, which is what lets grapher migrate them forward. See [MDIMs and Explorers](data-work/mdims.md).
+
+!!! note "Never resolve `grapher-schema.latest.json` at run time"
+
+    It is an alias for one concrete version — its `properties.$schema.const` names that version, so it cannot validate a config pinned at an older one. It belongs in the bump path only.
+
+The full workflow, including what the scheduled sync automates, is in [Grapher schema sync](grapher-schema-sync.md).
 

--- a/etl/collection/chart_upsert.py
+++ b/etl/collection/chart_upsert.py
@@ -24,8 +24,8 @@ from sqlalchemy import bindparam, text
 from sqlalchemy.orm import Session
 
 from apps.chart_sync.admin_api import AdminAPI
-from etl.collection.utils import map_indicator_path_to_id
-from etl.config import DEFAULT_GRAPHER_SCHEMA, OWIDEnv
+from etl.collection.utils import map_indicator_path_to_id, resolve_grapher_schema
+from etl.config import OWIDEnv
 from etl.files import read_json_schema
 from etl.paths import SCHEMAS_DIR
 
@@ -53,7 +53,7 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
     view = collection.views[0]
     # Grapher slugs are dash-separated; mdim short_names are snake_case.
     slug = collection.short_name.replace("_", "-")
-    chart_config = _build_chart_config(view, slug)
+    chart_config = _build_chart_config(view, slug, resolve_grapher_schema(collection.grapher_schema))
     _validate_chart_config(chart_config, slug)
 
     admin_api = AdminAPI(owid_env)
@@ -128,11 +128,18 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
     return chart_id
 
 
-def _build_chart_config(view: "View", slug: str) -> dict[str, Any]:
-    """Translate `view.config` + `view.indicators` into a grapher chart config dict."""
+def _build_chart_config(view: "View", slug: str, grapher_schema: str) -> dict[str, Any]:
+    """Translate `view.config` + `view.indicators` into a grapher chart config dict.
+
+    `grapher_schema` is the collection's resolved pin. A chart config carries its schema version
+    directly in `$schema` (there is no `grapherConfigSchema` indirection as in mdims), so this is
+    where the pin becomes the thing grapher migrates from. `setdefault` keeps the same precedence
+    as the mdim path, where grapher spreads the view config over the collection pin — a `$schema`
+    inside the view config still wins, and `warn_on_view_schema_overrides` flags it.
+    """
     config: dict[str, Any] = dict(view.config or {})
     config["slug"] = slug
-    config.setdefault("$schema", DEFAULT_GRAPHER_SCHEMA)
+    config.setdefault("$schema", grapher_schema)
 
     # Resolve indicator catalog paths (y/x/size/color) to variable IDs and emit as
     # the grapher `dimensions` block, which charts identify by numeric variableId.

--- a/etl/collection/core/utils.py
+++ b/etl/collection/core/utils.py
@@ -92,6 +92,10 @@ def create_collection_from_config(
     # Edit views
     process_views(c, dependencies=dependencies)
 
+    # Require a schema pin before `validate_schema()`, which also enforces it (`required` in
+    # multidim-schema.json) but only reports the missing key — not how to fill it in.
+    c.validate_grapher_schema_pinned()
+
     # Validate config
     if validate_schema:
         c.validate_schema()

--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -32,6 +32,7 @@ from etl.collection.model.schema_types import (
 )
 from etl.collection.model.view import CommonView, View, ViewIndicators
 from etl.collection.utils import (
+    default_grapher_schema_version,
     fill_placeholders,
     get_complete_dimensions_filter,
     get_tables_by_name_mapping,
@@ -40,7 +41,7 @@ from etl.collection.utils import (
     unique_records,
     validate_indicators_in_db,
 )
-from etl.config import DEFAULT_GRAPHER_SCHEMA, OWID_ENV, OWIDEnv
+from etl.config import OWID_ENV, OWIDEnv
 from etl.files import yaml_dump
 from etl.paths import SCHEMAS_DIR, VIZ_DIR
 
@@ -137,8 +138,9 @@ class Collection(MDIMBase):
     topic_tags: list[str] | None = None
     # Grapher chart-config schema version that this collection's view configs were authored
     # against. Short ("011") or full URL form; see `resolve_grapher_schema`. Grapher uses it as the
-    # `$schema` of every view config, and skips config migrations entirely when it is missing — so
-    # pin it explicitly rather than relying on the `DEFAULT_GRAPHER_SCHEMA` fallback.
+    # `$schema` of every view config, and skips config migrations entirely when it is missing.
+    # Required for mdims and single charts (`required` in multidim-schema.json, re-checked by
+    # `validate_grapher_schema_pinned()` on save); `None` only for explorers, which reject it.
     grapher_schema: str | None = None
     _default_dimensions: dict[str, str] | None = None
 
@@ -183,8 +185,11 @@ class Collection(MDIMBase):
             # Convert list to set
             self.dependencies = set(self.dependencies)
 
-        # Fail at authoring time on a malformed pin, rather than at upsert time
-        resolve_grapher_schema(self.grapher_schema)
+        # Fail at authoring time on a malformed pin, rather than at upsert time. A *missing* pin is
+        # caught by schema validation and by `validate_grapher_schema_pinned()`, not here: this runs
+        # for every Collection ever constructed, including ones assembled field-by-field.
+        if self.grapher_schema is not None:
+            resolve_grapher_schema(self.grapher_schema)
 
     @property
     def definitions(self) -> Definitions:
@@ -320,11 +325,11 @@ class Collection(MDIMBase):
         # Check that no view carries a corrupted description_key
         self.validate_description_keys()
 
+        # Require a schema pin (mdims and single charts; explorers have no equivalent)
+        self.validate_grapher_schema_pinned()
+
         # Warn about view configs that shadow the collection-level schema pin
         self.warn_on_view_schema_overrides()
-
-        # Warn when no version is pinned and we fall back to the vendored default
-        self.warn_if_grapher_schema_unpinned()
 
         # Sort views based on dimension order
         self.sort_views_based_on_dimensions()
@@ -890,7 +895,13 @@ class Collection(MDIMBase):
         the config YAML. That combination has bitten us before: a config pinned at an old version
         while its body used fields from a newer one, so Grapher ran migrations over a config they
         were never meant to touch. Pin the collection instead.
+
+        Skipped for explorers: they have no collection-level pin to shadow (see
+        `Explorer.__post_init__`), so a `$schema` in an explorer view config overrides nothing.
         """
+        if self._collection_type == "explorer":
+            return
+
         overrides = defaultdict(int)
         for view in self.views:
             config = view.config
@@ -905,19 +916,29 @@ class Collection(MDIMBase):
                 "collection with the top-level `grapher_schema` field instead."
             )
 
-    def warn_if_grapher_schema_unpinned(self):
-        """Warn when the collection pins no schema version and the default is used.
+    def validate_grapher_schema_pinned(self):
+        """Fail when an mdim or single chart pins no schema version.
 
-        The fallback is `DEFAULT_GRAPHER_SCHEMA`, so grapher is told the config already matches the
-        version this repo vendors. That is usually true, but it means a config authored against an
-        older schema would skip migration. It also makes "pinned" and "defaulted" indistinguishable
-        in the database while the two happen to agree — so say so out loud instead.
+        The pin has to live in the config, because it is the only record of what the view configs
+        were authored against: without one, the version Grapher is told about is whatever this repo
+        vendors on the day the step runs, which (a) claims the config is already current, so a
+        config written against an older schema skips migration, and (b) silently changes the next
+        time the step runs after a version bump. `multidim-schema.json` requires the field, which
+        catches every authored config; this re-check covers collections built without schema
+        validation or assembled field-by-field in Python.
+
+        Explorers are exempt — they reach Grapher through the legacy TSV path, which has no
+        equivalent of `grapherConfigSchema`, and `Explorer.__post_init__` rejects the field.
         """
+        if self._collection_type == "explorer":
+            return
+
         if self.grapher_schema is None:
-            log.warning(
-                f"Collection '{self.catalog_path}' pins no `grapher_schema`; falling back to "
-                f"{DEFAULT_GRAPHER_SCHEMA}. Add a top-level `grapher_schema` to the config YAML "
-                "recording the version its view configs were authored against."
+            raise ValueError(
+                f"Collection '{self.catalog_path}' pins no `grapher_schema`. Add a top-level "
+                "`grapher_schema` to the config YAML recording the version its view configs were "
+                f'authored against — `grapher_schema: "{default_grapher_schema_version()}"` for a '
+                "config written today (quoted: an unquoted `011` is YAML octal)."
             )
 
     def validate_description_keys(self):

--- a/etl/collection/utils.py
+++ b/etl/collection/utils.py
@@ -31,6 +31,11 @@ _GRAPHER_SCHEMA_VERSION_PATTERN = re.compile(r"^\d{3}$")
 _GRAPHER_SCHEMA_URL_PATTERN = re.compile(r"^https://files\.ourworldindata\.org/schemas/grapher-schema\.\d{3}\.json$")
 
 
+def default_grapher_schema_version() -> str:
+    """Three-digit version of `DEFAULT_GRAPHER_SCHEMA` — the value a new config should pin."""
+    return DEFAULT_GRAPHER_SCHEMA.rsplit(".", 2)[1]
+
+
 def resolve_grapher_schema(value: str | int | None) -> str:
     """Resolve an authored `grapher_schema` value into a full grapher schema URL.
 
@@ -39,13 +44,19 @@ def resolve_grapher_schema(value: str | int | None) -> str:
     - short: `grapher_schema: "011"`
     - full:  `grapher_schema: https://files.ourworldindata.org/schemas/grapher-schema.011.json`
 
-    `None` falls back to `DEFAULT_GRAPHER_SCHEMA` — the version this repo vendors and validates
-    against. Pinning explicitly is preferred: it records the version the config was authored
-    against, so Grapher migrates it forward after a breaking schema change instead of assuming
-    it is already current.
+    `None` is rejected. There is deliberately no fallback: resolving an unpinned collection to
+    whatever version the repo happens to vendor today would tell Grapher the config is already
+    current, so a config authored against an older schema would skip migration — and the same
+    config would resolve to a *different* version the next time the step runs. The pin has to be
+    recorded in the config itself.
     """
     if value is None:
-        return DEFAULT_GRAPHER_SCHEMA
+        raise ValueError(
+            "No `grapher_schema` pinned. Add a top-level `grapher_schema` to the config YAML "
+            f'recording the version its view configs were authored against — `grapher_schema: "'
+            f'{default_grapher_schema_version()}"` for a config written today. Quote it: an '
+            "unquoted YAML value like `011` is parsed as octal."
+        )
 
     if isinstance(value, str):
         if _GRAPHER_SCHEMA_URL_PATTERN.match(value):

--- a/etl/config.py
+++ b/etl/config.py
@@ -8,6 +8,7 @@ only important for OWID staff.
 """
 
 import asyncio
+import json
 import logging
 import os
 import pwd
@@ -28,7 +29,7 @@ from joblib import Memory  # 0.08
 from sqlalchemy.engine import Engine  # 0.07
 from sqlalchemy.orm import Session  # ~ 0.07
 
-from etl.paths import BASE_DIR, CACHE_DIR
+from etl.paths import BASE_DIR, CACHE_DIR, SCHEMAS_DIR
 
 log = structlog.get_logger()
 
@@ -319,8 +320,48 @@ GITHUB_API_URL = f"{GITHUB_API_BASE}/pulls"
 # Skip SSL verify
 TLS_VERIFY = bool(int(env.get("TLS_VERIFY", 1)))
 
-# Default schema for presentation.grapher_config in metadata. Try to keep it up to date with the latest schema.
-DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
+# Upstream alias that always serves the newest published grapher chart-config schema. Used only to
+# *discover* a new version at bump time (`scripts/generate_schema_types.py --bump-version`, and the
+# scheduled sync workflow). Never resolve it at run time: its `properties.$schema.const` names one
+# concrete version, so it can't validate a config pinned at an older one, and stamping it on our
+# output would claim configs match a version we haven't vendored, validated or generated types for.
+GRAPHER_SCHEMA_LATEST_URL = "https://files.ourworldindata.org/schemas/grapher-schema.latest.json"
+
+_GRAPHER_SCHEMA_FILE_RE = re.compile(r"^grapher-schema\.\d{3}\.json$")
+
+
+def vendored_grapher_schema_id() -> str:
+    """`$id` of the grapher chart-config schema this repo vendors.
+
+    The vendored file under `schemas/` is the single source of truth for the version: it is what
+    `multidim-schema.json` / `explorer-schema.json` `$ref`, what `schema_types.py` is generated
+    from, and what ETL validates configs against offline. Reading its own `$id` instead of
+    repeating the version here means the constant can never name a version we don't have on disk.
+    """
+    vendored = sorted(p for p in SCHEMAS_DIR.glob("grapher-schema.*.json") if _GRAPHER_SCHEMA_FILE_RE.match(p.name))
+    if len(vendored) != 1:
+        raise RuntimeError(
+            f"Expected exactly one vendored grapher schema (grapher-schema.NNN.json) in {SCHEMAS_DIR}, "
+            f"found {[p.name for p in vendored]}. A version bump replaces the file rather than adding "
+            "one — run `python scripts/generate_schema_types.py --bump-version`."
+        )
+
+    path = vendored[0]
+    schema_id = json.loads(path.read_text()).get("$id")
+    if not isinstance(schema_id, str) or schema_id.rsplit("/", 1)[-1] != path.name:
+        raise RuntimeError(
+            f"Vendored {path.name} declares `$id` {schema_id!r}, which doesn't match its filename. "
+            "Grapher keys config migrations on the `$id`, and ETL resolves `$schema` URLs to local "
+            "files by basename, so the two must agree. Re-vendor with "
+            "`python scripts/generate_schema_types.py --refresh`."
+        )
+    return schema_id
+
+
+# Grapher chart-config schema version this repo is built against — the default `$schema` for
+# indicator-level `presentation.grapher_config`, and the version a new collection config should pin.
+# Derived from the vendored copy (see above); bump it with `--bump-version`, never by hand.
+DEFAULT_GRAPHER_SCHEMA = vendored_grapher_schema_id()
 
 # Google Cloud service account path (used for BigQuery)
 GOOGLE_APPLICATION_CREDENTIALS = env.get("GOOGLE_APPLICATION_CREDENTIALS")

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -68,10 +68,10 @@
             "pattern": "^(\\d{3}|https://files\\.ourworldindata\\.org/schemas/grapher-schema\\.\\d{3}\\.json)$",
             "title": "Grapher config schema version",
             "description": "Version of the OWID Grapher chart-config schema that this collection's view configs were authored against. Grapher uses it as the `$schema` of every view config, and migrates outdated configs forward to the current version.",
-            "requirement_level": "recommended",
+            "requirement_level": "required",
             "guidelines": [
                 [
-                    "Pin the version explicitly. When it is omitted, Grapher is told the configs already match the version this repo vendors (`DEFAULT_GRAPHER_SCHEMA`), so a breaking schema change would skip the migration."
+                    "Pin the version explicitly — ETL fails without it. There is no fallback on purpose: an unpinned config would resolve to whatever version the repo vendors on the day the step runs, which both claims the config is already current (so a breaking schema change skips the migration) and silently changes on the next run after a version bump."
                 ],
                 [
                     "Two forms are accepted: the short three-digit version (`\"011\"`) or the full schema URL."
@@ -1044,7 +1044,8 @@
     },
     "required": [
         "dimensions",
-        "views"
+        "views",
+        "grapher_schema"
     ],
     "$defs": {
         "indicatorConfig": {

--- a/scripts/generate_schema_types.py
+++ b/scripts/generate_schema_types.py
@@ -6,16 +6,27 @@ This script reads the multidim, grapher, and dataset schemas and generates
 static TypedDict classes that provide autocompletion and type checking.
 
 Usage:
-    python scripts/generate_schema_types.py            # regenerate the file
-    python scripts/generate_schema_types.py --check    # fail if the file is out of date
-    python scripts/generate_schema_types.py --refresh  # re-download the vendored grapher schema, then regenerate
+    python scripts/generate_schema_types.py                 # regenerate the file (offline)
+    python scripts/generate_schema_types.py --check         # fail if the file is out of date (offline)
+    python scripts/generate_schema_types.py --refresh       # re-download the SAME version, then regenerate
+    python scripts/generate_schema_types.py --bump-version  # move to a NEWER version, then regenerate
 
 This will update etl/collection/model/schema_types.py with the latest types.
 
 The grapher schema is read from a vendored copy in `schemas/` (committed to the repo) so that
-generation is deterministic and offline. The upstream schema is mutated in place by the web team
-(e.g. dumbbell plots landed in grapher-schema.010.json without a version bump), so run `--refresh`
-to pull in upstream changes — the resulting diff of the vendored file is reviewable in the PR.
+generation is deterministic and offline. `--refresh` and `--bump-version` are the only modes that
+hit the network, and they are run deliberately — by the scheduled sync workflow or by a person.
+ETL itself never fetches a schema at run time.
+
+Which one to use:
+
+- `--refresh`: upstream mutated the version we already vendor (the web team does this without
+  version bumps — dumbbell plots landed in grapher-schema.010.json that way). The resulting diff
+  of the vendored file is what you review in the PR.
+- `--bump-version`: upstream published a *new* version. Reads the version from
+  `grapher-schema.latest.json`, vendors it, drops the old copy, repoints the `$ref`s in the
+  multidim/explorer schemas. `DEFAULT_GRAPHER_SCHEMA` needs no edit — `etl/config.py` derives it
+  from whichever file is vendored.
 
 NOTE: hand-written types that are not derived from any JSON schema belong in
 `etl/collection/model/params.py`, NOT in the generated file (they would be lost on
@@ -26,19 +37,31 @@ legacy fields into ViewConfig that the schemas don't know about.
 import argparse
 import difflib
 import json
+import re
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from etl.config import DEFAULT_GRAPHER_SCHEMA
+from etl.config import DEFAULT_GRAPHER_SCHEMA, GRAPHER_SCHEMA_LATEST_URL, vendored_grapher_schema_id
 from etl.paths import SCHEMAS_DIR
 
 OUTPUT_PATH = Path(__file__).parent.parent / "etl" / "collection" / "model" / "schema_types.py"
 
-# Vendored copy of the grapher schema (DEFAULT_GRAPHER_SCHEMA), refreshed with --refresh.
-VENDORED_GRAPHER_SCHEMA_PATH = SCHEMAS_DIR / DEFAULT_GRAPHER_SCHEMA.rsplit("/", 1)[-1]
+# Schemas whose `$ref`s name the vendored grapher schema by filename, and so have to be repointed
+# when the vendored version changes.
+SCHEMAS_REFERENCING_GRAPHER = ("multidim-schema.json", "explorer-schema.json")
+
+
+def vendored_grapher_schema_path() -> Path:
+    """Path of the vendored grapher schema copy, resolved on each call.
+
+    Deliberately a function rather than a module constant: `--bump-version` replaces the file mid-run, and
+    a path computed at import time would still point at the version that was just deleted.
+    """
+    return SCHEMAS_DIR / vendored_grapher_schema_id().rsplit("/", 1)[-1]
+
 
 # Extra fields injected into ViewConfig that are not part of the multidim schema.
 # TODO: remove once we are done with explorers
@@ -316,12 +339,13 @@ class TypedDictGenerator:
         with open(dataset_schema_path) as f:
             dataset_schema = json.load(f)
 
-        if not VENDORED_GRAPHER_SCHEMA_PATH.exists():
+        vendored_path = vendored_grapher_schema_path()
+        if not vendored_path.exists():
             raise SystemExit(
-                f"Vendored grapher schema not found at {VENDORED_GRAPHER_SCHEMA_PATH}. "
+                f"Vendored grapher schema not found at {vendored_path}. "
                 "Run `python scripts/generate_schema_types.py --refresh` to download it."
             )
-        with open(VENDORED_GRAPHER_SCHEMA_PATH) as f:
+        with open(vendored_path) as f:
             grapher_schema = json.load(f)
 
         # Extract properties
@@ -410,7 +434,7 @@ class TypedDictGenerator:
             "",
             "Provides strongly-typed interfaces for:",
             "- View configuration (based on multidim-schema.json, resolving $refs against the",
-            f"  vendored schemas/{VENDORED_GRAPHER_SCHEMA_PATH.name} — refresh it with --refresh)",
+            f"  vendored schemas/{vendored_grapher_schema_path().name} — refresh it with --refresh)",
             "- View metadata (based on dataset-schema.json)",
             '"""',
             "",
@@ -481,16 +505,92 @@ class TypedDictGenerator:
         return "\n".join(lines)
 
 
+def _write_vendored_schema(path: Path, schema: dict[str, Any]) -> None:
+    with open(path, "w") as f:
+        json.dump(schema, f, indent=2)
+        f.write("\n")
+
+
 def refresh_vendored_schema() -> None:
-    """Re-download the vendored grapher schema from the upstream URL."""
+    """Re-download the vendored grapher schema from the upstream URL (same version)."""
     from etl.http import session
 
     resp = session.get(DEFAULT_GRAPHER_SCHEMA, timeout=30)
     resp.raise_for_status()
-    with open(VENDORED_GRAPHER_SCHEMA_PATH, "w") as f:
-        json.dump(resp.json(), f, indent=2)
-        f.write("\n")
-    print(f"Refreshed {VENDORED_GRAPHER_SCHEMA_PATH} from {DEFAULT_GRAPHER_SCHEMA}")
+    path = vendored_grapher_schema_path()
+    _write_vendored_schema(path, resp.json())
+    print(f"Refreshed {path} from {DEFAULT_GRAPHER_SCHEMA}")
+
+
+def bump_vendored_schema() -> bool:
+    """Move the vendored grapher schema to the newest published version.
+
+    Reads the version from `grapher-schema.latest.json` — the alias upstream keeps pointed at the
+    newest concrete schema, whose `$id` names that version. This is the one place `latest` belongs:
+    a deliberate, reviewable action, not a run-time lookup.
+
+    Returns True if anything changed, False if we already vendor the newest version.
+    """
+    from etl.http import session
+
+    resp = session.get(GRAPHER_SCHEMA_LATEST_URL, timeout=30)
+    resp.raise_for_status()
+    schema = resp.json()
+
+    latest_id = schema.get("$id")
+    if not isinstance(latest_id, str) or not re.fullmatch(
+        r"https://files\.ourworldindata\.org/schemas/grapher-schema\.\d{3}\.json", latest_id
+    ):
+        raise SystemExit(
+            f"{GRAPHER_SCHEMA_LATEST_URL} declares `$id` {latest_id!r}, which is not a concrete "
+            "versioned schema URL. Refusing to vendor it — check with the web team."
+        )
+
+    old_path = vendored_grapher_schema_path()
+    new_path = SCHEMAS_DIR / latest_id.rsplit("/", 1)[-1]
+    if new_path == old_path:
+        print(f"Already vendoring the newest published schema ({old_path.name}); nothing to bump.")
+        print("To pull in an in-place upstream change to this same version, use --refresh.")
+        return False
+
+    # Write the new copy and drop the old one in one go: `etl.config` insists on exactly one
+    # vendored schema, so leaving both on disk would break every later import.
+    _write_vendored_schema(new_path, schema)
+    old_path.unlink()
+    print(f"Vendored {new_path.name} (was {old_path.name})")
+
+    # Repoint the `$ref`s that name the vendored file.
+    for name in SCHEMAS_REFERENCING_GRAPHER:
+        path = SCHEMAS_DIR / name
+        text = path.read_text()
+        updated = text.replace(f"{old_path.name}#", f"{new_path.name}#")
+        if updated != text:
+            path.write_text(updated)
+            print(f"Repointed $refs in {name}: {text.count(f'{old_path.name}#')} reference(s)")
+
+    # Anything left is a mention in prose, `description`s or `examples` rather than a `$ref` — e.g.
+    # the `grapher_schema` examples in multidim-schema.json, which show what a *new* config should
+    # pin. Not rewritten automatically: some of those examples are deliberately version-specific.
+    leftover = sorted(p.name for p in SCHEMAS_DIR.glob("*.json") if p != new_path and old_path.name in p.read_text())
+    if leftover:
+        print(
+            f"NOTE: {', '.join(leftover)} still reference {old_path.name} outside of `$ref`s "
+            "(descriptions/examples). Update the ones that should show the current version."
+        )
+
+    print(
+        "\nStill to do by hand (see the `/sync-grapher-schema` skill):\n"
+        "  1. Review what changed upstream:\n"
+        f"     git show HEAD:schemas/{old_path.name} | diff -u - schemas/{new_path.name}\n"
+        "  2. Mirror genuinely new/changed properties into the `grapher_config` block embedded in\n"
+        "     schemas/dataset-schema.json, PRESERVING the deliberate ETL-side deviations (Jinja\n"
+        "     `oneOf` escape hatches, the extra `WorldMap` chart type, the ETL-only\n"
+        "     `data`/`includedEntities` properties). `test_grapher_config_schema_sync` fails until\n"
+        "     this is done.\n"
+        "  3. Do NOT bump the `grapher_schema` pins in existing collection configs — those record\n"
+        "     what each config was authored against, and are what lets grapher migrate them.\n"
+    )
+    return True
 
 
 def format_content(content: str) -> str:
@@ -525,10 +625,30 @@ def main():
         action="store_true",
         help=f"Re-download the vendored grapher schema from {DEFAULT_GRAPHER_SCHEMA} before generating.",
     )
+    parser.add_argument(
+        "--bump-version",
+        action="store_true",
+        help=(
+            "Vendor the newest published schema version instead (read from "
+            f"{GRAPHER_SCHEMA_LATEST_URL}), repoint the $refs that name it, then generate. "
+            "No-op if we already vendor the newest version."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.refresh and args.bump_version:
+        raise SystemExit(
+            "--refresh and --bump-version are mutually exclusive: --refresh re-downloads the version we already vendor, --bump-version moves to a newer one."
+        )
+
+    if args.check and (args.refresh or args.bump_version):
+        raise SystemExit("--check is read-only; don't combine it with --refresh/--bump-version.")
 
     if args.refresh:
         refresh_vendored_schema()
+
+    if args.bump_version:
+        bump_vendored_schema()
 
     generator = TypedDictGenerator()
     content = format_content(generator.generate_file_content())

--- a/tests/collections/test_chart_upsert.py
+++ b/tests/collections/test_chart_upsert.py
@@ -35,12 +35,12 @@ def _make_view(indicators: dict, config: dict | None = None) -> View:
     )
 
 
-def _build(view: View, slug: str = "my-chart") -> dict:
+def _build(view: View, slug: str = "my-chart", grapher_schema: str = DEFAULT_GRAPHER_SCHEMA) -> dict:
     with patch(
         "etl.collection.chart_upsert.map_indicator_path_to_id",
         side_effect=lambda path: _PATH_TO_ID[path],
     ):
-        return _build_chart_config(view, slug)
+        return _build_chart_config(view, slug, grapher_schema)
 
 
 def test_single_y_indicator():
@@ -48,6 +48,18 @@ def test_single_y_indicator():
     assert config["slug"] == "my-chart"
     assert config["$schema"] == DEFAULT_GRAPHER_SCHEMA
     assert config["dimensions"] == [{"property": "y", "variableId": 111}]
+
+
+def test_collection_pin_becomes_the_config_schema():
+    """The collection's `grapher_schema` is what a single chart stores as `$schema`.
+
+    A chart config has no `grapherConfigSchema` indirection, so this is the only place the pin can
+    land. It used to be ignored here in favour of `DEFAULT_GRAPHER_SCHEMA`, which silently told
+    grapher every ETL-authored chart was written against the version of the day.
+    """
+    older = "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
+    config = _build(_make_view({"y": "table#ind1"}), grapher_schema=older)
+    assert config["$schema"] == older
 
 
 def test_multiple_y_indicators_preserve_order():

--- a/tests/collections/test_collection_core.py
+++ b/tests/collections/test_collection_core.py
@@ -364,6 +364,8 @@ def test_update_choice_slugs_in_views_handles_nan_entries_from_unstack():
 def _make_subcollection(view_type: str, catalog_path: str):
     """Build a minimal (non-explorer) Collection sub-collection for combine tests."""
     config = {
+        # Sub-collections are built from the same YAML as the combined one, so they carry its pin.
+        "grapher_schema": "008",
         "title": {"title": f"Test {view_type}", "title_variant": ""},
         "default_selection": ["World"],
         "dimensions": [

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -2368,7 +2368,8 @@ def test_collection_grapher_schema_round_trips():
     assert collection.grapher_schema == "011"
     assert collection.to_dict()["grapher_schema"] == "011"
 
-    # Omitted: the key is pruned, and `upsert_to_db` resolves the DEFAULT_GRAPHER_SCHEMA fallback.
+    # Omitted: the key is pruned. Construction still succeeds (explorers legitimately leave it
+    # unset); the requirement is enforced by `validate_grapher_schema_pinned` and schema validation.
     collection = Collection.from_dict(_make_minimal_config())
     assert collection.grapher_schema is None
     assert "grapher_schema" not in collection.to_dict()
@@ -2394,6 +2395,19 @@ def test_collection_grapher_schema_passes_schema_validation():
     collection = Collection.from_dict(_make_minimal_config(grapher_schema="011"))
     collection.grapher_schema = "latest"  # bypasses __post_init__
     with pytest.raises(ValueError, match="must match pattern"):
+        collection.validate_schema()
+
+
+def test_collection_grapher_schema_is_required_by_schema():
+    """
+    Test Collection.validate_schema - an unpinned collection fails schema validation.
+
+    `grapher_schema` is in multidim-schema.json's top-level `required`, so the missing pin is
+    caught for every authored config — YAML or assembled programmatically — the moment
+    `create_collection` builds it.
+    """
+    collection = Collection.from_dict(_make_minimal_config())
+    with pytest.raises(ValueError, match="grapher_schema"):
         collection.validate_schema()
 
 
@@ -2439,18 +2453,48 @@ def test_warn_on_view_schema_overrides(capsys):
     assert capsys.readouterr().out == ""
 
 
-def test_warn_if_grapher_schema_unpinned(capsys):
+def test_validate_grapher_schema_pinned():
     """
-    Test Collection.warn_if_grapher_schema_unpinned - an unpinned collection says so.
+    Test Collection.validate_grapher_schema_pinned - an unpinned mdim fails, an explorer doesn't.
 
-    Without this, a config that silently relies on the DEFAULT_GRAPHER_SCHEMA fallback is
-    indistinguishable in the database from one that pins the same version deliberately.
+    There is no default on purpose: an unpinned config would resolve to whatever version the repo
+    vendors on the day the step runs, so it both claims to be current and changes meaning after the
+    next version bump. Explorers are exempt — the legacy TSV path has no `grapherConfigSchema`, and
+    `Explorer.__post_init__` rejects the field outright.
     """
-    Collection.from_dict(_make_minimal_config()).warn_if_grapher_schema_unpinned()
-    out = capsys.readouterr().out
-    assert "pins no `grapher_schema`" in out
+    from etl.collection.explorer import Explorer
 
-    Collection.from_dict(_make_minimal_config(grapher_schema="011")).warn_if_grapher_schema_unpinned()
+    with pytest.raises(ValueError, match="pins no `grapher_schema`"):
+        Collection.from_dict(_make_minimal_config()).validate_grapher_schema_pinned()
+
+    Collection.from_dict(_make_minimal_config(grapher_schema="011")).validate_grapher_schema_pinned()
+
+    explorer = Explorer.from_dict(_make_minimal_config(config={"explorerTitle": "T"}))
+    explorer.validate_grapher_schema_pinned()
+
+
+def test_warn_on_view_schema_overrides_skips_explorers(capsys):
+    """
+    Test Collection.warn_on_view_schema_overrides - explorers have no pin to shadow, so no warning.
+
+    Explorers always leave `grapher_schema` unset, so the warning used to fire on every explorer
+    save and point at a collection pin that does not exist.
+    """
+    from etl.collection.explorer import Explorer
+
+    explorer = Explorer.from_dict(
+        _make_minimal_config(
+            config={"explorerTitle": "T"},
+            views=[
+                {
+                    "dimensions": {"metric": "total"},
+                    "indicators": {"y": [{"catalogPath": "grapher/ns/2024-01-01/ds/tb#ind"}]},
+                    "config": {"$schema": "https://files.ourworldindata.org/schemas/grapher-schema.008.json"},
+                }
+            ],
+        )
+    )
+    explorer.warn_on_view_schema_overrides()
     assert capsys.readouterr().out == ""
 
 

--- a/tests/collections/test_collections_utils.py
+++ b/tests/collections/test_collections_utils.py
@@ -175,11 +175,9 @@ def test_resolve_grapher_schema_accepted_forms():
     """
     Test resolve_grapher_schema - both authoring forms resolve to a full schema URL.
 
-    Short form "011" expands to the published URL; a full URL passes through unchanged;
-    None falls back to the version this repo vendors (DEFAULT_GRAPHER_SCHEMA).
+    Short form "011" expands to the published URL; a full URL passes through unchanged.
     """
     from etl.collection.utils import resolve_grapher_schema
-    from etl.config import DEFAULT_GRAPHER_SCHEMA
 
     assert resolve_grapher_schema("011") == "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
     # An older pin is preserved — that is the point of pinning: Grapher migrates it forward.
@@ -188,7 +186,23 @@ def test_resolve_grapher_schema_accepted_forms():
     full = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
     assert resolve_grapher_schema(full) == full
 
-    assert resolve_grapher_schema(None) == DEFAULT_GRAPHER_SCHEMA
+
+def test_resolve_grapher_schema_rejects_missing_pin():
+    """
+    Test resolve_grapher_schema - `None` raises instead of falling back to a default.
+
+    A fallback would resolve an unpinned config to whatever version the repo vendors on the day the
+    step runs: it tells Grapher the config is already current (skipping migrations for a config
+    authored earlier), and it silently resolves to a different version after the next version bump.
+    """
+    from etl.collection.utils import default_grapher_schema_version, resolve_grapher_schema
+    from etl.config import DEFAULT_GRAPHER_SCHEMA
+
+    with pytest.raises(ValueError, match="No `grapher_schema` pinned"):
+        resolve_grapher_schema(None)
+
+    # The version suggested in the error is the one this repo vendors, in short quoted form.
+    assert DEFAULT_GRAPHER_SCHEMA.endswith(f"grapher-schema.{default_grapher_schema_version()}.json")
 
 
 def test_resolve_grapher_schema_rejects_unquoted_yaml_version():

--- a/tests/collections/test_core_utils.py
+++ b/tests/collections/test_core_utils.py
@@ -15,6 +15,8 @@ from etl.collection.model.view import CommonView, View
 def create_test_config():
     """Create a basic test configuration for collections."""
     return {
+        # Required for mdims/charts (see `Collection.validate_grapher_schema_pinned`).
+        "grapher_schema": "011",
         "title": {"title": "Test Collection", "title_variant": "Test Collection Variant"},
         "default_selection": ["country"],
         "dimensions": [
@@ -45,6 +47,8 @@ def create_test_config_with_common_views():
 def create_test_explorer_config():
     """Create a basic test configuration for explorers."""
     config = create_test_config()
+    # Explorers reject `grapher_schema`: the legacy TSV path has no `grapherConfigSchema`.
+    config.pop("grapher_schema")
     config["config"] = {"hasMapTab": True, "chartTypes": ["LineChart"]}
     return config
 

--- a/tests/test_metadata_schemas.py
+++ b/tests/test_metadata_schemas.py
@@ -351,30 +351,36 @@ def test_snapshot_license_lives_under_origin():
 
 
 def test_multidim_configs_pin_grapher_schema():
-    """Guardrail: every multidim collection config must pin `grapher_schema`.
+    """Guardrail: every multidim collection config must pin a valid `grapher_schema`.
 
-    Grapher injects the collection's `grapherConfigSchema` as the `$schema` of each view config and
-    migrates outdated configs forward. When no version is given, ETL falls back to
-    `DEFAULT_GRAPHER_SCHEMA`, i.e. it tells Grapher the configs are already current — so a breaking
-    schema change upstream would silently skip the migration for those views.
+    Grapher injects the collection's `grapherConfigSchema` as the `$schema` of each view config
+    (single charts carry it as `$schema` directly) and migrates outdated configs forward. Without a
+    pin there is nothing recording what the config was authored against, and ETL refuses to guess —
+    see `etl.collection.utils.resolve_grapher_schema` for the accepted forms.
 
-    Pinning records the version the config was actually authored against. See
-    `etl.collection.utils.resolve_grapher_schema` for the accepted forms.
+    `Collection` enforces this at run time too (`validate_grapher_schema_pinned`, plus `required`
+    in multidim-schema.json). This test is the fast, offline version: it needs no step run, and it
+    catches a *malformed* pin (`grapher_schema:` with no value, an unquoted octal `011`) that a
+    key-presence check would wave through.
     """
-    missing = []
-    for config_path in sorted(Path(STEP_DIR / "viz" / "chart").glob("**/*.yml")):
+    from etl.collection.utils import default_grapher_schema_version, resolve_grapher_schema
+
+    broken = []
+    for config_path in sorted(Path(STEP_DIR / "viz" / "chart").glob("**/*.y*ml")):
         config = yaml.safe_load(config_path.read_text()) or {}
         # Only collection configs are in scope; the directory also holds plain data yaml
         # (e.g. un/latest/map_brackets.yml).
         if not isinstance(config, dict) or not {"dimensions", "views"} <= set(config):
             continue
-        if "grapher_schema" not in config:
-            missing.append(str(config_path.relative_to(BASE_DIR)))
+        try:
+            resolve_grapher_schema(config.get("grapher_schema"))
+        except ValueError as e:
+            broken.append(f"{config_path.relative_to(BASE_DIR)}: {e}")
 
-    assert not missing, (
-        "These multidim configs don't pin `grapher_schema`. Add the current version as a "
+    assert not broken, (
+        "These multidim configs don't pin a valid `grapher_schema`. Add the current version as a "
         f'**quoted** string (an unquoted `011` is parsed as octal) — `grapher_schema: "'
-        f'{DEFAULT_GRAPHER_SCHEMA.rsplit(".", 2)[1]}"`:\n  ' + "\n  ".join(missing)
+        f'{default_grapher_schema_version()}"`:\n  ' + "\n  ".join(broken)
     )
 
 
@@ -541,14 +547,53 @@ def test_no_newer_grapher_schema_version():
     when that moves past DEFAULT_GRAPHER_SCHEMA, we should consider bumping. See the
     "Version bump" section of the /sync-grapher-schema skill.
     """
+    from etl.config import GRAPHER_SCHEMA_LATEST_URL
     from etl.http import session
 
-    latest_url = DEFAULT_GRAPHER_SCHEMA.rsplit("/", 1)[0] + "/grapher-schema.latest.json"
-    resp = session.get(latest_url, timeout=30)
+    resp = session.get(GRAPHER_SCHEMA_LATEST_URL, timeout=30)
     resp.raise_for_status()
     latest_id = resp.json().get("$id")
     assert latest_id == DEFAULT_GRAPHER_SCHEMA, (
         f"Upstream published a newer grapher schema: {latest_id} "
         f"(we pin {DEFAULT_GRAPHER_SCHEMA}).\n"
-        "Follow the 'Version bump' section of the /sync-grapher-schema skill to upgrade."
+        "Run `python scripts/generate_schema_types.py --bump-version` and follow /sync-grapher-schema."
     )
+
+
+def test_default_grapher_schema_is_derived_from_the_vendored_copy():
+    """`DEFAULT_GRAPHER_SCHEMA` must name the schema we actually have on disk.
+
+    It is derived from the vendored file's own `$id` rather than written out in `etl/config.py`,
+    so the two can't drift apart. This test pins the contract the derivation provides: exactly one
+    vendored `grapher-schema.NNN.json`, whose filename matches its `$id`.
+    """
+    from etl.config import vendored_grapher_schema_id
+
+    vendored = sorted(SCHEMAS_DIR.glob("grapher-schema.[0-9][0-9][0-9].json"))
+    assert len(vendored) == 1, f"Expected exactly one vendored grapher schema, found {[p.name for p in vendored]}"
+    assert DEFAULT_GRAPHER_SCHEMA == vendored_grapher_schema_id()
+    assert DEFAULT_GRAPHER_SCHEMA.rsplit("/", 1)[-1] == vendored[0].name
+    assert json.loads(vendored[0].read_text())["$id"] == DEFAULT_GRAPHER_SCHEMA
+
+
+def test_vendored_schema_id_rejects_broken_states(tmp_path, monkeypatch):
+    """The derivation fails loudly rather than guessing a version.
+
+    Two states that must not resolve silently: more than one (or no) vendored schema — the state a
+    half-done bump leaves behind — and a file whose `$id` disagrees with its filename, since
+    grapher migrates on the `$id` while ETL resolves `$schema` URLs to local files by basename.
+    """
+    import etl.config as config
+
+    monkeypatch.setattr(config, "SCHEMAS_DIR", tmp_path)
+
+    with pytest.raises(RuntimeError, match="Expected exactly one vendored grapher schema"):
+        config.vendored_grapher_schema_id()
+
+    (tmp_path / "grapher-schema.011.json").write_text(json.dumps({"$id": "https://x/grapher-schema.012.json"}))
+    with pytest.raises(RuntimeError, match="doesn't match its filename"):
+        config.vendored_grapher_schema_id()
+
+    (tmp_path / "grapher-schema.012.json").write_text("{}")
+    with pytest.raises(RuntimeError, match="Expected exactly one vendored grapher schema"):
+        config.vendored_grapher_schema_id()

--- a/tests/test_schema_types_generation.py
+++ b/tests/test_schema_types_generation.py
@@ -9,10 +9,15 @@ and offline. It fails when:
 To fix a failure, run: python scripts/generate_schema_types.py
 """
 
+import json
+import shutil
 import subprocess
 import sys
+from unittest.mock import Mock, patch
 
-from etl.paths import BASE_DIR
+import pytest
+
+from etl.paths import BASE_DIR, SCHEMAS_DIR
 
 
 def test_schema_types_is_up_to_date():
@@ -49,3 +54,93 @@ def test_special_property_names_are_escaped_in_generated_annotations(tmp_path):
 
     assert not marker.exists()
     assert namespace["ExploitConfig"].__annotations__[malicious_name] is str
+
+
+@pytest.fixture
+def sandboxed_schemas(tmp_path, monkeypatch):
+    """Copy the schemas that a version bump touches into a temp dir and point both modules at it."""
+    import etl.config as config
+    import scripts.generate_schema_types as gen
+
+    for name in ("multidim-schema.json", "explorer-schema.json"):
+        shutil.copy(SCHEMAS_DIR / name, tmp_path / name)
+    vendored = next(SCHEMAS_DIR.glob("grapher-schema.[0-9][0-9][0-9].json"))
+    shutil.copy(vendored, tmp_path / vendored.name)
+
+    monkeypatch.setattr(config, "SCHEMAS_DIR", tmp_path)
+    monkeypatch.setattr(gen, "SCHEMAS_DIR", tmp_path)
+    return tmp_path, vendored.name
+
+
+def _fake_upstream(schema: dict, version: str) -> Mock:
+    schema = json.loads(json.dumps(schema))
+    schema["$id"] = f"https://files.ourworldindata.org/schemas/grapher-schema.{version}.json"
+    schema["properties"]["$schema"]["const"] = schema["$id"]
+    schema["properties"]["$schema"]["default"] = schema["$id"]
+    resp = Mock()
+    resp.json.return_value = schema
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_bump_replaces_the_vendored_schema_and_repoints_refs(sandboxed_schemas):
+    """`--bump-version` moves us to a newly published version without leaving the old one behind.
+
+    The vendored file is the single source of truth for the version (`DEFAULT_GRAPHER_SCHEMA` is
+    derived from it), so the bump has to swap the file *and* repoint every `$ref` that names it by
+    filename. Leaving two copies on disk would break `vendored_grapher_schema_id()` for everyone.
+    """
+    import etl.config as config
+    import scripts.generate_schema_types as gen
+
+    tmp_path, old_name = sandboxed_schemas
+    current = json.loads((tmp_path / old_name).read_text())
+    refs_before = {
+        name: (tmp_path / name).read_text().count(f"{old_name}#")
+        for name in ("multidim-schema.json", "explorer-schema.json")
+    }
+    assert all(n > 0 for n in refs_before.values()), "fixture should start with $refs to the vendored schema"
+
+    with patch("etl.http.session.get", return_value=_fake_upstream(current, "099")):
+        assert gen.bump_vendored_schema() is True
+
+    assert not (tmp_path / old_name).exists()
+    assert (tmp_path / "grapher-schema.099.json").exists()
+    assert config.vendored_grapher_schema_id().endswith("grapher-schema.099.json")
+    for name, count in refs_before.items():
+        text = (tmp_path / name).read_text()
+        assert text.count(f"{old_name}#") == 0
+        assert text.count("grapher-schema.099.json#") == count
+
+
+def test_bump_is_a_noop_when_already_current(sandboxed_schemas):
+    """Re-running `--bump-version` must not churn files — CI and the sync workflow may call it blindly."""
+    import scripts.generate_schema_types as gen
+
+    tmp_path, old_name = sandboxed_schemas
+    current = json.loads((tmp_path / old_name).read_text())
+    before = {p.name: p.read_text() for p in tmp_path.glob("*.json")}
+
+    with patch("etl.http.session.get", return_value=_fake_upstream(current, old_name.split(".")[1])):
+        assert gen.bump_vendored_schema() is False
+
+    assert {p.name: p.read_text() for p in tmp_path.glob("*.json")} == before
+
+
+def test_bump_refuses_a_non_versioned_latest_id(sandboxed_schemas):
+    """If `latest.json` ever stops naming a concrete version, don't vendor it under a guessed name."""
+    import scripts.generate_schema_types as gen
+
+    tmp_path, old_name = sandboxed_schemas
+    current = json.loads((tmp_path / old_name).read_text())
+    broken = json.loads(json.dumps(current))
+    broken["$id"] = "https://files.ourworldindata.org/schemas/grapher-schema.latest.json"
+    resp = Mock()
+    resp.json.return_value = broken
+    resp.raise_for_status.return_value = None
+
+    with patch("etl.http.session.get", return_value=resp):
+        with pytest.raises(SystemExit, match="not a concrete"):
+            gen.bump_vendored_schema()
+
+    assert (tmp_path / old_name).exists()


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

Two related changes to how the grapher chart-config schema version is handled.

**1. `grapher_schema` is now required in collection configs, with no fallback.**

Omitting it used to resolve to whatever version the repo vendored *on the day the step ran*, which both told grapher the config was already current (skipping the migrations the pin exists to trigger) and silently changed meaning after the next version bump. `resolve_grapher_schema(None)` now raises; the field is `required` in `multidim-schema.json` (so authored *and* programmatic configs are caught when `create_collection` builds them); `Collection.save()` re-checks for collections built without schema validation. Explorers stay exempt — they reject the field, because the legacy TSV path has no `grapherConfigSchema`.

Two bugs found on the way:

- **Single-chart configs' pin was inert.** `_build_chart_config` hardcoded `DEFAULT_GRAPHER_SCHEMA` as the chart's `$schema` and never read the authored pin. No effect on the DB today (all 77 configs pin `"011"`, which *is* the current default) — it becomes load-bearing at the next bump.
- The "unpinned" warning fired on **every** explorer save, telling authors to add a field explorers reject.

**2. The version is no longer hand-maintained.**

`DEFAULT_GRAPHER_SCHEMA` is derived from the vendored schema's own `$id`, so it can't name a version we don't have on disk, and it fails loudly on the states a half-done bump leaves behind. A version bump is one command:

```bash
python scripts/generate_schema_types.py --bump-version
```

It reads the new version from `grapher-schema.latest.json`, vendors it, drops the old copy, repoints the `$ref`s in the multidim/explorer schemas, regenerates the types, and prints what still needs judgment (the upstream diff, and mirroring new properties into the embedded `grapher_config` block). Idempotent, so the sync workflow can point at it blindly.

`latest.json` is consulted **only** there — never at run time, where it would be wrong anyway: its `properties.$schema.const` names one concrete version, so it cannot validate a config pinned at an older one. ETL stays offline and deterministic.

| | |
|---|---|
| Tests | `make unittest` green (889); both network schema guards green |
| Docs | `docs/guides/schema-management.md` (rewritten — it still showed the literal constant), `grapher-schema-sync.md`, `mdims.md` |
| Skills | `chart-editing` (it told authors to *omit* the schema, which now fails), `create-multidim`, `sync-grapher-schema` |

## Open

- **No step was run.** Nothing needs re-running for correctness: every config pins `011`, which equals the current default, so no stored value changes. An end-to-end check if wanted: `STAGING=1 .venv/bin/etlr viz://chart/animal_welfare/latest/banning_of_chick_culling --grapher`.
- **`--bump-version` has only been exercised against a simulated new version** (isolated schemas dir, `011 → 099`: file swapped, 59 + 55 `$ref`s repointed). Upstream has published `011` for a while, so the real path stays untested until it happens. The idempotent path and the input guards ran for real.
- **Behaviour change to be aware of:** `combine_collections(config={...})` with a hand-built dict now fails unless that dict carries the pin. All three in-repo callers pass the loaded YAML, so nothing breaks — an explicit error was preferred over inheriting the pin from sub-collections, which would reintroduce implicit resolution.
- **Not tightened:** `apps/chart_sync/admin_api.py` still `setdefault`s the default `$schema` in `put_grapher_config` / `upsert_chart_etl_config`. The collection path always supplies it now, so those only affect non-collection callers (indicator-level `grapher_config`, anomalist). Separate call.
- Prose mentions of the version aren't rewritten by `--bump-version` — the `grapher_schema` `examples` in `multidim-schema.json` are reported rather than edited, since one is a deliberately-bad bare-filename example.
