### PR TITLE
🎉 Add skill to log data producer report emails

### DIFF
--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -1,29 +1,35 @@
 ---
 name: log-producer-interactions
 description: >-
-  Sync the current user's Gmail exchanges with OWID's data producers into the shared Notion
-  "Data Producer Interactions" log, one row per email, incrementally and without duplicates.
-  Use when the user says "log my producer emails", "update the interactions log", "sync producer
-  interactions", after sending analytics reports, or when someone asks what is pending with a
-  data producer. Also flags emails from producers that are not yet in the contacts table, and
-  emails that look like open questions or promises, so the team can track them with Status and
-  Owner. Runs against the caller's own mailbox only.
+  Log the analytics reports sent to OWID's data producers, and the producers' replies, into the
+  shared Notion reports log: one row per email, incrementally and without duplicates. Use after
+  sending a round of producer analytics reports, or when the user says "log the report emails" or
+  asks whether a producer ever replied to a report. Searches only the addresses recorded in the
+  contacts table, only for report threads, and asks before writing anything. Runs against the
+  caller's own mailbox only.
 metadata:
   internal: true
 ---
 
-# Log data producer interactions
+# Log data producer report emails
 
-Keep the shared Notion log of exchanges with data producers up to date from the caller's Gmail. The log is the team's single place to answer "when did we last talk to producer X, about what, and is anything pending". It only works if every run costs the caller under a minute, so this skill is incremental, needs no manual input, and never asks questions it can answer from the data.
+Keep the shared Notion log of analytics-report exchanges up to date from the caller's Gmail. The log answers one question: which producer got which report, when, and what did they say back. A round of reports is eight to ten emails plus replies, so a run should cost the caller a minute.
 
-Background on the project: the "Data producer relations" Notion page (linked from the contacts table) explains why the log exists and how it relates to the analytics reports produced by `etl/scripts/create_report_for_data_producer.py`.
+**Scope, and why it is this narrow.** The log covers the analytics reports and their replies. Nothing else: not data issues, not release announcements, not introductions or scheduling. Two reasons, both learned the hard way:
+
+- A Gmail-derived log can only ever hold the mailbox of whoever runs it. Calls, Slack, and anything a colleague handled are invisible to it, so a broader log looks like a complete history of a relationship while missing most of it, and colleagues then read "last contact January 2026" and conclude nobody has been in touch since.
+- Producer correspondence is private correspondence. Copying it wholesale into a shared table exposes exchanges the sender would not expect a team to read.
+
+**Data issues belong in Front**, the shared inbox everyone can act in, not here.
+
+Background on the project: the "Data producer relations" Notion page (linked from the contacts table) explains why the reports exist and how they are produced.
 
 ## Prerequisites
 
-- The **Gmail** and **Notion** claude.ai connectors, available in the session. Load the tools with ToolSearch before calling them: `mcp__claude_ai_Gmail__search_threads`, `mcp__claude_ai_Gmail__get_thread`, `mcp__claude_ai_Notion__notion-fetch`, `mcp__claude_ai_Notion__notion-query-data-sources`, `mcp__claude_ai_Notion__notion-create-pages`, `mcp__claude_ai_Notion__notion-update-page`.
+- The **Gmail** and **Notion** claude.ai connectors, available in the session. Load the tools with ToolSearch before calling them: `mcp__claude_ai_Gmail__search_threads`, `mcp__claude_ai_Gmail__get_thread`, `mcp__claude_ai_Notion__notion-fetch`, `mcp__claude_ai_Notion__notion-query-data-sources`, `mcp__claude_ai_Notion__notion-create-pages`.
 - Two entries in the repo's `.env` (ask Pablo for the values; see `.env.example`):
   - `NOTION_DATA_PRODUCERS_CONTACTS_TABLE_URL`: the contacts table (producers, contact people, report emails).
-  - `NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL`: the interactions log.
+  - `NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL`: the reports log.
 
 Read both with `grep '^NOTION_DATA_P' .env`. If either is missing, stop and tell the user which one to add. Never hardcode the URLs, names, or email addresses in this skill or in any file committed to the repo: the repo is public.
 
@@ -34,86 +40,75 @@ Read both with `grep '^NOTION_DATA_P' .env`. If either is missing, stop and tell
 Call `notion-fetch` on each URL. From the results keep:
 
 - the contacts data source URL (`collection://...`) and, for every row: page URL, `Name`, `Contacts`, `Emails for analytics reports`;
-- the interactions data source URL and its schema. Expected properties: `Summary` (title), `Date`, `Producer` (relation to contacts), `Direction`, `Channel`, `Type`, `Link`, `Notes`, `Status`, `Owner`. If a property is missing, stop and report it rather than improvising.
+- the log's data source URL and its schema. Expected properties: `Summary` (title), `Date`, `Producer` (relation to contacts), `Direction`, `Channel`, `Type`, `Link`, `Notes`, `Status`, `Owner`. If a property is missing, stop and report it rather than improvising.
 
-Query the contacts rows with `notion-query-data-sources` in SQL mode (single data source), or rows mode if SQL is unavailable on the workspace plan.
+Query the contacts rows with `notion-query-data-sources` in SQL mode (single data source). If the workspace's SQL quota is exhausted, view mode works and is not metered.
 
 ### 1b. Identify the caller's mailbox
 
 Run `search_threads` with query `in:sent newer_than:90d`, `pageSize: 1`, and take the `sender` of the returned message as the caller's address. It is needed for the `authuser` part of every Link and to tell outgoing from incoming messages.
 
-### 2. Build the search terms per producer
+### 2. Collect the recorded addresses
 
-Two separate sets, used by the two passes below. Only the first one ever produces rows.
+For each producer, take every email address appearing in `Contacts` and `Emails for analytics reports`. Both columns are free text (`Contacts` typically reads `TO: <name> (<address>)`), so pull the addresses out with `[\w.+-]+@[\w.-]+\.\w+` rather than using the cell whole.
 
-- **Addresses (pass 1).** Every email address in `Contacts` and `Emails for analytics reports`. Both columns are free text, so extract with `[\w.+-]+@[\w.-]+\.\w+` rather than reading the cell whole; `Contacts` typically looks like `TO: <name> (<address>)\nCC: <name> (<address>)`. These are the addresses the team has recorded for the relationship, and they are the only basis for logging.
-- **Widening terms (pass 2 only).** The producer's name and its obvious short forms, plus the domain of each address above, excluding generic mail providers (`gmail.com`, `outlook.com`, `hotmail.com`, `yahoo.*`, `protonmail.com`, `icloud.com`). These exist because the person who writes is often a colleague of the recorded contact who is not in the table yet. They surface candidates for the report; they never create rows.
-
-A producer with no address at all has no pass 1, only pass 2.
+**These addresses are the only thing this skill ever searches for.** Do not search by the producer's domain, and do not search by the producer's name. A domain search returns everything the institution ever sent, most of which has nothing to do with us; a name search returns newsletters and third parties discussing the producer. Both were in an earlier version of this skill and both were wrong. If a contact writes from an unrecorded address, the reply simply will not be found, and the fix is to add that address to the contacts table, not to widen the search.
 
 ### 3. Find the watermark and the already-logged messages
 
