### PR TITLE
📜🤖 Document that merging reruns the pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ git push
 gh pr edit <number> --body "..."
 ```
 
-**Merging reruns the pipeline.** Merging to master triggers the production ETL run, which rebuilds every step whose checksum changed and performs the `grapher://` upserts. You do **not** need to re-run steps for a change to take effect, and it isn't an open item worth reporting — editing a step's code or metadata is enough, because `etlr`'s change detection picks it up on that run. Run steps locally to *verify* output before merge, not to publish it. The exceptions still worth flagging: a `--force` case where no checksum changed (upstream data patched out-of-band), and ghost-variable remapping after a version bump.
+**Merging reruns the pipeline.** Merging to master triggers the production ETL run (a Buildkite pipeline), which rebuilds every step whose checksum changed and performs the `grapher://` upserts. You do **not** need to re-run steps for a change to take effect, and it isn't an open item worth reporting — editing a step's code or metadata is enough, because `etlr`'s change detection picks it up on that run. Run steps locally to *verify* output before merge, not to publish it. The exceptions still worth flagging: a `--force` case where no checksum changed (upstream data patched out-of-band), and ghost-variable remapping after a version bump.
 
 **Cleaning up after merge**: `etl pr-clean` lists local branches whose PR was merged or closed (it checks the GitHub PR state, so squash-merges are detected), then deletes the selected branch(es). For branches created in a worktree (`etl pr "..." --worktree`), it also removes the worktree and copies that worktree's Claude sessions back into the main repo's `~/.claude/projects/` dir so they stay resumable.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ git push
 gh pr edit <number> --body "..."
 ```
 
+**Merging reruns the pipeline.** Merging to master triggers the production ETL run, which rebuilds every step whose checksum changed and performs the `grapher://` upserts. You do **not** need to re-run steps for a change to take effect, and it isn't an open item worth reporting — editing a step's code or metadata is enough, because `etlr`'s change detection picks it up on that run. Run steps locally to *verify* output before merge, not to publish it. The exceptions still worth flagging: a `--force` case where no checksum changed (upstream data patched out-of-band), and ghost-variable remapping after a version bump.
+
 **Cleaning up after merge**: `etl pr-clean` lists local branches whose PR was merged or closed (it checks the GitHub PR state, so squash-merges are detected), then deletes the selected branch(es). For branches created in a worktree (`etl pr "..." --worktree`), it also removes the worktree and copies that worktree's Claude sessions back into the main repo's `~/.claude/projects/` dir so they stay resumable.
 
 To run the full **review → wait → fix → re-review** loop hands-off (and watch CI) in the background while you keep working, use the `pr-babysitter` skill — it spawns a background agent that triggers Codex, judges and fixes the valid findings, and loops to a cap (never merges). Fire it proactively after pushing a substantial chunk to a PR branch.


### PR DESCRIPTION
> _Written by Claude Opus 5 — @edomt at the wheel._

Adds one paragraph to `CLAUDE.md`'s Git Workflow section: merging to master triggers the production ETL run, which rebuilds every step whose checksum changed and performs the `grapher://` upserts.

## Why

This is documented nowhere in the repo — not `CLAUDE.md`, `.claude/docs/`, `.claude/rules/`, any skill, or `docs/`. `.github/workflows/buildkite.yml` only *destroys* staging on PR close; the production rebuild is a Buildkite pipeline outside this repo, so there was no trace of it here to find. The only merge-related line in `CLAUDE.md` was `etl pr-clean` deleting branches.

The cost of the gap: after a metadata-only or code change, agents report "the affected datasets are now dirty and still need their `grapher://` upserts" as leftover work, and propose coordinating re-runs across dataset owners. That's noise — it's just what merging does. It came up on #6854, where the caveat spanned eight namespaces and was entirely self-resolving.

The paragraph also keeps the two cases that *do* still need a human: a `--force` re-run where no checksum changed (upstream data patched out-of-band), and ghost-variable remapping after a version bump.

Docs only — no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)