### PR TITLE
🐛 Fix measles update: drop CDC record with no year

### DIFF
--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -713,8 +713,13 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
             else:
                 year = tab.index.get_level_values("year")
             assert year.dtype in gh.INT_TYPES, f"year must be of an integer type but was: {year.dtype}"
+            _validate_time_column_not_null(tab, year, "year")
         elif {"date", "country"} <= set(tab.all_columns):
-            pass
+            if "date" in tab.columns:
+                date = tab["date"]
+            else:
+                date = tab.index.get_level_values("date")
+            _validate_time_column_not_null(tab, date, "date")
         else:
             raise AssertionError("Table must have columns country and year or date.")
 
@@ -760,6 +765,22 @@ TIME_INTERVALS = {"day", "week", "month", "quarter", "year", "decade"}
 # decode them first. "decade" is deliberately absent -- it codes a representative
 # calendar year, not an offset.
 SUB_YEARLY_TIME_INTERVALS = {"day", "week", "month", "quarter"}
+
+
+def _validate_time_column_not_null(tab: Table, time_values: Any, col: str) -> None:
+    """Reject rows whose time column is missing.
+
+    A row with no time is not plottable, and nothing downstream rejects it: `year` keeps a
+    nullable integer dtype, so the dtype check above passes and the NA travels all the way to
+    the MySQL upsert, where `calculate_checksum_metadata` sorts the unique years and dies with
+    `TypeError: boolean value of NA is ambiguous` -- a traceback that says nothing about which
+    dataset or which rows are at fault. Fail here instead, at the step that produced them.
+    """
+    missing = pd.isna(time_values)
+    assert not missing.any(), (
+        f"Table `{tab.metadata.short_name}` has {int(missing.sum())} row(s) with a missing `{col}`. "
+        f"Drop them upstream (usually in garden) or give them a time value."
+    )
 
 
 def _validate_time_interval(tab: Table, col: str) -> None:

--- a/etl/steps/data/garden/cdc/latest/measles_cases.py
+++ b/etl/steps/data/garden/cdc/latest/measles_cases.py
@@ -8,11 +8,11 @@ from etl.helpers import PathFinder, create_dataset
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-# The CDC's JSON has one record per year, but since 2026-09-10 it also carries a single record
-# with no `year` key at all (`{"cases": "5", "filter": "1985-Present*"}`), which pandas reads as a
-# missing year. It is not a year we can plot, and the years it sits between are all complete, so we
-# drop it. Bounded, so that a producer-side change that starts stripping years from real records
-# fails the step instead of silently shrinking the series.
+# The CDC's JSON has one record per year, but since 2026-09-10 it leads with a record that has no
+# `year` key at all (`{"cases": "5", "filter": "1985-Present*"}`), which pandas reads as a missing
+# year. There is nowhere to plot it, and every year from 1985 to the present is already reported by
+# its own record, so we drop it. The bound is there so that a producer-side change that starts
+# stripping years from real records fails the step instead of silently shrinking the series.
 MAX_RECORDS_WITHOUT_YEAR = 1
 
 

--- a/etl/steps/data/garden/cdc/latest/measles_cases.py
+++ b/etl/steps/data/garden/cdc/latest/measles_cases.py
@@ -1,10 +1,19 @@
 """Load a meadow dataset and create a garden dataset."""
 
+from owid.catalog import Table
+
 from etl.data_helpers import geo
 from etl.helpers import PathFinder, create_dataset
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
+
+# The CDC's JSON has one record per year, but since 2026-09-10 it also carries a single record
+# with no `year` key at all (`{"cases": "5", "filter": "1985-Present*"}`), which pandas reads as a
+# missing year. It is not a year we can plot, and the years it sits between are all complete, so we
+# drop it. Bounded, so that a producer-side change that starts stripping years from real records
+# fails the step instead of silently shrinking the series.
+MAX_RECORDS_WITHOUT_YEAR = 1
 
 
 def run(dest_dir: str) -> None:
@@ -19,6 +28,7 @@ def run(dest_dir: str) -> None:
     tb = tb[tb["filter"] == "1985-Present*"]
     assert tb["filter"].unique() == ["1985-Present*"]
     tb = tb.drop(columns=["filter", "filter_esp"])
+    tb = drop_records_without_year(tb)
     #
     # Process data.
     #
@@ -35,3 +45,13 @@ def run(dest_dir: str) -> None:
 
     # Save changes in the new garden dataset.
     ds_garden.save()