-Query the interactions table once (SQL, single source) for `Producer`, `date:Date:start`, `Link`. Keep:
+Query the log once for `Producer`, `date:Date:start`, `Link`. Keep:
 
-- the latest date per producer **among rows that came from an email**, i.e. rows whose `Link` is set (the watermark). Never take the maximum over all rows: a `call` row is dated when the call happens, so a scheduled future call would push the watermark forward and make the next run skip every email in between;
+- the latest date per producer **among rows whose `Link` is set**, i.e. rows that came from an email (the watermark). Never take the maximum over all rows: a `call` row is dated when the call happens, so a scheduled future call would push the watermark forward and make the next run skip every email in between;
 - the set of Gmail message IDs already logged: the part after `#all/` in every `Link` (older rows may use the `/mail/u/0/#all/<messageId>` form; treat both the same).
 
-Search from **7 days before the watermark** (Gmail dates and thread grouping make a small overlap safer than an exact cutoff). For a producer with no rows yet, search without a date filter.
+Search from **7 days before the watermark** (Gmail dates and thread grouping make a small overlap safer than an exact cutoff). For a producer with no rows yet, search the last 12 months.
 
-### 4. Search Gmail
+### 4. Search Gmail, then keep only the report threads
 
-**Pass 1, the recorded addresses.** This is the only pass that produces rows. One `search_threads` per producer, `pageSize: 50`, query like:
+One `search_threads` per producer, `pageSize: 50`, addresses only:
 
 ```
 addr1 OR addr2 OR addr3 after:YYYY/MM/DD
 ```
 
-Addresses only, never `from:domain`. A whole institutional domain carries a lot of mail that has nothing to do with the data relationship, and logging by domain would copy it into a shared table. Paginate with `pageToken` until exhausted.
-
-**Pass 2, widening.** One search per producer over the widening terms, same date filter, e.g.:
-
-```
-("Aurora Energy Institute" OR AEI OR from:aurora-energy.example OR to:aurora-energy.example) after:YYYY/MM/DD
-```
-
-Everything pass 2 finds that pass 1 did not is a **candidate**: do not log it, and do not paste its body anywhere. List it in the report with sender, date and subject, and let the user decide whether it belongs in the log and whether the sender should join the contacts table. A colleague of the recorded contact writing about the data relationship is the case this is for; anything else is noise the user can ignore in one glance.
-
-If a search result is too large and gets saved to a file, filter it with `jq` on the saved file instead of re-running with a smaller page size; the tool result tells you the path.
-
-### 5. Fetch threads and split into messages
-
-For each thread with at least one message not yet logged, call `get_thread` with `messageFormat: "PLAIN_TEXT"`. If the result is saved to a file, run:
+Paginate with `pageToken` until exhausted. Then fetch each thread containing an unlogged message with `get_thread` and `messageFormat: "PLAIN_TEXT"`, and split it into messages. If the result is saved to a file, run:
 
 ```
 .venv/bin/python .claude/skills/log-producer-interactions/scripts/strip_quotes.py <saved_file>
 ```
 
-It prints one block per message (id, date, from, to, cc, subject) with quoted replies and signatures stripped. Apply the same stripping by hand to results returned inline.
+It prints one block per message (id, date, from, to, cc, subject) with quoted replies, gateway banners and signatures stripped. Apply the same stripping by hand to results returned inline.
 
-Skip automated messages: calendar and Calendly notices, Zoom or Meet invites, Drive share requests, GitHub, Google Docs comments, Notion notifications, newsletters, auto-replies, Slack digests. A Drive share request from a producer contact is worth a mention in the Notes of the related "report sent" row, not a row of its own.
+**A thread is in scope only if it is about an analytics report.** In practice that means an outgoing message that shares one: the subject names the report, and the body carries the Drive link or the PDF is attached. Once a thread qualifies, every message in it is in scope, including replies that wander off topic.
 
-Skip messages whose ID is already logged. Within a thread that mixes producers and third parties (for example a producer introduced to a reader), log only the messages where the producer wrote, or where OWID wrote to the producer.
+Everything else the search returned is **out of scope**: data issues, release announcements, introductions, scheduling, advice, anything personal. Do not create rows for it and do not paste its body anywhere. Name it in one line in the report, so the user knows what the run saw and can act on it elsewhere.
+
+Skip automated messages entirely: calendar and Calendly notices, Drive share requests, GitHub, Google Docs comments, Notion notifications, newsletters, auto-replies. A Drive share request from a producer contact is worth a mention in the Notes of the related "report sent" row, not a row of its own.
+
+### 5. Propose the rows, and wait
+
+Before writing anything, show the user a table of the rows you intend to create (producer, date, direction, type, summary) and the out-of-scope messages you are leaving out. **Wait for approval.** The log is shared, so a wrong row is seen by the whole team, and one confirmation per run costs far less than removing rows afterwards.
 
 ### 6. Create one row per message
 
-Create pages with parent `{"type": "data_source_id", "data_source_id": "<interactions data source id>"}`, batched (up to ~40 per call), `allow_async: false`. Properties:
+Create pages with parent `{"type": "data_source_id", "data_source_id": "<log data source id>"}`, batched (up to ~40 per call), `allow_async: false`. Properties:
 
 | Property | Value |
 |---|---|
-| `Summary` | One line, at most 110 characters, who did what. Never the subject line verbatim. Shape to aim for, with an invented producer: "Their data lead announced the 2026 Aurora Energy Review and revised the 2025 figures". |
+| `Summary` | One line, at most 110 characters, who did what. Never the subject line verbatim. Shape to aim for, with an invented producer: "Their data lead called the 2026 report useful and asked for a mid-year one". |
 | `date:Date:start` | `YYYY-MM-DD` of the message; `date:Date:is_datetime`: the number `0` (Notion rejects the string `"0"`). |
 | `Producer` | `["<contacts page URL>"]`. |
 | `Direction` | `outgoing` if the sender is `@ourworldindata.org`, else `incoming`. For a colleague's message, add "sent by <first name>" to Notes. |
