### PR TITLE
🎉 Make viz://bespoke steps environment-aware, with a generic upload and derived metadata

### DIFF
--- a/dag/faostat.yml
+++ b/dag/faostat.yml
@@ -222,8 +222,8 @@ steps:
   # garden step; the dropdown definition lives next to it in food_trade.items.yaml.
   data://garden/faostat/2026-05-07/food_trade:
     - data://garden/faostat/2026-05-07/faostat_tm
-  # S3 export step: load the garden table and write a metadata JSON plus one JSON per product
-  # under s3://owid-public/data/food-trade/, for the bespoke viz to fetch.
+  # Bespoke feed: load the garden table and write a metadata JSON plus one JSON per product,
+  # synced to the environment's v1/bespoke path for the bespoke viz to fetch.
   viz://bespoke/faostat/latest/food_trade:
     - data://garden/faostat/2026-05-07/food_trade
   ######################################################################################################################

--- a/dag/migration.yml
+++ b/dag/migration.yml
@@ -117,7 +117,7 @@ steps:
   viz://chart/migration/latest/us_foreign_born_annual_change_by_decade:
     - data://grapher/migration/2026-07-22/us_foreign_born_population
 
-  # UN DESA migration flows S3 JSON export (2024)
+  # UN DESA migration flows JSON feed (2024)
   viz://bespoke/un_migration/latest/migration_stock_flows_json:
     - data://garden/demography/2024-07-15/population
     - data://garden/un/2025-03-18/migration_stock_flows

--- a/docs/architecture/design/uri.md
+++ b/docs/architecture/design/uri.md
@@ -75,7 +75,7 @@ where channel is one of the following:
 - `chart`: For charts and multidimensional indicators (a chart is an MDIM with no dimensions). Writes to the grapher DB with `--grapher`; without it, only the local config under `viz/chart/`.
 - `explorer`: For explorers. Writes to the grapher DB with `--grapher`; without it, only the local config under `viz/explorer/`.
 - `static`: For static images (PNG/SVG), written next to the recipe. They only write local files, so a named static step runs with or without `--grapher`.
-- `bespoke`: For the data feeds of bespoke interactive visualizations. Uploaded to R2 with `--grapher`; without it, only written locally.
+- `bespoke`: For the data feeds of bespoke interactive visualizations. Synced to the environment's R2 path with `--grapher`; without it, only written locally.
 
 Every `viz://` step is selected by a pattern only with `--grapher`; named by its URI it is always selected, and the flag decides whether it may write.
 

--- a/docs/architecture/workflow/index.md
+++ b/docs/architecture/workflow/index.md
@@ -248,7 +248,7 @@ A step's type says what it produces. Viz steps produce visualizations, and their
 - **Charts and multi-dimensional indicators** (`viz://chart/`): Create the configuration of a chart or an MDIM and upsert it to the grapher DB.
 - **Explorers** (`viz://explorer/`): Create a data explorer and upsert it to the grapher DB.
 - **Static images** (`viz://static/`): Render a PNG/SVG with matplotlib next to the recipe.
-- **Bespoke visualizations** (`viz://bespoke/`): Produce the data feed of a bespoke interactive visualization (currently uploaded to R2).
+- **Bespoke visualizations** (`viz://bespoke/`): Produce the data feed of a bespoke interactive visualization. The step writes JSON files into its output folder and the framework syncs them to R2, under the path of the environment being built.
 
 Viz steps publish with `--grapher`. Named by their URI they also run without it, in which case they only build locally (the chart config, the data feed) and skip the DB upsert or upload; a pattern such as `energy` selects them only with the flag.
 

--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -13,7 +13,7 @@ The channel of a viz step says what it produces:
 - `viz://chart/`: a chart or an MDIM (a chart is just an MDIM with no dimensions), upserted to the grapher DB. A chart step can be a bare `<name>.config.yml` with no Python file.
 - `viz://explorer/`: an explorer, upserted to the grapher DB.
 - `viz://static/`: a static image (PNG/SVG) rendered with matplotlib next to the recipe and committed.
-- `viz://bespoke/`: the data feed of a bespoke interactive visualization, uploaded to R2.
+- `viz://bespoke/`: the data feed of a bespoke interactive visualization. The step only writes JSON files into `viz/bespoke/<ns>/<version>/<name>/`; the framework syncs that folder to R2, see [Bespoke feeds](#bespoke-feeds).
 
 Chart and explorer steps also write their expanded config to the gitignored `viz/<channel>/...` folder, like `data/` for data steps.
 
@@ -118,6 +118,41 @@ etlr viz://chart/energy/latest/energy_prices --grapher
 
 and check out the preview at: http://staging-site-my-branch/admin/grapher/mdd-energy-prices
 
+
+## Bespoke feeds
+
+A `viz://bespoke/` step produces the JSON feed that one of owid-grapher's `bespoke/projects/` bundles
+fetches in the browser. The step writes files into its own output folder and nothing else; after it
+runs, the framework syncs that folder to
+
+| Environment | Feed location |
+| --- | --- |
+| production | `s3://owid-api/v1/bespoke/<ns>/<version>/<name>/`, served at `https://api.ourworldindata.org/v1/bespoke/...` |
+| staging server, laptop | `s3://owid-api-staging/<env>/v1/bespoke/<ns>/<version>/<name>/`, served at `https://api-staging.owid.io/<env>/v1/bespoke/...` |
+
+the same split that already applies to the baked indicator JSONs (`DATA_API_URL` in `etl/config.py`)
+and to MDIM download packages. So a staging server builds its own copy of a feed a branch changes,
+and an article preview shows the change before it is merged. Nothing seeds a new staging
+environment: the `owid-api-staging` worker falls back to the production bucket for any file the
+environment doesn't have, so a staging server that never ran the step serves production's feed.
+
+Files that the run no longer produces are deleted from the feed, so a dropped entity doesn't linger.
+Without `--grapher` the step writes its files and skips the sync.
+
+`etl.viz.bespoke.build_feed_metadata()` derives the feed's provenance — the source line, citations,
+last and next update — from the garden columns the feed is built on, in the shape the MDIM download
+packages publish, so it doesn't have to be typed into the step and go stale at the next data update:
+
+```python
+from etl.viz.bespoke import build_feed_metadata, write_feed_metadata
+
+feed_metadata = build_feed_metadata(
+    title="Causes of death",
+    columns={"deaths": tb["value"]},
+    update_period_days=ds_garden.metadata.update_period_days,
+)
+write_feed_metadata(paths.output_dir, feed_metadata)
+```
 
 ## Exporting data to GitHub
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -340,6 +340,19 @@ class PathFinder:
         return self.f.stem
 
     @property
+    def output_dir(self) -> Path:
+        """Folder a `viz://` or `export://` step writes its files to.
+
+        It is the folder the framework then publishes: for a `viz://bespoke` step, everything
+        written here is synced to the environment's R2 feed path (see `etl.viz.bespoke`).
+        """
+        assert self.step_type in ("viz", "export"), (
+            f"Only viz:// and export:// steps have an output folder, not {self.step_type}://"
+        )
+        root = paths.VIZ_DIR if self.step_type == "viz" else paths.EXPORT_DIR
+        return root / self.channel / self.namespace / self.version / self.short_name
+
+    @property
     def country_mapping_path(self) -> Path:
         return self.directory / (self.short_name + ".countries.json")
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -1226,6 +1226,8 @@ class ExportStep(DataStep):
             )
             return
 
