### PR TITLE
🐛 Let snapshot errors survive a worker process, and stop the BrokenProcessPool cascade

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -12,6 +12,7 @@ import time
 import traceback
 from collections.abc import Callable, Iterator, MutableMapping
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, ThreadPoolExecutor, wait
+from concurrent.futures.process import BrokenProcessPool
 from contextlib import contextmanager
 from functools import partial
 from graphlib import TopologicalSorter
@@ -884,6 +885,16 @@ def exec_graph_parallel(
                         # on a long build you want to see it while the run is still going.
                         _report_step_failure(task, e)
 
+                        # A dead pool cannot run the steps that are left, so --continue-on-failure
+                        # has nothing to continue with: every remaining future resolves to this
+                        # same BrokenProcessPool. Worse, they resolve to the very same exception
+                        # *object*, and each `future.result()` above appends its frames to that
+                        # object's traceback — so failure N prints N copies of them. A nightly
+                        # rebuild once reported 1210 of these and wrote 5.9M lines (546MB), past
+                        # the size Buildkite will serve a log at. Stop at the first one.
+                        if isinstance(e, BrokenProcessPool):
+                            raise
+
                         if continue_on_failure:
                             failed_tasks.add(task)
                             skipped_tasks.add(
@@ -940,16 +951,30 @@ def print_failure_recap() -> None:
 
     Each was printed as it happened, but by the end of a build they are thousands of lines up the
     log — and the tail is what gets read, being what Buildkite puts in its error box.
+
+    Steps that failed the same way share one traceback here. When something upstream of the steps
+    themselves breaks — a dead worker pool, an unreachable database — every step fails with the
+    identical text, and reprinting it once per step is what turns a recap into a log nobody can
+    open. Every failed step is still named, in the `steps_failed` list at the end.
     """
     if not STEP_FAILURES:
         return
 
     import structlog
 
+    # Group by traceback, first-seen order. A dict keyed on the text does both in one pass.
+    by_failure: dict[str, list[str]] = {}
+    for step_name, failure in STEP_FAILURES:
+        by_failure.setdefault(failure, []).append(step_name)
+
     # ">>>" for the individual steps: "---"/"+++" would each open a log group of their own and
     # split the recap up, whereas these stay inside the recap's own group.
     blocks = [f"+++ {len(STEP_FAILURES)} step(s) failed"]
-    blocks += [f">>> Failed {step_name}\n{failure}" for step_name, failure in STEP_FAILURES]
+    for failure, step_names in by_failure.items():
+        header = f">>> Failed {step_names[0]}"
+        if len(step_names) > 1:
+            header += f" — and {len(step_names) - 1} more step(s) with an identical traceback"
+        blocks.append(f"{header}\n{failure}")
     print("\n".join(blocks), flush=True)
 
     # The step list at the very end is what you feed back into `etl run`.

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -37,15 +37,24 @@ log = structlog.get_logger()
 class SnapshotNotFoundException(Exception):
     """Raised when a snapshot file is not found on the remote server.
 
-    This is a plain Exception subclass (no unpicklable attributes) so it can
-    safely travel across process boundaries in ProcessPoolExecutor workers.
+    `__reduce__` is what lets this cross a process boundary, and it is not optional. An exception
+    whose `__init__` takes more arguments than it passes to `super().__init__()` cannot be
+    unpickled: the default `BaseException.__reduce__` rebuilds it as `cls(*self.args)`, and
+    `self.args` holds only the single formatted message. The parent process then raises
+    `TypeError: ... missing 1 required positional argument` inside the `ProcessPoolExecutor`
+    result reader, which kills the pool and fails every remaining step with `BrokenProcessPool`.
     """
 
     def __init__(self, uri: str, md5: str) -> None:
+        self.uri = uri
+        self.md5 = md5
         super().__init__(
             f"Snapshot file not found on the remote server: {uri} (md5: {md5}). "
             f"Have you run `etls {uri} --upload` to upload it?"
         )
+
+    def __reduce__(self):
+        return (self.__class__, (self.uri, self.md5))
 
 
 class PrivateSnapshotAccessError(Exception):
@@ -55,11 +64,13 @@ class PrivateSnapshotAccessError(Exception):
     soon as a step they asked for depends on one. Boto's own message ("Unable to locate
     credentials", or a bare 400) says nothing about which bucket, or about the way out.
 
-    Plain Exception subclass (no unpicklable attributes) so it can safely travel across process
-    boundaries in ProcessPoolExecutor workers, as `SnapshotNotFoundException` does.
+    Carries `__reduce__` so it survives the trip back from a worker process, for the reason spelled
+    out on `SnapshotNotFoundException`.
     """
 
     def __init__(self, uri: str, reason: str) -> None:
+        self.uri = uri
+        self.reason = reason
         super().__init__(
             f"No access to private snapshot {uri} ({reason}). It lives in the "
             f"{config.R2_SNAPSHOTS_PRIVATE} bucket, which needs OWID credentials: R2_ACCESS_KEY and "
@@ -67,6 +78,9 @@ class PrivateSnapshotAccessError(Exception):
             f"Without them, run `etlr <steps> --public-only` to build only the steps that need no "
             f"private data."
         )
+
+    def __reduce__(self):
+        return (self.__class__, (self.uri, self.reason))
 
 
 # R2 answers a request signed with an unusable key with 400, not the 403 that S3 would return, so

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,3 +1,4 @@
+import pickle
 import tempfile
 import zipfile
 from pathlib import Path
@@ -10,7 +11,14 @@ from owid.catalog import Origin, s3_utils
 
 from etl import config, paths
 from etl.files import checksum_file, ruamel_load
-from etl.snapshot import Snapshot, SnapshotArchive, SnapshotMeta, _parse_snapshot_path
+from etl.snapshot import (
+    PrivateSnapshotAccessError,
+    Snapshot,
+    SnapshotArchive,
+    SnapshotMeta,
+    SnapshotNotFoundException,
+    _parse_snapshot_path,
+)
 
 
 @pytest.fixture
@@ -388,3 +396,25 @@ def test_private_snapshot_says_how_to_get_access_or_skip(monkeypatch, tmp_path):
     fail_with(EndpointConnectionError(endpoint_url="https://r2.example"))
     with pytest.raises(EndpointConnectionError):
         snap._download_dvc_file("abc123")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        SnapshotNotFoundException("dummy/2020-01-01/dummy.csv", "abc123"),
+        PrivateSnapshotAccessError("dummy/2020-01-01/dummy.csv", "R2 returned 400"),
+    ],
+    ids=lambda e: type(e).__name__,
+)
+def test_snapshot_errors_survive_a_process_boundary(error):
+    """Steps run in worker processes, so these have to be able to come back from one.
+
+    An exception whose `__init__` takes more arguments than reach `self.args` cannot be rebuilt by
+    the default `BaseException.__reduce__`, and unpickling it raises TypeError inside the
+    ProcessPoolExecutor result reader instead — killing the pool and failing every step that was
+    left with BrokenProcessPool — which a nightly rebuild once spent 546MB of log reporting.
+    """
+    revived = pickle.loads(pickle.dumps(error))
+
+    assert type(revived) is type(error)
+    assert str(revived) == str(error)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The nightly full rebuild has failed since 10 Sep with a 546MB log that Buildkite itself refuses to serve. The cause is one unpicklable exception: `PrivateSnapshotAccessError` and `SnapshotNotFoundException` each take two arguments but pass a single formatted message to `super().__init__()`, so unpickling one in the parent process raises `TypeError: __init__() missing 1 required positional argument` inside the `ProcessPoolExecutor` result reader and kills the pool. Both now define `__reduce__`. The other two changes stop a dead pool from burying the error that caused it.