-| `Channel` | `email`. Use `call` (no Link) only when a message schedules a call whose date is clear; one extra row for the call, with a Note asking to confirm it happened. |
-| `Type` | `report sent` when OWID shares an analytics report or numbers; `release notice` when the producer announces or shares new or updated data; `data issue` for errors, inconsistencies, missing data or methodology questions in either side's data; `feedback` when the producer comments on OWID's work or on ideas OWID proposed; otherwise `other`. |
-| `Link` | `https://mail.google.com/mail/?authuser=<caller email>#all/<messageId>` (message ID, not thread ID). The `authuser` parameter opens the right Google account whatever order the caller signed in; find the caller's address once per run with `search_threads` on `in:sent newer_than:90d` (`pageSize: 1`): the `sender` of that message is the mailbox owner. Do not use `git config user.email`; it is often a personal address. |
-| `Notes` | Optional, at most 300 characters: people cc'd, attachments, commitments, whether the message got a reply. |
-| `Status` | Set **only** when the message needs follow-up: `open` (OWID owes an answer or an action), `waiting on producer` (OWID asked, no reply yet). Leave empty otherwise. Never set `closed` when creating. |
-| `Owner` | Set together with Status, to the OWID person who owes the action (user ID or URL from `notion-fetch` of the workspace users, or leave empty if unsure and say so in the report). |
+| `Channel` | `email`. |
+| `Type` | `report sent` for the message that shares a report; `feedback` for what the producer says back. Nothing else is in scope. |
+| `Link` | `https://mail.google.com/mail/?authuser=<caller email>#all/<messageId>` (message ID, not thread ID). The `authuser` parameter opens the right Google account whatever order the caller signed in. The link only resolves for the mailbox holding the message, so it is a convenience for its owner, not something a colleague can open. Do not use `git config user.email`; it is often a personal address. |
+| `Notes` | Optional, at most 300 characters: people cc'd, whether the PDF was attached, commitments, whether the message got a reply. |
+| `Status` | Set **only** when the message needs follow-up: `open` (OWID owes an answer), `waiting on producer` (OWID asked, no reply yet). Leave empty otherwise. Never set `closed` when creating. |
+| `Owner` | Set together with Status, to the OWID person who owes the action (user ID from `notion-fetch` of `self` when it is the caller, or leave empty and say so in the report). |
 
-`content`: the stripped body of that message only, as plain markdown paragraphs. Keep the sign-off line; drop signatures, legal boilerplate and everything quoted from earlier messages.
+`content`: the stripped body of that message only, as plain markdown paragraphs. Keep the sign-off line; drop signatures, legal boilerplate and everything quoted from earlier messages. A producer's verbatim words about a report are the useful part of the log, because they are what the team can quote in a funding case.
 
-Heuristics for Status: an incoming message ending in a question, or asking for something (data, permission, a report, a signature), with no later outgoing message in the thread, is `open`. An outgoing message that asks the producer something, with no later incoming message, is `waiting on producer`. Set `Owner` to the OWID sender of the last outgoing message in that thread when there is one.
+Heuristics for Status: an outgoing report email with no reply yet is `waiting on producer`. An incoming reply that asks something still unanswered is `open`. Set `Owner` to whoever sent the report.
 
 ### 7. Report
 
@@ -121,15 +116,18 @@ Reply to the user with, in this order:
 
 1. A table of the rows created: producer, date, direction, type, summary. Group by producer.
 2. Rows given a Status, with the reason, so the user can correct them.
-3. Candidates from pass 2 (people writing from addresses not in the contacts table) and any producer found only by name. Ask whether to add them to the contacts table; do not add them yourself.
-4. Producers searched with zero new messages, in one line.
+3. Out-of-scope messages the search surfaced, one line each, and any reply that came from an address not in the contacts table, which is worth adding there.
+4. Producers with no new report emails, in one line.
 
 Do not paste email bodies into the reply.
 
 ## Guardrails
 
+- Search only the addresses recorded in the contacts table. Never by domain, never by producer name.
+- Log only analytics-report threads. Anything else gets a line in the report, never a row.
+- Never write a row without showing it to the user first.
 - Never edit or delete existing rows except to fill an empty `Link` or empty page body of a row that clearly matches a message (same producer, same date, same direction); say so in the report.
-- Never add rows to the contacts table.
+- Never add rows to the contacts table, and never edit it.
 - Never write producer names, contact names or email addresses into files in this repo. Examples in this file use invented institutions on purpose.
-- Log only what concerns the data relationship. A message that is personal, sensitive, or unrelated to the producer's data does not belong in a shared log, even when it comes from a recorded address: name it in the report and let the user decide, rather than creating a row. The same goes for anything a reasonable sender would not expect the whole team to read.
+- Nothing personal or sensitive belongs in a shared log, whatever address it came from.
 - Each run covers the caller's mailbox only. Rows for messages the caller received in cc are fine; rows for messages the caller cannot see are not this skill's job.

--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -40,7 +40,7 @@ Read both with `grep '^NOTION_DATA_P' .env`. If either is missing, stop and tell
 Call `notion-fetch` on each URL. From the results keep:
 
 - the contacts data source URL (`collection://...`) and, for every row: page URL, `Name`, `Contacts`, `Emails for analytics reports`;
-- the log's data source URL and its schema. Expected properties: `Summary` (title), `Date`, `Producer` (relation to contacts), `Direction`, `Channel`, `Type`, `Link`, `Notes`, `Status`, `Owner`. If a property is missing, stop and report it rather than improvising.
+- the log's data source URL and its schema. Expected properties: `Summary` (title), `Date`, `Producer` (relation to contacts), `Direction`, `Type`, `Link`, `Notes`, `Status`, `Owner`. There is deliberately no channel property: every row comes from an email. If a property is missing, stop and report it rather than improvising.
 
 Query the contacts rows with `notion-query-data-sources` in SQL mode (single data source). If the workspace's SQL quota is exhausted, view mode works and is not metered.
 
@@ -58,7 +58,7 @@ For each producer, take every email address appearing in `Contacts` and `Emails 
 
 Query the log once for `Producer`, `date:Date:start`, `Link`. Keep:
 
-- the latest date per producer **among rows whose `Link` is set**, i.e. rows that came from an email (the watermark). Never take the maximum over all rows: a `call` row is dated when the call happens, so a scheduled future call would push the watermark forward and make the next run skip every email in between;
+- the latest date per producer **among rows whose `Link` is set**, i.e. rows that came from an email (the watermark). Never take the maximum over all rows: a hand-added row (a call, a Slack thread) carries no Gmail link, and if it is dated in the future it would push the watermark forward and make the next run skip every email in between;
 - the set of Gmail message IDs already logged: the part after `#all/` in every `Link` (older rows may use the `/mail/u/0/#all/<messageId>` form; treat both the same).
 
 Search from **7 days before the watermark** (Gmail dates and thread grouping make a small overlap safer than an exact cutoff). For a producer with no rows yet, search the last 12 months.