+        self._publish()
+
         # save checksum (only update index.json, don't call ds.save() which iterates
         # table_names and would pick up custom JSON files written by the step)
         ds.metadata.source_checksum = self.checksum_input()
@@ -1239,6 +1241,14 @@ class ExportStep(DataStep):
         """Whether this run may write to the step's destination. Off, the recipe still runs (the steps
         check the same `config` switch before uploading), but nothing leaves the machine."""
         return config.EXPORT_ENABLED
+
+    def _publish(self) -> None:
+        """Ship what the recipe wrote, for step types whose destination the framework owns.
+
+        A no-op for `export://` steps: they write to destinations of their own choosing (a GitHub
+        repo, a public R2 path) from inside the recipe, which is why they exist as a separate step
+        type at all.
+        """
 
     def _run_recipe(self) -> None:
         if config.DEBUG:
@@ -1272,8 +1282,8 @@ class VizStep(ExportStep):
     step runs under `--grapher`, which grants the write (`config.GRAPHER_ENABLED`); named without it,
     the step builds its output locally (the chart config under `viz/`, the bespoke feed) and skips
     the upsert or upload, see `etl.command.construct_subdag`. Static steps only write local files,
-    so they publish regardless. Bespoke steps currently upload to a fixed public path rather than
-    to the environment being built.
+    so they publish regardless. A bespoke step's own upload is the framework's job (`_publish`), so
+    its feed lands in the R2 path of the environment being built, like every other output.
     """
 
     step_type = "viz"
@@ -1282,6 +1292,20 @@ class VizStep(ExportStep):
     @property
     def publishes(self) -> bool:
         return config.GRAPHER_ENABLED or self.channel == "static"
+
+    def _publish(self) -> None:
+        """Sync a bespoke feed to the environment's R2 path.
+
+        Chart and explorer steps publish from inside their recipe (`chart.save()` upserts to the
+        grapher DB) and static steps only ever write local files. A bespoke step just writes JSON
+        into its output folder, and the framework ships it -- see `etl.viz.bespoke`.
+        """
+        if self.channel != "bespoke":
+            return
+
+        from etl.viz.bespoke import sync_feed
+
+        sync_feed(self.path, self._dest_dir)
 
     def can_execute(self, archive_ok: bool = True) -> bool:
         return super().can_execute(archive_ok=archive_ok) or self._is_chart_yaml_only()

--- a/etl/steps/viz/bespoke/faostat/latest/food_trade.py
+++ b/etl/steps/viz/bespoke/faostat/latest/food_trade.py
@@ -1,4 +1,4 @@
-"""Bespoke viz step producing the S3 JSON feed for the FAOSTAT food-trade Sankey viz.
+"""Bespoke viz step producing the JSON feed for the FAOSTAT food-trade Sankey viz.
 
 Loads the `food_trade` garden table and writes two kinds of files:
 
@@ -14,30 +14,28 @@ the viz: pick a product, fetch one JSON, render. The metadata's
 `productsByEntity` map lets the viz pre-compute "what can this country be
 the exporter / importer of?" without loading every product file.
 
-Output URLs:
-    https://owid-public.owid.io/data/food-trade/food-trade.metadata.json
-    https://owid-public.owid.io/data/food-trade/food-trade.<product_id>.json
+It also writes `metadata.json`, the feed's provenance derived from the garden columns (see
+`etl.viz.bespoke`).
 
+The files go to the step's output folder; the framework syncs that folder to the R2 path of the
+environment being built, so the feed is served at
+`<root>/v1/bespoke/faostat/latest/food_trade/food-trade.metadata.json` and
+`.../food-trade.<product_id>.json` -- `api.ourworldindata.org` on production, and
+`api-staging.owid.io/<env>` on a staging server or a laptop.
 """
 
 import json
-from pathlib import Path
 
 import pandas as pd
-from owid.catalog import s3_utils
 from structlog import get_logger
 from tqdm.auto import tqdm
 
-from etl import config
 from etl.helpers import PathFinder
-from etl.paths import VIZ_DIR
+from etl.viz.bespoke import build_feed_metadata, write_feed_metadata
 
 log = get_logger()
 paths = PathFinder(__file__)
 
-# Public S3 bucket and prefix.
-S3_BUCKET_NAME = "owid-public"
-S3_DATA_DIR = Path("data/food-trade")
 FILE_SLUG = "food-trade"
 
 # Decimal places kept for tonnage values written to the JSON files. Trade