_Deep review on `etl/snapshot.py`, skim the rest._ The `__reduce__` fix is the one that has to be right; the `command.py` changes only affect what gets printed after a run has already failed.

## How it works

`BaseException.__reduce__` rebuilds an exception as `cls(*self.args)`. Both classes format their arguments into one string before calling `super().__init__()`, so `self.args` has one element and the two-argument constructor can't be called with it. Storing the arguments as attributes is not enough on its own — `__reduce__` has to return them, which is what these classes now do.

Reproducing the exact CI error against the shipped class, and confirming the fix:

```python
class WithoutReduce(PrivateSnapshotAccessError):
    __reduce__ = BaseException.__reduce__
pickle.loads(pickle.dumps(WithoutReduce("uri", "R2 returned 400")))
# TypeError: PrivateSnapshotAccessError.__init__() missing 1 required positional argument: 'reason'
```

The cascade is the reason this cost 546MB rather than a few hundred lines. When the pool dies, `ProcessPoolExecutor` resolves every pending future to the *same* `BrokenProcessPool` instance, and each `future.result()` in `exec_graph_parallel` appends its frames to that one object's `__traceback__`. So failure N prints N copies of them — measured at exactly `8N + 16` lines per block, 24 lines for the first and 9,688 for the 1,210th.

Two changes follow from that, both about reporting rather than execution:

- `--continue-on-failure` re-raises `BrokenProcessPool` instead of recording it. A dead pool cannot run the steps that are left, so there is nothing to continue with, and every step it would report is a victim rather than a cause.
- `print_failure_recap` groups steps whose traceback text is identical. This is the general case of the same problem — an unreachable database would do it too — and it keeps the recap readable without discarding anything: every failed step is still named in the `steps_failed` list.

I chose re-raise over filtering `BrokenProcessPool` out of the recap, because continuing past it produces thousands of misleading `+++ Failed <step>` headers during the run as well, not just at the end.

## Verified

- New parametrised test pickles both exception types and asserts the class and message survive; it fails against the shipped classes with the CI's own `TypeError`.
- Ran the recap against 1,210 identical failures plus one distinct: 8 lines out, with the odd one out visible instead of buried.
- Ran the dummy step chain through the parallel runner (`etl run 'dummy/2020-01-01/dummy$' --workers=4 --continue-on-failure`) — unaffected.
- **Not verified:** the actual private-snapshot failure. Nothing here reaches R2, and no test exercises a real worker-pool death.

## Still open — why the private snapshot was unreachable

This PR makes the error legible; it does not explain it. The failing step is `snapshot-private://emissions/2021/ghg_emissions_from_food_by_life_cycle_stage__crippa_et_al__2021.feather`, and **its actual message was destroyed by this bug**, so we still don't know whether the build agent lacks R2 credentials or something else got classified as a credentials failure. Worth knowing: `_R2_ACCESS_ERROR_CODES` treats a bare `400` as one, deliberately, because R2 answers an unusable key with 400 rather than 403.

Two things about the nightly point the same way. It ran **zero** `snapshot-private://` steps in its last passing build — despite the pipeline being named "full private rebuild", the ops command never passed `--private`, so private steps were never selected. They started running when private became the default, and the first one attempted tripped this. Whoever picks that up should decide whether that agent is meant to have private access at all.

Nobody has checked whether other exception classes raised inside steps have the same arity problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