@@ -99,8 +99,7 @@ Create pages with parent `{"type": "data_source_id", "data_source_id": "<log dat
 | `date:Date:start` | `YYYY-MM-DD` of the message; `date:Date:is_datetime`: the number `0` (Notion rejects the string `"0"`). |
 | `Producer` | `["<contacts page URL>"]`. |
 | `Direction` | `outgoing` if the sender is `@ourworldindata.org`, else `incoming`. For a colleague's message, add "sent by <first name>" to Notes. |
-| `Channel` | `email`. |
-| `Type` | `report sent` for the message that shares a report; `feedback` for what the producer says back. Nothing else is in scope. |
+| `Type` | `report sent` for the message that shares a report; `feedback` for what the producer says back. Those are the only two options the property has, because nothing else is in scope. |
 | `Link` | `https://mail.google.com/mail/?authuser=<caller email>#all/<messageId>` (message ID, not thread ID). The `authuser` parameter opens the right Google account whatever order the caller signed in. The link only resolves for the mailbox holding the message, so it is a convenience for its owner, not something a colleague can open. Do not use `git config user.email`; it is often a personal address. |
 | `Notes` | Optional, at most 300 characters: people cc'd, whether the PDF was attached, commitments, whether the message got a reply. |
 | `Status` | Set **only** when the message needs follow-up: `open` (OWID owes an answer), `waiting on producer` (OWID asked, no reply yet). Leave empty otherwise. Never set `closed` when creating. |

--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -44,7 +44,12 @@ Run `search_threads` with query `in:sent newer_than:90d`, `pageSize: 1`, and tak
 
 ### 2. Build the search terms per producer
 
-From `Contacts` and `Emails for analytics reports`, extract every email address (regex `[\w.+-]+@[\w.-]+\.\w+`). For each address also take its domain, except generic mail providers (`gmail.com`, `outlook.com`, `hotmail.com`, `yahoo.*`, `protonmail.com`, `icloud.com`). Producers with no address at all are searched by name only (pass 2 below).
+Two separate sets, used by the two passes below. Only the first one ever produces rows.
+
+- **Addresses (pass 1).** Every email address in `Contacts` and `Emails for analytics reports`. Both columns are free text, so extract with `[\w.+-]+@[\w.-]+\.\w+` rather than reading the cell whole; `Contacts` typically looks like `TO: <name> (<address>)\nCC: <name> (<address>)`. These are the addresses the team has recorded for the relationship, and they are the only basis for logging.
+- **Widening terms (pass 2 only).** The producer's name and its obvious short forms, plus the domain of each address above, excluding generic mail providers (`gmail.com`, `outlook.com`, `hotmail.com`, `yahoo.*`, `protonmail.com`, `icloud.com`). These exist because the person who writes is often a colleague of the recorded contact who is not in the table yet. They surface candidates for the report; they never create rows.
+
+A producer with no address at all has no pass 1, only pass 2.
 
 ### 3. Find the watermark and the already-logged messages
 