@@ -83,20 +81,11 @@ def _build_products_by_entity(df: pd.DataFrame, entity_to_id: dict, product_to_i
     return out
 
 
-def _save_and_upload(data: dict, filename: str) -> None:
-    """Write JSON locally and upload to S3 (skipping the upload without --grapher)."""
-    export_dir = VIZ_DIR / paths.channel / paths.namespace / paths.version / paths.short_name
-    export_dir.mkdir(parents=True, exist_ok=True)
-    local_file = export_dir / filename
-    s3_path = f"s3://{S3_BUCKET_NAME}/{S3_DATA_DIR / filename}"
-
-    with open(local_file, "w") as f:
+def _save(data: dict, filename: str) -> None:
+    """Write one JSON file of the feed into the step's output folder."""
+    paths.output_dir.mkdir(parents=True, exist_ok=True)
+    with open(paths.output_dir / filename, "w") as f:
         json.dump(data, f, separators=(",", ":"))
-
-    if not config.GRAPHER_ENABLED:
-        tqdm.write(f"[not uploaded, no --grapher] {local_file} -> {s3_path}")
-    else:
-        s3_utils.upload(s3_path, local_file, public=True, downloadable=True)
 
 
 def run() -> None:
@@ -106,10 +95,14 @@ def run() -> None:
     ds = paths.load_dataset("food_trade")
     tb = ds.read("food_trade", safe_types=False)
 
-    # Source attribution for the metadata JSON is read from the `value`
-    # column's origin (TM snapshot) — the default grapher "producer (year)"
-    # form — so it stays in sync with the dataset's metadata.
-    source = tb["value"].metadata.origins[0].attribution
+    # The feed's provenance, derived from the origins of the data it is built on, in the same
+    # shape the MDIM download packages publish.
+    feed_metadata = build_feed_metadata(
+        title="Food trade",
+        columns={"Bilateral trade flow": tb["value"]},
+        update_period_days=ds.metadata.update_period_days,
+    )
+    write_feed_metadata(paths.output_dir, feed_metadata)
 
     df = pd.DataFrame(tb)
     for col in ("exporter", "importer", "item"):
@@ -144,7 +137,7 @@ def run() -> None:
     #
     metadata = {
         "year": year,
-        "source": source,
+        "source": feed_metadata["feed"]["citation"],
         "dimensions": {
             "entities": [{"id": entity_to_id[c], "name": c} for c in countries],
             "products": [{"id": product_to_id[p], "name": p} for p in products],
@@ -152,7 +145,7 @@ def run() -> None:
         "productsByEntity": _build_products_by_entity(df, entity_to_id, product_to_id),
     }
     log.info("food_trade.write_metadata", n_entities=len(countries), n_products=len(products))
-    _save_and_upload(metadata, f"{FILE_SLUG}.metadata.json")
+    _save(metadata, f"{FILE_SLUG}.metadata.json")
 
     #
     # Write one file per product.
@@ -160,4 +153,4 @@ def run() -> None:
     log.info("food_trade.write_per_product", n_files=len(products))
     for product in tqdm(products, desc="food_trade per-product JSON"):
         data = _build_product_data(df, product, entity_to_id)
-        _save_and_upload(data, f"{FILE_SLUG}.{product_to_id[product]}.json")
+        _save(data, f"{FILE_SLUG}.{product_to_id[product]}.json")

--- a/etl/steps/viz/bespoke/ihme_gbd/latest/gbd_treemap_json.py
+++ b/etl/steps/viz/bespoke/ihme_gbd/latest/gbd_treemap_json.py
@@ -1,40 +1,35 @@
 """Bespoke viz step that generates JSON files for the IHME GBD treemap visualization.
 
 This step combines the GBD treemap datasets and generates:
+* `metadata.json`, the feed's provenance, derived from the garden columns (see `etl.viz.bespoke`)
 * A metadata JSON file with categories, dimensions, and time ranges
 * Individual data JSON files per entity
 
-Outputs:
-* Files are uploaded to S3 and made publicly available at:
-  * https://owid-public.owid.io/data/gbd/causes-of-death.metadata.json
-  * https://owid-public.owid.io/data/gbd/causes-of-death.<entityId>.json
-
+The files are written to the step's output folder; the framework syncs that folder to the R2 path
+of the environment being built, so the feed is served at
+`<root>/v1/bespoke/ihme_gbd/latest/gbd_treemap_json/causes-of-death.metadata.json` and
+`.../causes-of-death.<entityId>.json` -- `api.ourworldindata.org` on production, and
+`api-staging.owid.io/<env>` on a staging server or a laptop.
 """
 
 import json
-from pathlib import Path
 
-from owid.catalog import Table, s3_utils
+from owid.catalog import Table
 from owid.catalog import processing as pr
 from structlog import get_logger
 from tqdm.auto import tqdm
 
-from etl import config
 from etl.helpers import PathFinder
-from etl.paths import VIZ_DIR
+from etl.viz.bespoke import build_feed_metadata, write_feed_metadata
 
 # Initialize logger.
 log = get_logger()
-
-# S3 bucket name and folder where dataset files will be stored.
-S3_BUCKET_NAME = "owid-public"
-S3_DATA_DIR = Path("data/gbd")
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def create_metadata_json(tb_filtered: Table) -> tuple[dict, dict]:
+def create_metadata_json(tb_filtered: Table, source: str) -> tuple[dict, dict]:
     """Create the metadata JSON structure."""
     # Get unique values for mappings
     countries = sorted(tb_filtered["country"].unique())
@@ -142,7 +137,7 @@ def create_metadata_json(tb_filtered: Table) -> tuple[dict, dict]:
     # Create metadata JSON
     metadata = {
         "timeRange": {"start": int(tb_filtered["year"].min()), "end": int(tb_filtered["year"].max())},
-        "source": "IHME, Global Burden of Disease (2025)",
+        "source": source,
         "categories": categories_list,
         "dimensions": {"entities": entities, "ageGroups": age_groups, "sexes": sex_list, "variables": variables},
     }
@@ -179,31 +174,16 @@ def create_entity_data_json(tb_filtered: Table, country: str, mappings: dict) ->
     return data
 
 
-def save_and_upload_json(data: dict, filename: str, s3_data_dir: Path) -> None:
-    """Save JSON data to local file and upload to S3.
+def save_json(data: dict, filename: str) -> None:
+    """Write one JSON file of the feed into the step's output folder.
 
     Args:
         data: Dictionary to save as JSON
         filename: Name of the file (e.g., "causes-of-death.1.json")
-        s3_data_dir: S3 directory path (within bucket)
     """
-    # Create export directory using paths
-    export_dir = VIZ_DIR / paths.channel / paths.namespace / paths.version / paths.short_name
-    export_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create full paths
-    local_file = export_dir / filename
-    s3_path = s3_data_dir / filename
-
-    # Save locally
-    with open(local_file, "w") as f:
+    paths.output_dir.mkdir(parents=True, exist_ok=True)
+    with open(paths.output_dir / filename, "w") as f:
         json.dump(data, f, indent=2)
-
-    # Upload to S3
-    if not config.GRAPHER_ENABLED:
-        tqdm.write(f"[not uploaded, no --grapher] {local_file} -> s3://{S3_BUCKET_NAME}/{s3_path}")
-    else:
-        s3_utils.upload(f"s3://{S3_BUCKET_NAME}/{str(s3_path)}", local_file, public=True, downloadable=True)
 
 
 def run() -> None:
@@ -229,26 +209,33 @@ def run() -> None:
     #
     log.info("Creating metadata and data JSON files.")
 
+    # The feed's provenance, from the origins of the data it is built on, rather than a source
+    # string typed in here that goes stale the next time GBD is updated.
+    feed_metadata = build_feed_metadata(
+        title="Causes of death",
+        columns={"Deaths": tb_filtered["value"]},
+        update_period_days=ds_garden.metadata.update_period_days,
+    )
+    write_feed_metadata(paths.output_dir, feed_metadata)
+
     # Create metadata
-    metadata, mappings = create_metadata_json(tb_filtered)
+    metadata, mappings = create_metadata_json(tb_filtered, source=feed_metadata["feed"]["citation"])
 
     #
-    # Generate and upload JSON files.
+    # Write the JSON files. The framework syncs the output folder to R2 afterwards.
     #
-    log.info(f"Creating and uploading {len(mappings['countries']) + 1} JSON files.")
+    log.info(f"Creating {len(mappings['countries']) + 1} JSON files.")
 
-    # Save and upload metadata file
-    save_and_upload_json(metadata, "causes-of-death.metadata.json", S3_DATA_DIR)
+    save_json(metadata, "causes-of-death.metadata.json")
 
-    # Save and upload entity data files
     country_to_id = {country: i + 1 for i, country in enumerate(mappings["countries"])}
     for country in tqdm(mappings["countries"], desc="Processing entities"):
         entity_id = country_to_id[country]
         data = create_entity_data_json(tb_filtered, country, mappings)
-        save_and_upload_json(data, f"causes-of-death.{entity_id}.json", S3_DATA_DIR)
+        save_json(data, f"causes-of-death.{entity_id}.json")
 
     log.info(
-        f"""Successfully created and uploaded {len(mappings["countries"]) + 1} files:
+        f"""Successfully created {len(mappings["countries"]) + 1} files:
         - 1 metadata file
         - {len(mappings["countries"])} entity data files
         - {len(metadata["dimensions"]["variables"])} variables

--- a/etl/steps/viz/bespoke/poverty_inequality/latest/income_distribution.py
+++ b/etl/steps/viz/bespoke/poverty_inequality/latest/income_distribution.py
@@ -1,30 +1,27 @@
-"""Export the thousand-bins income distribution data to S3.
+"""Export the thousand-bins income distribution data for our bespoke income distribution chart.
 
-This data is then used for our bespoke income distribution chart.
+This step uses the thousand_bins_distribution dataset dependency as its basis, and writes one
+JSON file per year plus `metadata.json`, the feed's provenance derived from the garden columns
+(see `etl.viz.bespoke`).
 
-This step uses the thousand_bins_distribution dataset dependency as its basis.
+The files are written to the step's output folder; the framework syncs that folder to the R2 path
+of the environment being built, so the feed is served at
+`<root>/v1/bespoke/poverty_inequality/latest/income_distribution/income-distribution.<year>.json`
+-- `api.ourworldindata.org` on production, and `api-staging.owid.io/<env>` on a staging server or
+a laptop.
 
-Output:
-* https://owid-public.owid.io/data/poverty-inequality/income-distribution.<year>.json
-
-Run without --grapher to skip the S3 upload and only write the local export file.
+Run without --grapher to skip the upload and only write the local files.
 """
 
 import json
-from pathlib import Path
 
 import pandas as pd
-from owid.catalog import Table, s3_utils
+from owid.catalog import Table
 from tqdm.auto import tqdm
 
-from etl import config
 from etl.data_helpers.misc import round_to_sig_figs
 from etl.helpers import PathFinder
-from etl.paths import VIZ_DIR
-
-# S3 bucket name and folder where dataset files will be stored.
-S3_BUCKET_NAME = "owid-public"
-S3_DATA_DIR = Path("data/poverty-inequality")
+from etl.viz.bespoke import build_feed_metadata, write_feed_metadata
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -87,25 +84,11 @@ def create_distribution_json(tb_export: pd.DataFrame, year: int) -> dict:
     }
 
 
-def save_and_upload_json(data: dict, filename: str, s3_data_dir: Path) -> None:
-    """Save JSON data to local file and upload to S3."""
-    # Create export directory using paths.
-    export_dir = VIZ_DIR / paths.channel / paths.namespace / paths.version / paths.short_name
-    export_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create full paths.
-    local_file = export_dir / filename
-    s3_path = s3_data_dir / filename
-
-    # Save locally.
-    with open(local_file, "w") as f:
+def save_json(data: dict, filename: str) -> None:
+    """Write one JSON file of the feed into the step's output folder."""
+    paths.output_dir.mkdir(parents=True, exist_ok=True)
+    with open(paths.output_dir / filename, "w") as f:
         json.dump(data, f, separators=(",", ":"))
-
-    # Upload to S3.
-    if not config.GRAPHER_ENABLED:
-        paths.log.info(f"[not uploaded, no --grapher] {local_file} -> s3://{S3_BUCKET_NAME}/{s3_path}")
-    else:
-        s3_utils.upload(f"s3://{S3_BUCKET_NAME}/{str(s3_path)}", local_file, public=True, downloadable=True)
 
 
 def run() -> None:
@@ -115,6 +98,16 @@ def run() -> None:
     paths.log.info("Loading thousand_bins_distribution dataset.")
     ds_garden = paths.load_dataset("thousand_bins_distribution")
     tb = ds_garden.read("thousand_bins_distribution", reset_index=False, safe_types=False)
+
+    # The feed's provenance, derived from the origins of the data it is built on.
+    write_feed_metadata(
+        paths.output_dir,
+        build_feed_metadata(
+            title="Income distribution",
+            columns={"Average income or consumption": tb["avg"], "Population": tb["pop"]},
+            update_period_days=ds_garden.metadata.update_period_days,
+        ),
+    )
 
     #
     # Prepare data.
@@ -129,6 +122,6 @@ def run() -> None:
     paths.log.info(f"Creating {len(years)} income distribution JSON files.")
     for year in tqdm(years, desc="Processing years"):
         data = create_distribution_json(tb_export, year=year)
-        save_and_upload_json(data, f"income-distribution.{year}.json", S3_DATA_DIR)
+        save_json(data, f"income-distribution.{year}.json")
 
     paths.log.info(f"Successfully created {len(years)} income distribution JSON files.")

--- a/etl/steps/viz/bespoke/un_migration/latest/migration_stock_flows_json.py
+++ b/etl/steps/viz/bespoke/un_migration/latest/migration_stock_flows_json.py
@@ -1,37 +1,34 @@
 """Bespoke viz step that generates JSON files for the UN migration flows visualization.
 
 This step reads the migration_stock_flows garden dataset and generates:
+* `metadata.json`, the feed's provenance, derived from the garden columns (see `etl.viz.bespoke`)
 * A metadata JSON file with entity/gender dimensions and time range
 * Individual data JSON files per country/entity
 
 Each per-country file contains all pairwise immigrant and emigrant stocks for
 that country, encoded as parallel arrays indexed by entity IDs from the metadata.
 
-Outputs:
-* Files are saved locally and (with --grapher) uploaded to S3 at:
-  * https://owid-public.owid.io/data/migration/migration-stock-flows.metadata.json
-  * https://owid-public.owid.io/data/migration/migration-stock-flows.<entityId>.json
+The files are written to the step's output folder; the framework syncs that folder to the R2 path
+of the environment being built, so the feed is served at
+`<root>/v1/bespoke/un_migration/latest/migration_stock_flows_json/migration-stock-flows.metadata.json`
+and `.../migration-stock-flows.<entityId>.json` -- `api.ourworldindata.org` on production, and
+`api-staging.owid.io/<env>` on a staging server or a laptop.
 
-Run without --grapher to skip the S3 upload and only write the local files:
+Run without --grapher to skip the upload and only write the local files:
   .venv/bin/etlr viz://bespoke/un_migration/latest/migration_stock_flows_json
 """
 
 import json
-from pathlib import Path
 
 import pandas as pd
-from owid.catalog import Table, s3_utils
+from owid.catalog import Table
 from structlog import get_logger
 from tqdm.auto import tqdm
 
-from etl import config
 from etl.helpers import PathFinder
-from etl.paths import VIZ_DIR
+from etl.viz.bespoke import build_feed_metadata, write_feed_metadata
 
 log = get_logger()
-
-S3_BUCKET_NAME = "owid-public"
-S3_DATA_DIR = Path("data/migration/")
 
 # Region/aggregate names to exclude from the visualization output.
 REGIONS = [
@@ -92,7 +89,7 @@ GENDER_MAP = {
 POPULATION_YEARS = [1990, 1995, 2000, 2005, 2010, 2015, 2020, 2024]
 
 
-def create_metadata_json(tb: Table, tb_pop: Table) -> tuple[dict, dict]:
+def create_metadata_json(tb: Table, tb_pop: Table, source: str) -> tuple[dict, dict]:
     """Build the metadata JSON and return it alongside lookup dicts."""
     # All entities = union of destinations and origins
     all_entities = sorted(set(tb["country_destination"].unique()) | set(tb["country_origin"].unique()))
@@ -134,7 +131,7 @@ def create_metadata_json(tb: Table, tb_pop: Table) -> tuple[dict, dict]:
     metadata = {
         "timeRange": {"start": int(tb["year"].min()), "end": int(tb["year"].max())},
         "years": sorted(tb["year"].unique().tolist()),
-        "source": "UN DESA, International Migrant Stock (2024)",
+        "source": source,
         "dimensions": {
             "entities": entities,
             "genders": genders,
@@ -178,24 +175,11 @@ def create_entity_data_json(tb: Table, entity: str, mappings: dict) -> dict:
     }
 
 
-def save_and_upload_json(data: dict, filename: str) -> None:
-    """Write JSON locally and upload to S3 (only with --grapher)."""
-    export_dir = VIZ_DIR / paths.channel / paths.namespace / paths.version / paths.short_name
-    export_dir.mkdir(parents=True, exist_ok=True)
-
-    local_file = export_dir / filename
-    s3_path = S3_DATA_DIR / filename
-
-    with open(local_file, "w") as f:
-        if not config.GRAPHER_ENABLED:
-            json.dump(data, f, indent=2)
-        else:
-            json.dump(data, f, separators=(",", ":"))
-
-    if not config.GRAPHER_ENABLED:
-        tqdm.write(f"[not uploaded, no --grapher] {local_file} -> s3://{S3_BUCKET_NAME}/{s3_path}")
-    else:
-        s3_utils.upload(f"s3://{S3_BUCKET_NAME}/{str(s3_path)}", local_file, public=True, downloadable=True)
+def save_json(data: dict, filename: str) -> None:
+    """Write one JSON file of the feed into the step's output folder."""
+    paths.output_dir.mkdir(parents=True, exist_ok=True)
+    with open(paths.output_dir / filename, "w") as f:
+        json.dump(data, f, separators=(",", ":"))
 
 
 def run() -> None:
@@ -218,12 +202,21 @@ def run() -> None:
     # Build metadata + entity file.
     #
     log.info("Creating metadata JSON.")
-    metadata, mappings = create_metadata_json(tb, tb_pop)
+    # The feed's provenance, from the origins of the data it is built on, rather than a source
+    # string typed in here that goes stale the next time the dataset is updated.
+    feed_metadata = build_feed_metadata(
+        title="Migrant stocks by origin and destination",
+        columns={"Migrants": tb["migrants"]},
+        update_period_days=ds_garden.metadata.update_period_days,
+    )
+    write_feed_metadata(paths.output_dir, feed_metadata)
+
+    metadata, mappings = create_metadata_json(tb, tb_pop, source=feed_metadata["feed"]["citation"])
 
     total_files = len(mappings["entities"]) + 1
-    log.info(f"Creating and {'uploading' if config.GRAPHER_ENABLED else 'not uploading'} {total_files} JSON files.")
+    log.info(f"Creating {total_files} JSON files.")
 
-    save_and_upload_json(metadata, "migration-stock-flows.metadata.json")
+    save_json(metadata, "migration-stock-flows.metadata.json")
 
     #
     # Per-entity files.
@@ -232,8 +225,6 @@ def run() -> None:
     for entity in tqdm(mappings["entities"], desc="Processing entities"):
         entity_id = entity_to_id[entity]
         data = create_entity_data_json(tb, entity, mappings)
-        save_and_upload_json(data, f"migration-stock-flows.{entity_id}.json")
+        save_json(data, f"migration-stock-flows.{entity_id}.json")
 
-    log.info(
-        f"Done. Created {total_files} files: 1 metadata + {len(mappings['entities'])} entity files. (uploaded={config.GRAPHER_ENABLED})"
-    )
+    log.info(f"Done. Created {total_files} files: 1 metadata + {len(mappings['entities'])} entity files.")

--- a/etl/viz/bespoke.py
+++ b/etl/viz/bespoke.py
@@ -1,0 +1,282 @@
+"""Framework support for `viz://bespoke` steps.
+
+A bespoke step turns garden tables into the JSON feed that one of owid-grapher's
+`bespoke/projects/` bundles fetches in the browser. The step itself only writes files into
+its own output folder (`data/viz/bespoke/<ns>/<version>/<name>/`); this module ships them,
+and derives the provenance block that used to be hand-typed in each step.
+
+Two things it gives a feed that a per-step `s3_utils.upload()` call could not:
+
+* **One environment-dependent location.** The feed goes to `v1/bespoke/<ns>/<version>/<name>/`
+  under `s3://owid-api` on production and under `s3://owid-api-staging/<env>` everywhere else --
+  the same split `BAKED_VARIABLES_PATH` / `DATA_API_URL` (`etl/config.py`) already apply to the
+  baked indicator JSONs and `download_package.py` applies to MDIM download packages. A staging
+  server therefore builds its own feed and an article preview can show a data change before it
+  is merged, instead of every run overwriting the one production copy.
+
+  Nothing has to seed a new staging environment: the `owid-api-staging` worker falls back to
+  the production bucket for any key missing under the environment's prefix (see
+  `workers/owid-api-staging/src/index.ts` in owid/cloudflare-workers), so a staging server that
+  never ran the step serves production's feed.
+
+* **Metadata derived from the garden data** (`build_feed_metadata`), so the source line a
+  reader sees under a bespoke viz is the dataset's own origins rather than a string typed into
+  the step that goes stale the next time the dataset is updated.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import mimetypes
+from dataclasses import dataclass
+from datetime import date, timezone
+from pathlib import Path
+
+import humps
+import pandas as pd
+from owid.catalog import Variable, s3_utils
+from structlog import get_logger
+
+from etl import config
+from etl.viz.chart.download_package_format import (
+    IndicatorColumn,
+    dumps_like_json_stringify,
+    format_attributions,
+    get_attribution,
+    metadata_column_entry,
+)
+
+log = get_logger()
+
+# The dataset index that `ExportStep.run` writes next to the feed. It records the step's
+# checksum for etl's own change detection and means nothing to a browser.
+INDEX_FILE = "index.json"
+
+# The file `build_feed_metadata` is written to, and the name the bundles fetch.
+METADATA_FILENAME = "metadata.json"
+
+
+@dataclass(frozen=True)
+class FeedLocation:
+    """Where a feed's files live once published."""
+
+    s3_folder: str
+    public_url: str
+
+
+def feed_location(step_path: str) -> FeedLocation:
+    """Where the feed of `viz://bespoke/<ns>/<version>/<name>` is published.
+
+    `step_path` is the step's path without its scheme, i.e. `bespoke/<ns>/<version>/<name>`;
+    the `bespoke/` channel segment is dropped because the root already names it.
+    """
+    feed_path = step_path.lstrip("/").removeprefix("bespoke/")
+    if config.DATA_API_ENV == "production":
+        return FeedLocation(
+            s3_folder=f"s3://owid-api/v1/bespoke/{feed_path}",
+            public_url=f"https://api.ourworldindata.org/v1/bespoke/{feed_path}",
+        )
+    return FeedLocation(
+        s3_folder=f"s3://owid-api-staging/{config.DATA_API_ENV}/v1/bespoke/{feed_path}",
+        public_url=f"https://api-staging.owid.io/{config.DATA_API_ENV}/v1/bespoke/{feed_path}",
+    )
+
+
+def sync_feed(step_path: str, local_dir: Path, max_workers: int = 20) -> FeedLocation:
+    """Upload every file in `local_dir` to the step's feed folder, and delete what it no longer has.
+
+    Stale objects are deleted because a feed is a set of files, not a list: a run that drops an
+    entity (`causes-of-death.<entityId>.json`) or renumbers one has to take the old file with it,
+    or the bundle keeps fetching data that nothing produces any more.
+    """
+    location = feed_location(step_path)
+    files = sorted(p for p in local_dir.glob("**/*") if p.is_file() and p.name != INDEX_FILE)
+    # A step that wrote nothing is a bug in the step; deleting the published feed on the strength
+    # of it would turn that bug into an outage.
+    assert files, f"{step_path} produced no files to publish in {local_dir}"
+
+    client = s3_utils.connect_r2()
+    bucket, prefix = s3_utils.s3_bucket_key(location.s3_folder)
+    keys = {f"{prefix}/{path.relative_to(local_dir).as_posix()}": path for path in files}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(
+                s3_utils.upload,
+                f"s3://{bucket}/{key}",
+                path,
+                public=True,
+                quiet=True,
+                content_type=mimetypes.guess_type(path.name)[0] or "application/octet-stream",
+            )
+            for key, path in keys.items()
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            # Raise the first failure rather than reporting a feed as published when part of it isn't.
+            future.result()
+
+    stale = [key for key in s3_utils.list_s3_objects(f"{location.s3_folder}/", client=client) if key not in keys]
+    if stale:
+        # delete_objects takes at most 1000 keys per call.
+        for i in range(0, len(stale), 1000):
+            client.delete_objects(Bucket=bucket, Delete={"Objects": [{"Key": key} for key in stale[i : i + 1000]]})
+
+    log.info(
+        "bespoke.published",
+        step=step_path,
+        files=len(keys),
+        deleted=len(stale),
+        url=location.public_url,
+    )
+    return location
+
+
+#
+# Derived metadata
+#
+# The feed's provenance, built from the garden columns it is made of, in the shape the MDIM
+# download package already publishes (`download_package.py`): a top-level block with a title and
+# a citation, and one entry per column. The formatting is grapher's own, via the port in
+# `download_package_format.py`, so a source line under a bespoke viz reads like a source line
+# under a chart.
+#
+
+
+def build_feed_metadata(
+    title: str,
+    columns: dict[str, Variable],
+    update_period_days: int | None = None,
+    build_date: date | None = None,
+) -> dict:
+    """Build the feed's `metadata.json` content from the columns it is built from.
+
+    `columns` maps the name a reader sees to the garden column carrying the metadata, e.g.
+    `{"Deaths": tb["value"]}` -- the same role the long display name plays in an MDIM download
+    package. Most bespoke feeds are built from a single long table, so that is usually one entry;
+    the mapping exists for the feeds that combine several. The key also stands in as the title
+    when the column's own title is a Jinja template a garden table can't render.
+
+    `update_period_days` comes from the garden dataset (`ds.metadata.update_period_days`) and is
+    only used to derive `nextUpdate`.
+    """
+    build_date = build_date or pd.Timestamp.now(tz=timezone.utc).date()
+
+    entries = {}
+    attributions = []
+    for name, variable in columns.items():
+        col = IndicatorColumn(
+            variable_meta_to_api_dict(variable, update_period_days=update_period_days, default_title=name)
+        )
+        attributions.append(get_attribution(col))
+        # No variable id and no `fullMetadata` URL: a bespoke feed is built from garden tables,
+        # whose columns have no variable in the grapher DB to point at. Both keys drop out.
+        entries[name] = metadata_column_entry(col, None, None, build_date)
+
+    return {
+        "feed": {
+            "title": title,
+            # The "Source: ..." line, as grapher composes it for a chart built on these columns.
+            "citation": format_attributions(_uniq(attributions)),
+        },
+        "columns": entries,
+        "dateGenerated": build_date.isoformat(),
+    }
+
+
+def write_feed_metadata(dest_dir: Path, metadata: dict, filename: str = METADATA_FILENAME) -> Path:
+    """Write `build_feed_metadata`'s output into the step's output folder."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    path = dest_dir / filename
+    path.write_text(dumps_like_json_stringify(metadata))
+    return path
+
+
+# Markers of a metadata value that is still a Jinja template. The templates in a `.meta.yml` are
+# rendered per dimension combination when a grapher step builds its wide tables, so the single
+# long column a bespoke feed reads still carries the template text (`gbd_treemap`'s title is
+# `<% if metric == ... %>`). Shipping that as an indicator title would be worse than shipping
+# nothing, so those fields are dropped -- with a warning, since a feed that wanted the title has
+# to get it from somewhere else.
+JINJA_MARKERS = ("<%", "<<")
+
+# Presentation fields that exist only inside grapher and have no place in a feed's metadata.
+PRESENTATION_FIELDS_TO_DROP = ("topic_tags", "faqs", "grapher_config")
+
+
+def variable_meta_to_api_dict(
+    variable: Variable, update_period_days: int | None = None, default_title: str | None = None
+) -> dict:
+    """A garden column's `VariableMeta` in the shape of a published indicator's `<id>.metadata.json`.
+
+    That shape is what `download_package_format.py` is a port against -- it reads camelCased keys
+    off the JSON the Data API serves -- so a column coming straight out of a garden table has to
+    be converted before the same formatting code can run on it.
+
+    `default_title` is used when the column has no usable title of its own, which is the normal
+    case for a long garden table: an empty title would otherwise reach a reader as `"" [dataset]`
+    in the middle of the full citation.
+    """
+    meta = variable.metadata.to_dict()
+    for field in PRESENTATION_FIELDS_TO_DROP:
+        (meta.get("presentation") or {}).pop(field, None)
+
+    api = humps.camelize(meta)
+    # The DB column, and therefore the API field, for `VariableMeta.title` is `name`.
+    api["name"] = api.pop("title", None)
+    api["shortName"] = variable.name
+    if update_period_days is not None:
+        api["updatePeriodDays"] = update_period_days
+    if api.get("type") is None:
+        # Garden columns rarely set `type` -- a grapher step infers it at upsert time, from the
+        # stringified values it writes to the DB. Same call here, so a feed says what the DB would.
+        # Imported here to keep the framework's publish path off the grapher/sqlalchemy import chain.
+        from etl.grapher.model import Variable as GrapherVariable
+
+        api["type"] = GrapherVariable.infer_type(variable.dropna().astype(str))
+
+    dropped, api = _drop_unrendered_templates(api)
+    if api.get("name") is None and default_title is not None:
+        api["name"] = default_title
+    if dropped:
+        # A warning, not an error: origins, unit and license -- everything the citation is made
+        # of -- are never templated, so the feed's provenance is complete even when its titles
+        # are unusable.
+        log.warning("bespoke.metadata_template_not_rendered", column=variable.name, fields=sorted(dropped))
+    return api
+
+
+def _drop_unrendered_templates(value: dict, path: str = "") -> tuple[list[str], dict]:
+    """Drop every string field that is still a Jinja template, and report which ones went."""
+    dropped = []
+    kept = {}
+    for key, item in value.items():
+        name = f"{path}{key}"
+        if isinstance(item, str) and any(marker in item for marker in JINJA_MARKERS):
+            dropped.append(name)
+        elif isinstance(item, dict):
+            nested_dropped, nested = _drop_unrendered_templates(item, path=f"{name}.")
+            dropped += nested_dropped
+            kept[key] = nested
+        elif item is not None:
+            kept[key] = item
+    return dropped, kept
+
+
+def _uniq(values: list[str]) -> list[str]:
+    seen = set()
+    out = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+__all__ = [
+    "FeedLocation",
+    "build_feed_metadata",
+    "feed_location",
+    "sync_feed",
+    "variable_meta_to_api_dict",
+    "write_feed_metadata",
+]

--- a/etl/viz/chart/download_package_format.py
+++ b/etl/viz/chart/download_package_format.py
@@ -839,12 +839,19 @@ def compute_title_long(col: IndicatorColumn) -> str:
     return parts["title"]
 
 
-def metadata_column_entry(col: IndicatorColumn, variable_id: int, full_metadata_url: str, today: date) -> dict:
+def metadata_column_entry(
+    col: IndicatorColumn, variable_id: int | None, full_metadata_url: str | None, today: date
+) -> dict:
     """One entry of metadata.json's "columns" object.
 
     Keys are emitted in the same order as the TS object literal, and keys whose
     value is None are dropped -- `JSON.stringify` omits undefined properties,
     so keeping them would show up as a diff against a real chart download.
+
+    `variable_id` and `full_metadata_url` are optional because a bespoke feed
+    (`etl/viz/bespoke.py`) describes garden columns, which have no variable in
+    the grapher DB to carry an id or a metadata URL; both keys then drop out
+    along with every other empty one.
     """
     entry = {
         "titleShort": col.title_public_or_display_name["title"],

--- a/tests/viz/test_bespoke.py
+++ b/tests/viz/test_bespoke.py
@@ -1,0 +1,171 @@
+"""Tests for the framework half of `viz://bespoke` steps."""
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from owid.catalog import Origin, Table, VariableMeta, VariablePresentationMeta
+
+from etl import config
+from etl.viz import bespoke
+
+ORIGIN = Origin(
+    producer="IHME, Global Burden of Disease",
+    title="Global Burden of Disease",
+    citation_full="Global Burden of Disease Collaborative Network (2024).",
+    attribution_short="IHME-GBD",
+    url_main="https://vizhub.healthdata.org/gbd-results/",
+    date_accessed="2025-10-21",
+    date_published="2024-05-17",
+)
+
+
+@pytest.fixture
+def table() -> Table:
+    tb = Table({"country": ["France"], "year": [2020], "value": [1.5]})
+    tb._fields["value"] = VariableMeta(
+        title="Deaths",
+        unit="deaths",
+        short_unit="",
+        description_short="Number of deaths.",
+        processing_level="minor",
+        origins=[ORIGIN],
+        presentation=VariablePresentationMeta(topic_tags=["Causes of Death"]),
+    )
+    return tb
+
+
+def test_feed_location_splits_by_environment(monkeypatch):
+    monkeypatch.setattr(config, "DATA_API_ENV", "production")
+    location = bespoke.feed_location("bespoke/ihme_gbd/latest/gbd_treemap_json")
+    assert location.s3_folder == "s3://owid-api/v1/bespoke/ihme_gbd/latest/gbd_treemap_json"
+    assert location.public_url == "https://api.ourworldindata.org/v1/bespoke/ihme_gbd/latest/gbd_treemap_json"
+
+    monkeypatch.setattr(config, "DATA_API_ENV", "staging-site-my-branch")
+    location = bespoke.feed_location("bespoke/ihme_gbd/latest/gbd_treemap_json")
+    assert location.s3_folder == (
+        "s3://owid-api-staging/staging-site-my-branch/v1/bespoke/ihme_gbd/latest/gbd_treemap_json"
+    )
+    assert location.public_url == (
+        "https://api-staging.owid.io/staging-site-my-branch/v1/bespoke/ihme_gbd/latest/gbd_treemap_json"
+    )
+
+
+def test_variable_meta_to_api_dict(table):
+    api = bespoke.variable_meta_to_api_dict(table["value"], update_period_days=365)
+
+    assert api["name"] == "Deaths"
+    assert api["shortName"] == "value"
+    assert api["descriptionShort"] == "Number of deaths."
+    assert api["processingLevel"] == "minor"
+    assert api["updatePeriodDays"] == 365
+    # Inferred from the values, as a grapher upsert would.
+    assert api["type"] == "float"
+    assert api["origins"][0]["producer"] == "IHME, Global Burden of Disease"
+    assert api["origins"][0]["citationFull"] == "Global Burden of Disease Collaborative Network (2024)."
+    # Grapher-only presentation fields don't travel with a feed.
+    assert "topicTags" not in api["presentation"]
+
+
+def test_variable_meta_drops_unrendered_templates(table):
+    """A long garden table's metadata is still templated -- it is rendered per dimension only when a
+    grapher step builds wide tables -- so template text must not reach the feed."""
+    table._fields["value"].title = "<% if metric == 'Number' %>Deaths<% endif %>"
+    table._fields["value"].display = {"name": "<< cause >>", "numDecimalPlaces": 0}
+
+    api = bespoke.variable_meta_to_api_dict(table["value"], default_title="Deaths")
+
+    # The title the step gave the column stands in, so the citation doesn't read `"" [dataset]`.
+    assert api["name"] == "Deaths"
+    assert api["display"] == {"numDecimalPlaces": 0}
+
+
+def test_build_feed_metadata(table):
+    metadata = bespoke.build_feed_metadata(
+        title="Causes of death",
+        columns={"Deaths": table["value"]},
+        update_period_days=1460,
+        build_date=date(2026, 9, 11),
+    )
+
+    assert metadata["feed"]["title"] == "Causes of death"
+    # The source line grapher would put under a chart built on this column, rather than a string
+    # typed into the step.
+    assert metadata["feed"]["citation"] == "IHME, Global Burden of Disease (2024)"
+    assert metadata["dateGenerated"] == "2026-09-11"
+
+    column = metadata["columns"]["Deaths"]
+    assert column["titleShort"] == "Deaths"
+    assert column["unit"] == "deaths"
+    assert column["lastUpdated"] == "2025-10-21"
+    assert column["citationShort"].endswith("with minor processing by Our World in Data")
+    # No variable in the grapher DB to point at.
+    assert "owidVariableId" not in column
+    assert "fullMetadata" not in column
+
+
+def test_write_feed_metadata(tmp_path, table):
+    metadata = bespoke.build_feed_metadata("Causes of death", {"Deaths": table["value"]})
+    path = bespoke.write_feed_metadata(tmp_path / "feed", metadata)
+
+    assert path.name == "metadata.json"
+    assert pd.read_json(path).index.tolist()  # parses as JSON
+
+
+class _FakeClient:
+    def __init__(self):
+        self.deleted: list[str] = []
+
+    def delete_objects(self, Bucket: str, Delete: dict) -> None:
+        self.deleted += [obj["Key"] for obj in Delete["Objects"]]
+
+
+def test_sync_feed_uploads_and_deletes_stale(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "DATA_API_ENV", "production")
+    local = tmp_path / "gbd_treemap_json"
+    local.mkdir()
+    (local / "causes-of-death.metadata.json").write_text("{}")
+    (local / "causes-of-death.1.json").write_text("{}")
+    # The dataset index is etl's own bookkeeping and must not reach the bucket.
+    (local / "index.json").write_text("{}")
+
+    prefix = "v1/bespoke/ihme_gbd/latest/gbd_treemap_json"
+    client = _FakeClient()
+    uploaded: list[str] = []
+    monkeypatch.setattr(bespoke.s3_utils, "connect_r2", lambda: client)
+    monkeypatch.setattr(bespoke.s3_utils, "upload", lambda url, path, **kwargs: uploaded.append(url))
+    monkeypatch.setattr(
+        bespoke.s3_utils,
+        "list_s3_objects",
+        # An entity file from a previous run that this one no longer produces.
+        lambda folder, client=None: [
+            f"{prefix}/causes-of-death.metadata.json",
+            f"{prefix}/causes-of-death.1.json",
+            f"{prefix}/causes-of-death.999.json",
+        ],
+    )
+
+    location = bespoke.sync_feed("bespoke/ihme_gbd/latest/gbd_treemap_json", local)
+
+    assert location.public_url == f"https://api.ourworldindata.org/{prefix}"
+    assert sorted(uploaded) == [
+        f"s3://owid-api/{prefix}/causes-of-death.1.json",
+        f"s3://owid-api/{prefix}/causes-of-death.metadata.json",
+    ]
+    assert client.deleted == [f"{prefix}/causes-of-death.999.json"]
+
+
+def test_sync_feed_refuses_an_empty_folder(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(AssertionError, match="produced no files"):
+        bespoke.sync_feed("bespoke/ihme_gbd/latest/gbd_treemap_json", empty)
+
+
+def test_output_dir_of_a_bespoke_step():
+    from etl import paths as etl_paths
+    from etl.helpers import PathFinder
+
+    step_file = etl_paths.STEP_DIR / "viz/bespoke/ihme_gbd/latest/gbd_treemap_json.py"
+    assert PathFinder(str(step_file)).output_dir == Path(etl_paths.VIZ_DIR / "bespoke/ihme_gbd/latest/gbd_treemap_json")


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Implements items 1, 2 and 4 of #6846 (PR 1 of the three it plans).

A `viz://bespoke` step used to carry its own copy of an S3 upload helper, a hardcoded `owid-public` bucket and a hand-picked folder (`data/gbd`, `data/food-trade`, …). The target was the same production path regardless of environment, so every run — a staging build, a laptop — overwrote the production files, and a data change could not be previewed in an article on a staging server.

Now the step only writes JSON into its output folder, and the framework ships it, like every other output we produce.

## What changes

**The upload moves into the framework.** `VizStep._publish()` → `etl.viz.bespoke.sync_feed()` syncs the step's output folder to `v1/bespoke/<ns>/<version>/<name>/`, under `s3://owid-api` on production and `s3://owid-api-staging/<env>` everywhere else — the split `BAKED_VARIABLES_PATH` / `DATA_API_URL` already apply to baked indicators and `download_package.py` applies to MDIM download packages. Files a run no longer produces are deleted from the feed, so a dropped entity doesn't linger; a run that produced nothing fails rather than emptying the feed. Without `--grapher` the step writes its files and skips the sync (the `publishes` gate added in #6851 — no `DRY_RUN` handling left in the steps). About 80 lines leave the four steps, 30 arrive in one place.

**Metadata is derived, not typed.** `build_feed_metadata()` builds the feed's provenance from the garden columns it reads — source line, `citationShort` / `citationLong`, unit, last and next update — in the shape the MDIM download packages publish, reusing grapher's own formatting through the existing port in `download_package_format.py`. The steps drop their hand-typed strings (`"source": "IHME, Global Burden of Disease (2025)"`) and take that string from the derived metadata, so it follows the dataset instead of going stale at the next update.

One wrinkle worth knowing: these feeds read *long* garden tables, whose metadata is still Jinja (`<% if metric == 'Number' %>…`) — templates are rendered per dimension only when a grapher step builds wide tables. Template text is dropped with a warning rather than shipped as a title, and the name the step gives the column stands in. Everything the citation is made of (origins, unit, licence) is never templated, so provenance is complete either way.

**Production URLs change** from `owid-public.owid.io/data/<topic>/…` to the step-derived path. Hand-picked folder names can't survive a generic scheme, and the bundles have to change anyway. The old files stay where they are, so the live bundles keep reading them until the owid-grapher PR switches over.

Paired ops PR, which adds `viz://bespoke` to the production and staging viz passes: owid/ops#666.

## Staging, and why nothing needs seeding

Each environment gets its own prefix, and a staging server that never ran a bespoke step still serves the production feed: the `owid-api-staging` worker (`owid/cloudflare-workers`) already falls back to the production bucket for any key missing under the environment's prefix. Verified on a live URL — `https://api-staging.owid.io/some-nonexistent-branch/v1/mdim-downloads/energy-mix.complete-dataset.zip` → `200`. Neither worker filters paths, so `/v1/bespoke/…` needs no worker change (one of the two things #6846 asked to confirm before starting; the other, whether bundle owners want production building the three hand-run feeds, is still open — see below).

## How to test it

Two of the four steps were run end to end against this branch's staging prefix, and the files were fetched back over HTTPS:

```bash
PREFER_DOWNLOAD=1 .venv/bin/etlr viz://bespoke/poverty_inequality/latest/income_distribution --grapher
curl https://api-staging.owid.io/staging-site-make-viz-bespoke-steps-envir/v1/bespoke/poverty_inequality/latest/income_distribution/metadata.json
```

```json
{
  "feed": {
    "title": "Income distribution",
    "citation": "Lakner et al. (2022) (updated using World Bank PIP in March 2026)"
  },
  "columns": {
    "Average income or consumption": {
      "titleShort": "Average income or consumption",
      "unit": "international-$ in 2021 prices",
      "lastUpdated": "2026-04-01",
      "nextUpdate": "2026-09-28",
      "citationShort": "Lakner et al. (2022) (updated using World Bank PIP in March 2026) – with major processing by Our World in Data",
      …
```

`viz://bespoke/un_migration/latest/migration_stock_flows_json` was run the same way (236 files, templated metadata correctly dropped), and stale-file deletion was checked live: removing one local file and re-syncing deleted it from the bucket, and the URL then 404s.

`gbd_treemap_json` was run too, after the review fixes: 224 files, and its `metadata.json` derives `"IHME, Global Burden of Disease (2024)"` from the origins where the step used to hard-code `(2025)`. Only `food_trade` was never run — its garden input is a slice of an 8.5 GB trade matrix — and its diff is the same mechanical change as the other three.

With the owid-grapher side (owid/owid-grapher#7274) on a branch of the same name, the whole chain runs on the shared staging server: http://staging-site-make-viz-bespoke-steps-envir/what-do-people-die-from-in-different-countries draws the treemap from `api-staging.owid.io/staging-site-make-viz-bespoke-steps-envir/v1/bespoke/ihme_gbd/latest/gbd_treemap_json/...`, with the source line showing the derived citation. The migration bundle was checked the same way.

## Still open

- ~~Whether bundle owners want production building the three feeds that have only ever been run by hand~~ — confirmed, they should. owid/ops#666 enables `food_trade`, `migration_stock_flows_json` and `income_distribution` in the production pass; from then on they follow the garden data on every deploy instead of a hand run.
- **owid-grapher (PR 2 of #6846)** is open as owid/owid-grapher#7274 and should merge after this one plus one production ETL run, so the new paths exist before anything reads them. Until it lands, the live bundles read the old `owid-public` files, which stop being updated — GBD updates annually, so the freeze is not urgent, but it is real. (The citation part turned out to need no grapher change: each feed's own metadata file carries the derived string.)
- ~~The Cloudflare preview doesn't serve bespoke bundles unless the PR carries the `staging-bespoke` label~~ — fixed in owid/ops#672: a branch that touches `bespoke/` builds them, so no one has to remember the label. The staging server itself never needed it.
- **PR 3**: delete `owid-public/data/{gbd,food-trade,migration,poverty-inequality}` once nothing reads them.
- ~~The feed JSON was not diffed against what production currently serves~~ — done, and it matches. Every key path and value type in `causes-of-death.metadata.json`, `migration-stock-flows.metadata.json`, `income-distribution.<year>.json` and a per-entity file from each is identical to production's, with the same dimensions (222 entities / 6 age groups / 3 sexes / 40 variables for GBD, 234 entities and the same 8 years for migration, 218 countries x 1000 bins for income) and the same row counts. The two `source` strings change on purpose, and both move *towards* the site: GBD `(2025)` -> `(2024)`, and `UN DESA, International Migrant Stock (2024)` -> `United Nations Department of Economic and Social Affairs (2024)`, which is verbatim what grapher shows on a chart built from the same dataset (`ourworldindata.org/grapher/migrant-stock-total`). `food_trade` was not rebuilt, but its diff touches only the output path and the `source` value, and its origin sets `attribution` explicitly, which old and new code both emit verbatim -- so its feed should be unchanged. The one thing that would change it is a second origin on that column, which the new code joins with `; ` where the old took the first; worth an eye on the first production run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