+
+
+def drop_records_without_year(tb: Table) -> Table:
+    """Drop CDC records that carry no year, and check there are no more of them than expected."""
+    without_year = tb["year"].isna()
+    assert without_year.sum() <= MAX_RECORDS_WITHOUT_YEAR, (
+        f"{without_year.sum()} CDC records have no year, expected at most {MAX_RECORDS_WITHOUT_YEAR}. "
+        f"Check whether the producer changed the shape of the file before raising this bound."
+    )
+    return tb[~without_year]

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import pytest
 from owid.catalog import (
     DatasetMeta,
     Table,
@@ -224,3 +225,44 @@ def test_adapt_table_with_dates_preserves_declared_interval():
     tb["value"].metadata.display = {"timeInterval": "month"}
     tb = gh.adapt_table_with_dates_to_grapher(tb)
     assert tb["value"].m.display["timeInterval"] == "month"
+
+
+class _FakeDataset:
+    """Minimal stand-in for catalog.Dataset: grapher_checks only needs a title and its tables."""
+
+    def __init__(self, tables):
+        self.metadata = DatasetMeta(title="Test dataset")
+        self._tables = tables
+
+    def __iter__(self):
+        return iter(self._tables)
+
+
+def test_grapher_checks_rejects_missing_year():
+    # A row with no year is not plottable, and its NA used to survive all the way to the MySQL
+    # upsert, where it failed with an unattributable "boolean value of NA is ambiguous".
+    df = pd.DataFrame(
+        {
+            "country": ["France", "France"],
+            "year": pd.array([2020, None], dtype="Int64"),
+            "value": [1, 2],
+        }
+    )
+    tb = Table(df.set_index(["country", "year"]), short_name="tb")
+
+    with pytest.raises(AssertionError, match="1 row\\(s\\) with a missing `year`"):
+        gh.grapher_checks(_FakeDataset([tb]))
+
+
+def test_grapher_checks_rejects_missing_date():
+    df = pd.DataFrame(
+        {
+            "country": ["France", "France"],
+            "date": pd.to_datetime(pd.Series(["2020-01-01", None])),
+            "value": [1, 2],
+        }
+    )
+    tb = Table(df.set_index(["country", "date"]), short_name="tb")
+
+    with pytest.raises(AssertionError, match="1 row\\(s\\) with a missing `date`"):
+        gh.grapher_checks(_FakeDataset([tb]))


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The master deploy ([build 11423](https://buildkite.com/our-world-in-data/etl-deploy-master/builds/11423)) failed on `grapher://grapher/health/latest/measles_long_run` with `TypeError: boolean value of NA is ambiguous`. The CDC's yearly measles JSON gained a record with no `year` key at all, and the resulting NA travelled untouched through meadow, garden and grapher into the MySQL upsert, where `calculate_checksum_metadata` sorts the unique years and dies. This drops that record in the CDC garden step, and makes `grapher_checks` reject missing `year`/`date` so the next occurrence fails at the step that produced it.

_Deep on `etl/grapher/helpers.py` — it runs on every grapher dataset. Skim the rest._

## How it works

The producer's file now leads with `{"cases": "5", "filter": "1985-Present*"}` — no `year`. It appeared in the 2026-09-10 file (70 records; the 2026-09-03 one had 69, all with a year) and is still being served. Every year from 1985 to 2026 is already reported by its own record, so the row adds nothing and is dropped in `garden/cdc/latest/measles_cases`, behind a bound (`MAX_RECORDS_WITHOUT_YEAR = 1`) so that a producer change which starts stripping years from *real* records fails the step rather than silently shortening the series.

Dropping it in garden rather than meadow keeps meadow a faithful mirror of the source, per the sanity-check rules.

The second half is the part worth the review. Nothing in the pipeline rejects a missing time value today: `year` keeps a nullable `Int64` dtype, so `grapher_checks`'s existing dtype assertion passes, and the `date` branch of that same check does nothing at all. The failure therefore surfaces hundreds of frames deep in a parallel worker, in a traceback that names neither the dataset nor the offending rows. `_validate_time_column_not_null` fails instead at `create_dataset()` time with the table name and the row count.

This cannot break a dataset that currently builds: any NA in `year` already crashes the upsert on the same line, so the new assertion only fires where the deploy was already failing.

## Verified

- Reproduced the crash: the published `garden/health/latest/measles_long_run` rebuilt from the current snapshot carries a `United States / <NA> / 5 cases` row.
- After the fix, the chain rebuilds to 93 rows, 1919–2026, no NA years. `etl diff REMOTE data/ --include measles_long_run` shows only the legitimate weekly change (2026 cases 3134 → 3294, `case_rate` accordingly) and the `date_published` bump — same row count as the last good published version, confirming the dropped record contributed nothing.
- The new tests assert that `grapher_checks` raises on a missing `year` and on a missing `date`, naming the row count.
- Not verified: the grapher upsert itself (needs a DB). The failing line is `calculate_checksum_metadata`, which is unchanged — this PR removes its bad input rather than touching it.

<details>
<summary>Producer file, before and after</summary>

```
2026-09-03 (md5 eb25940ee556a4dcbf49117b8b7d2305): 69 records, 0 without a year
2026-09-10 (md5 135aaa6fc915dc3d52dbab918473387f): 70 records, 1 without a year
live at 2026-09-12:                                70 records, 1 without a year
```

The extra record is the first element of the array: `{"cases": "5", "filter": "1985-Present*", "filter_esp": "1985-Presente*"}`. Unlike every real year, it appears under only one of the two filters.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