@@ -57,15 +62,21 @@ Search from **7 days before the watermark** (Gmail dates and thread grouping mak
 
 ### 4. Search Gmail
 
-**Pass 1, exact.** One `search_threads` per producer, `pageSize: 50`, query like:
+**Pass 1, the recorded addresses.** This is the only pass that produces rows. One `search_threads` per producer, `pageSize: 50`, query like:
 
 ```
-addr1 OR addr2 OR from:domain OR to:domain OR cc:domain after:YYYY/MM/DD
+addr1 OR addr2 OR addr3 after:YYYY/MM/DD
 ```
 
-Paginate with `pageToken` until exhausted.
+Addresses only, never `from:domain`. A whole institutional domain carries a lot of mail that has nothing to do with the data relationship, and logging by domain would copy it into a shared table. Paginate with `pageToken` until exhausted.
 
-**Pass 2, broad.** One search per producer on the producer's name (and obvious short forms, e.g. `UCDP OR "Uppsala Conflict Data Program"`) with the same date filter. Anything from pass 2 whose sender or recipients are not in pass 1's address set is a **candidate**: do not log it, list it in the report with sender, date and subject, and let the user decide.
+**Pass 2, widening.** One search per producer over the widening terms, same date filter, e.g.:
+
+```
+("Aurora Energy Institute" OR AEI OR from:aurora-energy.example OR to:aurora-energy.example) after:YYYY/MM/DD
+```
+
+Everything pass 2 finds that pass 1 did not is a **candidate**: do not log it, and do not paste its body anywhere. List it in the report with sender, date and subject, and let the user decide whether it belongs in the log and whether the sender should join the contacts table. A colleague of the recorded contact writing about the data relationship is the case this is for; anything else is noise the user can ignore in one glance.
 
 If a search result is too large and gets saved to a file, filter it with `jq` on the saved file instead of re-running with a smaller page size; the tool result tells you the path.
 
@@ -89,8 +100,8 @@ Create pages with parent `{"type": "data_source_id", "data_source_id": "<interac
 
 | Property | Value |
 |---|---|
-| `Summary` | One line, at most 110 characters, who did what. Never the subject line verbatim. Good: "Nic announced Global Electricity Review 2025 and updated 2024 data". |
-| `date:Date:start` | `YYYY-MM-DD` of the message; `date:Date:is_datetime`: `0`. |
+| `Summary` | One line, at most 110 characters, who did what. Never the subject line verbatim. Shape to aim for, with an invented producer: "Their data lead announced the 2026 Aurora Energy Review and revised the 2025 figures". |
+| `date:Date:start` | `YYYY-MM-DD` of the message; `date:Date:is_datetime`: the number `0` (Notion rejects the string `"0"`). |
 | `Producer` | `["<contacts page URL>"]`. |
 | `Direction` | `outgoing` if the sender is `@ourworldindata.org`, else `incoming`. For a colleague's message, add "sent by <first name>" to Notes. |
 | `Channel` | `email`. Use `call` (no Link) only when a message schedules a call whose date is clear; one extra row for the call, with a Note asking to confirm it happened. |
@@ -119,5 +130,6 @@ Do not paste email bodies into the reply.
 
 - Never edit or delete existing rows except to fill an empty `Link` or empty page body of a row that clearly matches a message (same producer, same date, same direction); say so in the report.
 - Never add rows to the contacts table.
-- Never write producer names, contact names or email addresses into files in this repo.
+- Never write producer names, contact names or email addresses into files in this repo. Examples in this file use invented institutions on purpose.
+- Log only what concerns the data relationship. A message that is personal, sensitive, or unrelated to the producer's data does not belong in a shared log, even when it comes from a recorded address: name it in the report and let the user decide, rather than creating a row. The same goes for anything a reasonable sender would not expect the whole team to read.
 - Each run covers the caller's mailbox only. Rows for messages the caller received in cc are fine; rows for messages the caller cannot see are not this skill's job.

--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: log-producer-interactions
+description: >-
+  Sync the current user's Gmail exchanges with OWID's data producers into the shared Notion
+  "Data Producer Interactions" log, one row per email, incrementally and without duplicates.
+  Use when the user says "log my producer emails", "update the interactions log", "sync producer
+  interactions", after sending analytics reports, or when someone asks what is pending with a
+  data producer. Also flags emails from producers that are not yet in the contacts table, and
+  emails that look like open questions or promises, so the team can track them with Status and
+  Owner. Runs against the caller's own mailbox only.
+metadata:
+  internal: true
+---
+
+# Log data producer interactions
+
+Keep the shared Notion log of exchanges with data producers up to date from the caller's Gmail. The log is the team's single place to answer "when did we last talk to producer X, about what, and is anything pending". It only works if every run costs the caller under a minute, so this skill is incremental, needs no manual input, and never asks questions it can answer from the data.
+
+Background on the project: the "Data producer relations" Notion page (linked from the contacts table) explains why the log exists and how it relates to the analytics reports produced by `etl/scripts/create_report_for_data_producer.py`.
+
+## Prerequisites
+
+- The **Gmail** and **Notion** claude.ai connectors, available in the session. Load the tools with ToolSearch before calling them: `mcp__claude_ai_Gmail__search_threads`, `mcp__claude_ai_Gmail__get_thread`, `mcp__claude_ai_Notion__notion-fetch`, `mcp__claude_ai_Notion__notion-query-data-sources`, `mcp__claude_ai_Notion__notion-create-pages`, `mcp__claude_ai_Notion__notion-update-page`.
+- Two entries in the repo's `.env` (ask Pablo for the values; see `.env.example`):
+  - `NOTION_DATA_PRODUCERS_CONTACTS_TABLE_URL`: the contacts table (producers, contact people, report emails).
+  - `NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL`: the interactions log.
+
+Read both with `grep '^NOTION_DATA_P' .env`. If either is missing, stop and tell the user which one to add. Never hardcode the URLs, names, or email addresses in this skill or in any file committed to the repo: the repo is public.
+
+## Procedure
+
+### 1. Load the two tables
+
+Call `notion-fetch` on each URL. From the results keep:
+
+- the contacts data source URL (`collection://...`) and, for every row: page URL, `Name`, `Contacts`, `Emails for analytics reports`;
+- the interactions data source URL and its schema. Expected properties: `Summary` (title), `Date`, `Producer` (relation to contacts), `Direction`, `Channel`, `Type`, `Link`, `Notes`, `Status`, `Owner`. If a property is missing, stop and report it rather than improvising.
+
+Query the contacts rows with `notion-query-data-sources` in SQL mode (single data source), or rows mode if SQL is unavailable on the workspace plan.
+
+### 1b. Identify the caller's mailbox
+
+Run `search_threads` with query `in:sent newer_than:90d`, `pageSize: 1`, and take the `sender` of the returned message as the caller's address. It is needed for the `authuser` part of every Link and to tell outgoing from incoming messages.
+
+### 2. Build the search terms per producer
+
+From `Contacts` and `Emails for analytics reports`, extract every email address (regex `[\w.+-]+@[\w.-]+\.\w+`). For each address also take its domain, except generic mail providers (`gmail.com`, `outlook.com`, `hotmail.com`, `yahoo.*`, `protonmail.com`, `icloud.com`). Producers with no address at all are searched by name only (pass 2 below).
+
+### 3. Find the watermark and the already-logged messages
+
+Query the interactions table once (SQL, single source) for `Producer`, `date:Date:start`, `Link`. Keep:
+
+- the latest date per producer (the watermark);
+- the set of Gmail message IDs already logged: the part after `#all/` in every `Link` (older rows may use the `/mail/u/0/#all/<messageId>` form; treat both the same).
+
+Search from **7 days before the watermark** (Gmail dates and thread grouping make a small overlap safer than an exact cutoff). For a producer with no rows yet, search without a date filter.
+
+### 4. Search Gmail
+
+**Pass 1, exact.** One `search_threads` per producer, `pageSize: 50`, query like:
+
+```
+addr1 OR addr2 OR from:domain OR to:domain OR cc:domain after:YYYY/MM/DD
+```
+
+Paginate with `pageToken` until exhausted.
+
+**Pass 2, broad.** One search per producer on the producer's name (and obvious short forms, e.g. `UCDP OR "Uppsala Conflict Data Program"`) with the same date filter. Anything from pass 2 whose sender or recipients are not in pass 1's address set is a **candidate**: do not log it, list it in the report with sender, date and subject, and let the user decide.
+
+If a search result is too large and gets saved to a file, filter it with `jq` on the saved file instead of re-running with a smaller page size; the tool result tells you the path.
+
+### 5. Fetch threads and split into messages
+
+For each thread with at least one message not yet logged, call `get_thread` with `messageFormat: "PLAIN_TEXT"`. If the result is saved to a file, run:
+
+```
+python3 .claude/skills/log-producer-interactions/scripts/strip_quotes.py <saved_file>
+```
+
+It prints one block per message (id, date, from, to, cc, subject) with quoted replies and signatures stripped. Apply the same stripping by hand to results returned inline.
+
+Skip automated messages: calendar and Calendly notices, Zoom or Meet invites, Drive share requests, GitHub, Google Docs comments, Notion notifications, newsletters, auto-replies, Slack digests. A Drive share request from a producer contact is worth a mention in the Notes of the related "report sent" row, not a row of its own.
+
+Skip messages whose ID is already logged. Within a thread that mixes producers and third parties (for example a producer introduced to a reader), log only the messages where the producer wrote, or where OWID wrote to the producer.
+
+### 6. Create one row per message
+
+Create pages with parent `{"type": "data_source_id", "data_source_id": "<interactions data source id>"}`, batched (up to ~40 per call), `allow_async: false`. Properties:
+
+| Property | Value |
+|---|---|
+| `Summary` | One line, at most 110 characters, who did what. Never the subject line verbatim. Good: "Nic announced Global Electricity Review 2025 and updated 2024 data". |
+| `date:Date:start` | `YYYY-MM-DD` of the message; `date:Date:is_datetime`: `0`. |
+| `Producer` | `["<contacts page URL>"]`. |
+| `Direction` | `outgoing` if the sender is `@ourworldindata.org`, else `incoming`. For a colleague's message, add "sent by <first name>" to Notes. |
+| `Channel` | `email`. Use `call` (no Link) only when a message schedules a call whose date is clear; one extra row for the call, with a Note asking to confirm it happened. |
+| `Type` | `report sent` when OWID shares an analytics report or numbers; `release notice` when the producer announces or shares new or updated data; `data issue` for errors, inconsistencies, missing data or methodology questions in either side's data; `feedback` when the producer comments on OWID's work or on ideas OWID proposed; otherwise `other`. |
+| `Link` | `https://mail.google.com/mail/?authuser=<caller email>#all/<messageId>` (message ID, not thread ID). The `authuser` parameter opens the right Google account whatever order the caller signed in; find the caller's address once per run with `search_threads` on `in:sent newer_than:90d` (`pageSize: 1`): the `sender` of that message is the mailbox owner. Do not use `git config user.email`; it is often a personal address. |
+| `Notes` | Optional, at most 300 characters: people cc'd, attachments, commitments, whether the message got a reply. |
+| `Status` | Set **only** when the message needs follow-up: `open` (OWID owes an answer or an action), `waiting on producer` (OWID asked, no reply yet). Leave empty otherwise. Never set `closed` when creating. |
+| `Owner` | Set together with Status, to the OWID person who owes the action (user ID or URL from `notion-fetch` of the workspace users, or leave empty if unsure and say so in the report). |
+
+`content`: the stripped body of that message only, as plain markdown paragraphs. Keep the sign-off line; drop signatures, legal boilerplate and everything quoted from earlier messages.
+
+Heuristics for Status: an incoming message ending in a question, or asking for something (data, permission, a report, a signature), with no later outgoing message in the thread, is `open`. An outgoing message that asks the producer something, with no later incoming message, is `waiting on producer`. Set `Owner` to the OWID sender of the last outgoing message in that thread when there is one.
+
+### 7. Report
+
+Reply to the user with, in this order:
+
+1. A table of the rows created: producer, date, direction, type, summary. Group by producer.
+2. Rows given a Status, with the reason, so the user can correct them.
+3. Candidates from pass 2 (people writing from addresses not in the contacts table) and any producer found only by name. Ask whether to add them to the contacts table; do not add them yourself.
+4. Producers searched with zero new messages, in one line.
+
+Do not paste email bodies into the reply.
+
+## Guardrails
+
+- Never edit or delete existing rows except to fill an empty `Link` or empty page body of a row that clearly matches a message (same producer, same date, same direction); say so in the report.
+- Never add rows to the contacts table.
+- Never write producer names, contact names or email addresses into files in this repo.
+- Each run covers the caller's mailbox only. Rows for messages the caller received in cc are fine; rows for messages the caller cannot see are not this skill's job.

--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -55,7 +55,7 @@ A producer with no address at all has no pass 1, only pass 2.
 
 Query the interactions table once (SQL, single source) for `Producer`, `date:Date:start`, `Link`. Keep:
 
-- the latest date per producer (the watermark);
+- the latest date per producer **among rows that came from an email**, i.e. rows whose `Link` is set (the watermark). Never take the maximum over all rows: a `call` row is dated when the call happens, so a scheduled future call would push the watermark forward and make the next run skip every email in between;
 - the set of Gmail message IDs already logged: the part after `#all/` in every `Link` (older rows may use the `/mail/u/0/#all/<messageId>` form; treat both the same).
 
 Search from **7 days before the watermark** (Gmail dates and thread grouping make a small overlap safer than an exact cutoff). For a producer with no rows yet, search without a date filter.
@@ -85,7 +85,7 @@ If a search result is too large and gets saved to a file, filter it with `jq` on
 For each thread with at least one message not yet logged, call `get_thread` with `messageFormat: "PLAIN_TEXT"`. If the result is saved to a file, run:
 
 ```
-python3 .claude/skills/log-producer-interactions/scripts/strip_quotes.py <saved_file>
+.venv/bin/python .claude/skills/log-producer-interactions/scripts/strip_quotes.py <saved_file>
 ```
 
 It prints one block per message (id, date, from, to, cc, subject) with quoted replies and signatures stripped. Apply the same stripping by hand to results returned inline.

--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -99,7 +99,7 @@ Create pages with parent `{"type": "data_source_id", "data_source_id": "<log dat
 | `date:Date:start` | `YYYY-MM-DD` of the message; `date:Date:is_datetime`: the number `0` (Notion rejects the string `"0"`). |
 | `Producer` | `["<contacts page URL>"]`. |
 | `Direction` | `outgoing` if the sender is `@ourworldindata.org`, else `incoming`. For a colleague's message, add "sent by <first name>" to Notes. |
-| `Type` | `report sent` for the message that shares a report; `feedback` for what the producer says back. Those are the only two options the property has, because nothing else is in scope. |
+| `Type` | `report sent` for the message that shares a report; `feedback` for what the producer says back; `other` for the rest of a report thread, such as our answer to a producer's question, or a message arranging who should receive the file. |
 | `Link` | `https://mail.google.com/mail/?authuser=<caller email>#all/<messageId>` (message ID, not thread ID). The `authuser` parameter opens the right Google account whatever order the caller signed in. The link only resolves for the mailbox holding the message, so it is a convenience for its owner, not something a colleague can open. Do not use `git config user.email`; it is often a personal address. |
 | `Notes` | Optional, at most 300 characters: people cc'd, whether the PDF was attached, commitments, whether the message got a reply. |
 | `Status` | Who owes the next action: `waiting on OWID`, `waiting on producer`, or `closed` when the exchange needs nothing further. Every row carries one, so the table answers "what is still pending" by itself. |
@@ -108,6 +108,8 @@ Create pages with parent `{"type": "data_source_id", "data_source_id": "<log dat
 `content`: the stripped body of that message only, as plain markdown paragraphs. Keep the sign-off line; drop signatures, legal boilerplate and everything quoted from earlier messages. A producer's verbatim words about a report are the useful part of the log, because they are what the team can quote in a funding case.
 
 Heuristics for Status: an outgoing report email with no reply yet is `waiting on producer`. An incoming reply that asks something still unanswered is `waiting on OWID`. A reply that needs nothing further is `closed`, and so is an outgoing report once it has been answered. Set `Owner` to whoever sent the report.
+
+**A later message resolves an earlier row.** A report logged before its reply sits at `waiting on producer`; once the reply is logged, set that report row to `closed` in the same run, otherwise the log keeps claiming the producer owes an answer they already sent. The same applies in reverse: when we answer a row marked `waiting on OWID`, close it. This is the one case where the skill edits an existing row's properties, and it must be named in the report.
 
 ### 7. Report
 
@@ -125,7 +127,7 @@ Do not paste email bodies into the reply.
 - Search only the addresses recorded in the contacts table. Never by domain, never by producer name.
 - Log only analytics-report threads. Anything else gets a line in the report, never a row.
 - Never write a row without showing it to the user first.
-- Never edit or delete existing rows except to fill an empty `Link` or empty page body of a row that clearly matches a message (same producer, same date, same direction); say so in the report.
+- Never edit or delete existing rows, with two exceptions, both of which must be named in the report: filling an empty `Link` or empty page body of a row that clearly matches a message (same producer, same date, same direction), and closing a row that a newly logged message resolves. Never rewrite a `Summary`, a `Notes` or a page body that is already there.
 - Never add rows to the contacts table, and never edit it.
 - Never write producer names, contact names or email addresses into files in this repo. Examples in this file use invented institutions on purpose.
 - Nothing personal or sensitive belongs in a shared log, whatever address it came from.

--- a/.claude/skills/log-producer-interactions/SKILL.md
+++ b/.claude/skills/log-producer-interactions/SKILL.md
@@ -102,19 +102,19 @@ Create pages with parent `{"type": "data_source_id", "data_source_id": "<log dat
 | `Type` | `report sent` for the message that shares a report; `feedback` for what the producer says back. Those are the only two options the property has, because nothing else is in scope. |
 | `Link` | `https://mail.google.com/mail/?authuser=<caller email>#all/<messageId>` (message ID, not thread ID). The `authuser` parameter opens the right Google account whatever order the caller signed in. The link only resolves for the mailbox holding the message, so it is a convenience for its owner, not something a colleague can open. Do not use `git config user.email`; it is often a personal address. |
 | `Notes` | Optional, at most 300 characters: people cc'd, whether the PDF was attached, commitments, whether the message got a reply. |
-| `Status` | Set **only** when the message needs follow-up: `open` (OWID owes an answer), `waiting on producer` (OWID asked, no reply yet). Leave empty otherwise. Never set `closed` when creating. |
+| `Status` | Who owes the next action: `waiting on OWID`, `waiting on producer`, or `closed` when the exchange needs nothing further. Every row carries one, so the table answers "what is still pending" by itself. |
 | `Owner` | Set together with Status, to the OWID person who owes the action (user ID from `notion-fetch` of `self` when it is the caller, or leave empty and say so in the report). |
 
 `content`: the stripped body of that message only, as plain markdown paragraphs. Keep the sign-off line; drop signatures, legal boilerplate and everything quoted from earlier messages. A producer's verbatim words about a report are the useful part of the log, because they are what the team can quote in a funding case.
 
-Heuristics for Status: an outgoing report email with no reply yet is `waiting on producer`. An incoming reply that asks something still unanswered is `open`. Set `Owner` to whoever sent the report.
+Heuristics for Status: an outgoing report email with no reply yet is `waiting on producer`. An incoming reply that asks something still unanswered is `waiting on OWID`. A reply that needs nothing further is `closed`, and so is an outgoing report once it has been answered. Set `Owner` to whoever sent the report.
 
 ### 7. Report
 
 Reply to the user with, in this order:
 
 1. A table of the rows created: producer, date, direction, type, summary. Group by producer.
-2. Rows given a Status, with the reason, so the user can correct them.
+2. Rows not marked `closed`, with the reason, so the user can correct them.
 3. Out-of-scope messages the search surfaced, one line each, and any reply that came from an address not in the contacts table, which is worth adding there.
 4. Producers with no new report emails, in one line.
 

--- a/.claude/skills/log-producer-interactions/scripts/strip_quotes.py
+++ b/.claude/skills/log-producer-interactions/scripts/strip_quotes.py
@@ -17,6 +17,7 @@ QUOTE_START = re.compile(
     r"|-----Original Message-----"
     r"|De : |Von: |El .{5,120} escribi[oó]:|Le .{5,120} a écrit"
     r"|Den .{5,120} skrev"
+    r"|Am .{5,160} schrieb:?"
     r"|\d{1,2}/\d{1,2}/\d{2,4} .*wrote:"
     r")",
     re.I,

--- a/.claude/skills/log-producer-interactions/scripts/strip_quotes.py
+++ b/.claude/skills/log-producer-interactions/scripts/strip_quotes.py
@@ -1,6 +1,6 @@
 """Print each message of a saved Gmail get_thread JSON with quoted replies and signatures stripped.
 
-Usage: python3 strip_quotes.py <saved_get_thread_result.json>
+Usage: .venv/bin/python strip_quotes.py <saved_get_thread_result.json>
 """
 
 import json
@@ -31,7 +31,11 @@ SIGN_OFF = re.compile(
 )
 
 # Typical mobile footers and legal boilerplate that end a body when no sign-off is present.
-FOOTER = re.compile(r"^(sent from my |get outlook for |this e-?mail .*confidential|caution: |varning: )", re.I)
+FOOTER = re.compile(r"^(sent from my |get outlook for |this e-?mail .*confidential)", re.I)
+
+# Gateway banners, which mail systems prepend *above* the body: drop the line and keep reading, or a
+# banner on the first line would leave the body empty.
+BANNER = re.compile(r"^(caution[:!]|varning[:!]|\[external\]|external email|warning: external)", re.I)
 
 
 def _join_wrapped_quote_headers(body: str) -> str:
@@ -48,12 +52,14 @@ def strip(body: str) -> str:
         s = line.strip()
         if QUOTE_START.match(s) or FOOTER.match(s):
             break
+        if BANNER.match(s):
+            continue
         kept.append(line.rstrip())
     lines = "\n".join(kept).strip().splitlines()
     for i, line in enumerate(lines):
         if i > 0 and SIGN_OFF.match(line.strip()):
             tail = [line]
-            # Keep a following short name line ("Nic", "Dr. J. Smith"), drop titles, orgs and links.
+            # Keep a following short name line ("Alex", "Dr. J. Smith"), drop titles, orgs and links.
             for nxt in lines[i + 1 :]:
                 if not nxt.strip():
                     continue

--- a/.claude/skills/log-producer-interactions/scripts/strip_quotes.py
+++ b/.claude/skills/log-producer-interactions/scripts/strip_quotes.py
@@ -1,0 +1,83 @@
+"""Print each message of a saved Gmail get_thread JSON with quoted replies and signatures stripped.
+
+Usage: python3 strip_quotes.py <saved_get_thread_result.json>
+"""
+
+import json
+import re
+import sys
+
+# A line that starts the quoted part of a reply (English, French, German, Spanish, Swedish variants).
+QUOTE_START = re.compile(
+    r"^("
+    r">"
+    r"|On .{5,160} wrote:"
+    r"|.*<mailto:.*>> wrote:"
+    r"|From: "
+    r"|-----Original Message-----"
+    r"|De : |Von: |El .{5,120} escribi[oó]:|Le .{5,120} a écrit"
+    r"|Den .{5,120} skrev"
+    r"|\d{1,2}/\d{1,2}/\d{2,4} .*wrote:"
+    r")",
+    re.I,
+)
+
+# A sign-off line: the body ends here, plus at most one short name line after it.
+SIGN_OFF = re.compile(
+    r"^(--\s*$|kind regards|best wishes|best regards|warm regards|warm wishes|regards|best|cheers|"
+    r"thanks|thank you|many thanks|thanks again|all the best|sincerely|yours|take care|"
+    r"saludos|cordialement|mit freundlichen grüßen|med vänliga hälsningar)[,!. ]*$",
+    re.I,
+)
+
+# Typical mobile footers and legal boilerplate that end a body when no sign-off is present.
+FOOTER = re.compile(r"^(sent from my |get outlook for |this e-?mail .*confidential|caution: |varning: )", re.I)
+
+
+def _join_wrapped_quote_headers(body: str) -> str:
+    """Gmail wraps long headers: "On Mon, ... <a@b.c>" on one line and "wrote:" on the next. Rejoin them."""
+    return re.sub(
+        r"(\n(?:On|El|Le|Den|Am) [^\n]{5,200})\n[ \t]*(wrote:|escribi[oó]:|a écrit|skrev|schrieb)", r"\1 \2", body
+    )
+
+
+def strip(body: str) -> str:
+    body = _join_wrapped_quote_headers("\n" + body)
+    kept = []
+    for line in body.splitlines():
+        s = line.strip()
+        if QUOTE_START.match(s) or FOOTER.match(s):
+            break
+        kept.append(line.rstrip())
+    lines = "\n".join(kept).strip().splitlines()
+    for i, line in enumerate(lines):
+        if i > 0 and SIGN_OFF.match(line.strip()):
+            tail = [line]
+            # Keep a following short name line ("Nic", "Dr. J. Smith"), drop titles, orgs and links.
+            for nxt in lines[i + 1 :]:
+                if not nxt.strip():
+                    continue
+                if len(nxt.split()) <= 4 and not re.search(r"[@|]|https?://|www\.", nxt):
+                    tail.append(nxt)
+                break
+            lines = lines[:i] + tail
+            break
+    text = "\n".join(lines).strip()
+    return re.sub(r"\n{3,}", "\n\n", text)
+
+
+def main(path: str) -> None:
+    data = json.load(open(path))
+    for m in data["messages"]:
+        print("=" * 80)
+        print(
+            f"id={m['id']} date={m['date'][:10]} from={m['sender']} "
+            f"to={','.join(m.get('toRecipients', []))} cc={','.join(m.get('ccRecipients', []))}"
+        )
+        print(f"subject={m.get('subject', '')}")
+        print("-" * 80)
+        print(strip(m.get("plaintextBody", "")))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ DB_HOST=127.0.0.1
 # URL to Notion impact highlights table.
 # NOTION_IMPACT_HIGHLIGHTS_TABLE_URL=***
 # NOTION_DATA_PRODUCERS_CONTACTS_TABLE_URL=***
+# NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL=***
 
 
 # Google drive IDs for folders, docs and sheets, for the data producer reports project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Most recurring work here has a skill that runs it end to end. Reach for it **bef
 | Review a dataset-update PR | `/review-data-pr` |
 | Announce a finished update, internally | `/data-updates-comms` — the #data-updates-comms Slack form |
 | Announce a finished update, to readers | `/data-update-announcement` — the "Data update" post on ourworldindata.org/latest |
+| Log emails exchanged with a data producer in the shared Notion interactions log | `/log-producer-interactions` — incremental, from your own Gmail |
 
 One that's easy to skip and shouldn't be: `/edit-faust-metadata` owns **every** user-facing-text edit — it routes each field to the right layer (garden `.meta.yml` vs MDim yaml vs chart config on staging) and reports the blast radius on other charts before touching shared metadata.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Most recurring work here has a skill that runs it end to end. Reach for it **bef
 | Review a dataset-update PR | `/review-data-pr` |
 | Announce a finished update, internally | `/data-updates-comms` — the #data-updates-comms Slack form |
 | Announce a finished update, to readers | `/data-update-announcement` — the "Data update" post on ourworldindata.org/latest |
-| Log emails exchanged with a data producer in the shared Notion interactions log | `/log-producer-interactions` — incremental, from your own Gmail |
+| Log the analytics reports sent to data producers, and their replies, in the shared Notion log | `/log-producer-interactions` — incremental, from your own Gmail, reports only |
 
 One that's easy to skip and shouldn't be: `/edit-faust-metadata` owns **every** user-facing-text edit — it routes each field to the right layer (garden `.meta.yml` vs MDim yaml vs chart config on staging) and reports the blast radius on other charts before touching shared metadata.
 

--- a/etl/config.py
+++ b/etl/config.py
@@ -797,6 +797,7 @@ FORCE_DATASETTE = (not METABASE_API_KEY) or (not METABASE_URL)
 NOTION_API_KEY = os.environ.get("NOTION_API_KEY")
 NOTION_IMPACT_HIGHLIGHTS_TABLE_URL = os.environ.get("NOTION_IMPACT_HIGHLIGHTS_TABLE_URL")
 NOTION_DATA_PRODUCERS_CONTACTS_TABLE_URL = os.environ.get("NOTION_DATA_PRODUCERS_CONTACTS_TABLE_URL")
+NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL = os.environ.get("NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL")
 
 # Google drive IDs for folders, docs and sheets, for the data producer reports project.
 # NOTE: Here we fill all variables with "" if not found to simplify type checks (this way we ensure they are strings).


### PR DESCRIPTION
> _Written by Claude Fable 5.1 — @pabloarosado at the wheel._

Adds `/log-producer-interactions`, a skill that records the analytics reports we send to data producers, and the producers' replies, in the shared Notion log: one row per email, incremental (it starts from the latest logged date per producer), deduplicated on the Gmail message ID, with quoted replies, gateway banners and signatures stripped from the stored body.

Context: the data producer relations project sends periodic analytics reports to producers (`etl/scripts/data-producer-reports/`). The log is the shared answer to "which producer got which report, when, and what did they say back", which is otherwise spread across individual inboxes and impossible to see when the person who sent it is away.

**Scope is deliberately narrow, and the skill enforces it:**

- It searches **only the addresses recorded in the contacts table**. No domain searches, no producer-name searches. An earlier version had both, and they returned everything an institution had ever sent, most of it unrelated to us.
- It logs **only threads that share a report**. Data issues, release announcements, introductions and anything personal are named in one line in the run's report and never written to Notion. Data issues belong in Front, which the whole team can act in.
- It **shows the proposed rows and waits for approval** before creating any.
- Each run sees the caller's own mailbox only, which is also why the log cannot pretend to be a complete history of a relationship: calls, Slack, and colleagues' threads are invisible to it.

Changes:
- `.claude/skills/log-producer-interactions/SKILL.md`: the procedure (internal skill), including why the scope is what it is, so it does not drift back.
- `.claude/skills/log-producer-interactions/scripts/strip_quotes.py`: prints the messages of a saved Gmail thread with quoted text, signatures and prepended `CAUTION:`-style gateway banners removed.
- `.env.example`, `etl/config.py`: new `NOTION_DATA_PRODUCER_INTERACTIONS_TABLE_URL`.
- `CLAUDE.md`: entry in the skill index.

No producer names, contact names, email addresses or Notion URLs are in the repo; they live in Notion and in `.env`. Examples in the skill use an invented institution.

Open items:

- **Everyone who runs this needs the new `.env` entry**; without it the skill stops and says so.
- The skill has **not been run in this narrowed form**. The one real run happened under the earlier, broader design, whose rows have since been removed from the log; the first run after merge is the real test.
- The env var and the Notion database are still named "interactions" although the log is now reports-only. Renaming the variable would mean every user editing their `.env`, so it is left alone on purpose.
- Not covered here: having the report script append its own "report sent" row, which would remove the mailbox step for outgoing mail entirely, and scheduling the skill. Both need the ETL Notion integration to be granted access to the log database.
- Nobody has reviewed the skill against a second mailbox, so the "identify the caller" and watermark logic is exercised on one account only.
